### PR TITLE
Allow aliased or extended builtin imports in device modules

### DIFF
--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -166,8 +166,11 @@ def _is_device_skipped(func: Callable[..., Any]) -> bool:
 
 
 def _is_device_factory(func: Callable[..., Any]) -> bool:
-    return_type = signature(func).return_annotation
-    return _is_device_type(return_type)
+    try:
+        return_type = signature(func).return_annotation
+        return _is_device_type(return_type)
+    except ValueError:
+        return False
 
 
 def _is_device_type(obj: Type[Any]) -> bool:

--- a/tests/fake_beamline_misbehaving_builtins.py
+++ b/tests/fake_beamline_misbehaving_builtins.py
@@ -1,8 +1,7 @@
+from math import hypot, log
 from typing import TypedDict
 
 from ophyd.utils import DisconnectedError
-from math import hypot, log
-
 
 """
     Some builtins (e.g. dict, Exception), types that extend
@@ -44,4 +43,5 @@ class B(TypedDict):
     """
     Causes issue only if a class that extends TypedDict exists.
     """
+
     foo: int

--- a/tests/fake_beamline_misbehaving_builtins.py
+++ b/tests/fake_beamline_misbehaving_builtins.py
@@ -1,0 +1,47 @@
+from typing import TypedDict
+
+from ophyd.utils import DisconnectedError
+from math import hypot, log
+
+
+"""
+    Some builtins (e.g. dict, Exception), types that extend
+    them, and aliases for them, do not have signature information.
+    PEP-8 recommends being conservative with adding typing information
+    to builtins and the core Python library, so this may change slowly.
+    This beamline uses some types or constructions that are known to
+    cause issue but that could conceivably be used in a beamline file.
+
+    - Importing specific exceptions
+    - Importing functions from builtins, including math
+    - Aliasing builtins, including dict
+    - Defining a class that extends TypedDict (e.g. for parameters)
+
+"""
+
+
+def not_a_device() -> None:
+    """
+    Importing DisconnectedError is enough to cause issue, but we
+    use it here to prevent linting from removing it from the imports.
+    """
+    raise DisconnectedError()
+
+
+def also_not_a_device() -> float:
+    """
+    log and hypot both do not have signatures.
+    Not required to actually be used, importing is enough.
+    """
+    return log(hypot(0, 0))
+
+
+a = dict
+b = Exception
+
+
+class B(TypedDict):
+    """
+    Causes issue only if a class that extends TypedDict exists.
+    """
+    foo: int

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,12 @@ def test_get_hostname() -> None:
         assert get_hostname() == "a"
 
 
+def test_no_signature_builtins_not_devices() -> None:
+    import tests.fake_beamline_misbehaving_builtins as fake_beamline
+    devices = make_all_devices(fake_beamline)
+    assert not devices
+
+
 def device_a() -> Readable:
     return MagicMock()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,6 +54,7 @@ def test_get_hostname() -> None:
 
 def test_no_signature_builtins_not_devices() -> None:
     import tests.fake_beamline_misbehaving_builtins as fake_beamline
+
     devices = make_all_devices(fake_beamline)
     assert not devices
 


### PR DESCRIPTION
- Fixes #56
- e.g. a = dict
- e.g. from ophyd.utils import DisconnectedError