### PR TITLE
Establish dodal as primary project name over python-dodal

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -7,7 +7,7 @@ filing a new one. If you have a great idea but it involves big changes, please
 file a ticket before making a pull request! We want to make sure you don't spend
 your time coding something that might not fit the scope of the project.
 
-.. _GitHub: https://github.com/DiamondLightSource/python-dodal/issues
+.. _GitHub: https://github.com/DiamondLightSource/dodal/issues
 
 Issue or Discussion?
 --------------------
@@ -16,7 +16,7 @@ Github also offers discussions_ as a place to ask questions and share ideas. If
 your issue is open ended and it is not obvious when it can be "closed", please
 raise it as a discussion instead.
 
-.. _discussions: https://github.com/DiamondLightSource/python-dodal/discussions
+.. _discussions: https://github.com/DiamondLightSource/dodal/discussions
 
 Code coverage
 -------------
@@ -32,4 +32,4 @@ The `Developer Guide`_ contains information on setting up a development
 environment, running the tests and what standards the code and documentation
 should follow.
 
-.. _Developer Guide: https://diamondlightsource.github.io/python-dodal/main/developer/how-to/contribute.html
+.. _Developer Guide: https://diamondlightsource.github.io/dodal/main/developer/how-to/contribute.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ COPY --from=build /venv/ /venv/
 ENV PATH=/venv/bin:$PATH
 
 # change this entrypoint if it is not the same as the repo
-ENTRYPOINT ["python-dodal"]
+ENTRYPOINT ["dodal"]
 CMD ["--version"]

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-python-dodal
+dodal
 ============
 
 |code_ci| |docs_ci| |coverage| |pypi_version| |license|
@@ -7,27 +7,27 @@ python-dodal
 Ophyd devices and other utils that could be used across DLS beamlines
 
 ============== ==============================================================
-PyPI           ``pip install python-dodal``
-Source code    https://github.com/DiamondLightSource/python-dodal
-Documentation  https://DiamondLightSource.github.io/python-dodal
-Releases       https://github.com/DiamondLightSource/python-dodal/releases
+PyPI           ``pip install dodal``
+Source code    https://github.com/DiamondLightSource/dodal
+Documentation  https://DiamondLightSource.github.io/dodal
+Releases       https://github.com/DiamondLightSource/dodal/releases
 ============== ==============================================================
 
 
-.. |code_ci| image:: https://github.com/DiamondLightSource/python-dodal/actions/workflows/code.yml/badge.svg?branch=main
-    :target: https://github.com/DiamondLightSource/python-dodal/actions/workflows/code.yml
+.. |code_ci| image:: https://github.com/DiamondLightSource/dodal/actions/workflows/code.yml/badge.svg?branch=main
+    :target: https://github.com/DiamondLightSource/dodal/actions/workflows/code.yml
     :alt: Code CI
 
-.. |docs_ci| image:: https://github.com/DiamondLightSource/python-dodal/actions/workflows/docs.yml/badge.svg?branch=main
-    :target: https://github.com/DiamondLightSource/python-dodal/actions/workflows/docs.yml
+.. |docs_ci| image:: https://github.com/DiamondLightSource/dodal/actions/workflows/docs.yml/badge.svg?branch=main
+    :target: https://github.com/DiamondLightSource/dodal/actions/workflows/docs.yml
     :alt: Docs CI
 
-.. |coverage| image:: https://codecov.io/gh/DiamondLightSource/python-dodal/branch/main/graph/badge.svg
-    :target: https://codecov.io/gh/DiamondLightSource/python-dodal
+.. |coverage| image:: https://codecov.io/gh/DiamondLightSource/dodal/branch/main/graph/badge.svg
+    :target: https://codecov.io/gh/DiamondLightSource/dodal
     :alt: Test Coverage
 
-.. |pypi_version| image:: https://img.shields.io/pypi/v/python-dodal.svg
-    :target: https://pypi.org/project/python-dodal
+.. |pypi_version| image:: https://img.shields.io/pypi/v/dodal.svg
+    :target: https://pypi.org/project/dodal
     :alt: Latest PyPI version
 
 .. |license| image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
@@ -38,4 +38,4 @@ Releases       https://github.com/DiamondLightSource/python-dodal/releases
     Anything below this line is used when viewing README.rst and will be replaced
     when included in index.rst
 
-See https://DiamondLightSource.github.io/python-dodal for more detailed documentation.
+See https://DiamondLightSource.github.io/dodal for more detailed documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ import dodal
 # -- General configuration ------------------------------------------------
 
 # General information about the project.
-project = "python-dodal"
+project = "dodal"
 
 # The full version, including alpha/beta/rc tags.
 release = dodal.__version__

