### PR TITLE
Changed zoom system test to look at s03

### DIFF
--- a/tests/devices/system_tests/test_oav_system.py
+++ b/tests/devices/system_tests/test_oav_system.py
@@ -35,6 +35,6 @@ def test_grid_overlay():
 
 @pytest.mark.s03
 def test_get_zoom_levels():
-    my_zoom_controller = ZoomController("BL03I-EA-OAV-01:FZOOM:", name="test_zoom")
+    my_zoom_controller = ZoomController("BL03S-EA-OAV-01:FZOOM:", name="test_zoom")
     my_zoom_controller.wait_for_connection()
     assert my_zoom_controller.allowed_zoom_levels[0] == "1.0x"


### PR DESCRIPTION
To test:
* Make sure you don't have an s03 running
* We want to just test this on the usual EPICS ports so run:
```
unset S03_EPICS_CA_SERVER_PORT
unset S03_EPICS_CA_REPEATER_PORT
```
* Run the test this PR edits - confirm it fails
* Pull https://gitlab.diamond.ac.uk/controls/support/bl03s-builder/-/merge_requests/4
* Run `make` on the top of that directory
* Run `./iocs/BL03S-MO-IOC-03/bin/linux-x86_64/stBL03S-MO-IOC-03.sh`
* Run the test this PR edits - confirm it passes