### PR TITLE
Added smoke system tests against s03 and i03

### DIFF
--- a/src/dodal/i03.py
+++ b/src/dodal/i03.py
@@ -76,6 +76,7 @@ def device_instantiation(
     return ACTIVE_DEVICES[name]
 
 
+@skip_device(lambda: BL == "s03")
 def dcm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> DCM:
     """Get the i03 DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -127,6 +128,7 @@ def backlight(
     )
 
 
+@skip_device(lambda: BL == "s03")
 def eiger(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
@@ -166,6 +168,7 @@ def fast_grid_scan(
     )
 
 
+@skip_device(lambda: BL == "s03")
 def oav(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> OAV:
     """Get the i03 OAV device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -209,6 +212,7 @@ def s4_slit_gaps(
     )
 
 
+@skip_device(lambda: BL == "s03")
 def synchrotron(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> Synchrotron:

--- a/tests/system_tests/test_i03_system.py
+++ b/tests/system_tests/test_i03_system.py
@@ -12,4 +12,6 @@ if __name__ == "__main__":
     EPICS ports and switching ports at runtime is non-trivial
     """
     with patch("dodal.i03.BL", "i03"):
+        print("Making all i03 devices")
         make_all_devices(i03)
+        print("Successfully connected")

--- a/tests/system_tests/test_i03_system.py
+++ b/tests/system_tests/test_i03_system.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+from dodal import i03
+from dodal.utils import make_all_devices
+
+if __name__ == "__main__":
+    """This test runs against the real beamline and confirms that all the devices connect
+    i.e. that we match the beamline PVs. Obviously this must be run on the DLS network
+    and could be flaky if parts of the beamline are down for maintenance.
+
+    This is not implemented as a normal pytest test as those tests run using the S03
+    EPICS ports and switching ports at runtime is non-trivial
+    """
+    with patch("dodal.i03.BL", "i03"):
+        make_all_devices(i03)

--- a/tests/system_tests/test_s03_system.py
+++ b/tests/system_tests/test_s03_system.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.s03
+def test_all_i03_devices_connect_to_s03():
+    from dodal import i03
+    from dodal.utils import make_all_devices
+
+    make_all_devices(i03)


### PR DESCRIPTION
To test:
* Get a running S03
* Run the new system tests (note the s03 one is run using `pytest -m s03` but the other one must be run with `python tests/system_tests/test_i03_system.py`)

Note there are currently issues with `BL03I-EA-BL-01:CTRL`