### PR TITLE
Getting an aperture scatterguard twice with no positions is valid if positions already specified

### DIFF
--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -7,6 +7,7 @@ from ophyd.status import AndStatus
 from dodal.devices.aperture import Aperture
 from dodal.devices.logging_ophyd_device import InfoLoggingDevice
 from dodal.devices.scatterguard import Scatterguard
+from dodal.log import LOGGER
 
 
 class InvalidApertureMove(Exception):
@@ -72,6 +73,7 @@ class ApertureScatterguard(InfoLoggingDevice):
     aperture_positions: Optional[AperturePositions] = None
 
     def load_aperture_positions(self, positions: AperturePositions):
+        LOGGER.info(f"{self.name} loaded in {positions}")
         self.aperture_positions = positions
 
     def set(self, pos: Tuple[float, float, float, float, float]) -> AndStatus:

--- a/src/dodal/i03.py
+++ b/src/dodal/i03.py
@@ -105,7 +105,8 @@ def aperture_scatterguard(
     """
 
     def load_positions(a_s: ApertureScatterguard):
-        a_s.load_aperture_positions(aperture_positions)
+        if aperture_positions is not None:
+            a_s.load_aperture_positions(aperture_positions)
 
     return device_instantiation(
         device=ApertureScatterguard,

--- a/tests/unit_tests/test_i03.py
+++ b/tests/unit_tests/test_i03.py
@@ -3,7 +3,7 @@ from ophyd import Device
 from ophyd.sim import FakeEpicsSignal
 
 from dodal import i03
-from dodal.devices.aperturescatterguard import ApertureScatterguard
+from dodal.devices.aperturescatterguard import AperturePositions, ApertureScatterguard
 from dodal.devices.smargon import Smargon
 from dodal.devices.zebra import Zebra
 from dodal.utils import make_all_devices
@@ -78,3 +78,15 @@ def test_device_is_new_after_clearing():
     i03.clear_devices()
     ids_3 = [_make_devices_and_get_id()]
     assert ids_1 != ids_3
+
+
+def test_getting_second_aperture_scatterguard_gives_valid_device():
+    test_positions = AperturePositions(
+        (0, 1, 2, 3, 4), (5, 6, 7, 8, 9), (10, 11, 12, 13, 14), (15, 16, 17, 18, 19)
+    )
+    ap_sg: ApertureScatterguard = i03.aperture_scatterguard(
+        fake_with_ophyd_sim=True, aperture_positions=test_positions
+    )
+    assert ap_sg.aperture_positions is not None
+    ap_sg = i03.aperture_scatterguard(fake_with_ophyd_sim=True)
+    assert ap_sg.aperture_positions is not None


### PR DESCRIPTION
Fixes #51 