--- a/docs/developer/how-to/make-release.rst
+++ b/docs/developer/how-to/make-release.rst
@@ -13,4 +13,4 @@ To make a new release, please follow this checklist:
 Note that tagging and pushing to the main branch has the same effect except that
 you will not get the option to edit the release notes.
 
-.. _release: https://github.com/DiamondLightSource/python-dodal/releases
+.. _release: https://github.com/DiamondLightSource/dodal/releases

--- a/docs/developer/how-to/move-code.rst
+++ b/docs/developer/how-to/move-code.rst
@@ -48,7 +48,7 @@ In the process of writing code in other DLS repos you may come to realise that i
 
 #. In a different folder clone ``dodal``, remove the origin (for now) to be safe and create a branch::
 
-    git clone git@github.com:DiamondLightSource/python-dodal.git
+    git clone git@github.com:DiamondLightSource/dodal.git
     cd dodal
     git remote rm origin
     git checkout -b add_code_from_artemis
@@ -66,7 +66,7 @@ In the process of writing code in other DLS repos you may come to realise that i
 #. Remove the source remote and re-add origin::
 
     git remote rm source
-    git remote add origin git@github.com:DiamondLightSource/python-dodal.git
+    git remote add origin git@github.com:DiamondLightSource/dodal.git
 
 #. Tidy up the code so that it fits into the ``dodal`` repo e.g. in the Artemis case we had to change the tests to import from ``artemis`` to import from ``dodal`` and add some more dependencies.
 

--- a/docs/developer/tutorials/dev-install.rst
+++ b/docs/developer/tutorials/dev-install.rst
@@ -10,7 +10,7 @@ Clone the repository
 First clone the repository locally using `Git
 <https://git-scm.com/downloads>`_::
 
-    $ git clone git://github.com/DiamondLightSource/python-dodal.git
+    $ git clone git://github.com/DiamondLightSource/dodal.git
 
 Install dependencies
 --------------------
@@ -25,7 +25,7 @@ requires python 3.8 or later) or to run in a container under `VSCode
 
         .. code::
 
-            $ cd python-dodal
+            $ cd dodal
             $ python3 -m venv venv
             $ source venv/bin/activate
             $ pip install -e .[dev]
@@ -34,7 +34,7 @@ requires python 3.8 or later) or to run in a container under `VSCode
 
         .. code::
 
-            $ vscode python-dodal
+            $ vscode dodal
             # Click on 'Reopen in Container' when prompted
             # Open a new terminal
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,13 +14,13 @@ The documentation is split into 2 sections:
         :link: user/index
         :link-type: doc
 
-        The User Guide contains documentation on how to install and use python-dodal.
+        The User Guide contains documentation on how to install and use dodal.
 
     .. grid-item-card:: :material-regular:`code;4em`
         :link: developer/index
         :link-type: doc
 
-        The Developer Guide contains documentation on how to develop and contribute changes back to python-dodal.
+        The Developer Guide contains documentation on how to develop and contribute changes back to dodal.
 
 .. toctree::
     :hidden:

--- a/docs/user/how-to/run-container.rst
+++ b/docs/user/how-to/run-container.rst
@@ -1,15 +1,15 @@
 Run in a container
 ==================
 
-Pre-built containers with python-dodal and its dependencies already
+Pre-built containers with dodal and its dependencies already
 installed are available on `Github Container Registry
-<https://ghcr.io/DiamondLightSource/python-dodal>`_.
+<https://ghcr.io/DiamondLightSource/dodal>`_.
 
 Starting the container
 ----------------------
 
 To pull the container from github container registry and run::
 
-    $ docker run ghcr.io/DiamondLightSource/python-dodal:main --version
+    $ docker run ghcr.io/DiamondLightSource/dodal:main --version
 
 To get a released version, use a numbered release instead of ``main``.

--- a/docs/user/tutorials/installation.rst
+++ b/docs/user/tutorials/installation.rst
@@ -25,14 +25,14 @@ Installing the library
 
 You can now use ``pip`` to install the library and its dependencies::
 
-    $ python3 -m pip install python-dodal
+    $ python3 -m pip install dodal
 
 If you require a feature that is not currently released you can also install
 from github::
 
-    $ python3 -m pip install git+https://github.com/DiamondLightSource/python-dodal.git
+    $ python3 -m pip install git+https://github.com/DiamondLightSource/dodal.git
 
 The library should now be installed and the commandline interface on your path.
 You can check the version that has been installed by typing::
 
-    $ python-dodal --version
+    $ dodal --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 ]
 
 [project.urls]
-GitHub = "https://github.com/DiamondLightSource/python-dodal"
+GitHub = "https://github.com/DiamondLightSource/dodal"
 
 [[project.authors]] # Further authors may be added by duplicating this section
 email = "dominic.oram@diamond.ac.uk"


### PR DESCRIPTION
Rename instances of python-dodal to dodal in docs and config following renaming of repo. This should ensure smooth publication to pypi under the correct name.