### PR TITLE
Fix number of images calculated for grid scans

### DIFF
--- a/src/dodal/devices/fast_grid_scan.py
+++ b/src/dodal/devices/fast_grid_scan.py
@@ -98,7 +98,7 @@ class GridScanParams(DataClassJsonMixin, AbstractExperimentParameterBase):
         return first_grid_in_limits and second_grid_in_limits
 
     def get_num_images(self):
-        return self.x_steps * self.y_steps + self.y_steps * self.z_steps
+        return self.x_steps * self.y_steps + self.x_steps * self.z_steps
 
     @property
     def is_3d_grid_scan(self):

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -331,3 +331,9 @@ def test_can_run_fast_grid_scan_in_run_engine(fast_grid_scan):
     RE = RunEngine()
     RE(kickoff_and_complete(fast_grid_scan))
     assert RE.state == "idle"
+
+
+def test_given_x_y_z_steps_when_full_number_calculated_then_answer_is_as_expected(
+    grid_scan_params: GridScanParams,
+):
+    assert grid_scan_params.get_num_images() == 350


### PR DESCRIPTION
Underlying fix for https://github.com/DiamondLightSource/python-artemis/issues/630