### PR TITLE
Allow creating all devices when device instantiation(s) raise an exception

### DIFF
--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -166,8 +166,11 @@ def _is_device_skipped(func: Callable[..., Any]) -> bool:
 
 
 def _is_device_factory(func: Callable[..., Any]) -> bool:
-    return_type = signature(func).return_annotation
-    return _is_device_type(return_type)
+    try:
+        return_type = signature(func).return_annotation
+        return _is_device_type(return_type)
+    except ValueError:  # e.g. built ins without a signature
+        return False
 
 
 def _is_device_type(obj: Type[Any]) -> bool:

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -152,18 +152,18 @@ def make_all_devices_without_throwing(
     """
     if isinstance(module, str) or module is None:
         module = import_module(module or __name__)
-    factories = collect_factories(module)
-    return invoke_factories(factories, **kwargs)
+    factories = _collect_factories(module)
+    return _invoke_factories(factories, **kwargs)
 
 
-def invoke_factories(
+def _invoke_factories(
     factories: Mapping[str, Callable[..., Any]],
     **kwargs,
 ) -> DevicesAndExceptions:
     devices: Dict[str, HasName] = {}
     exceptions: Dict[str, Exception] = {}
     dependencies = {
-        factory_name: set(extract_dependencies(factories, factory_name))
+        factory_name: set(_extract_dependencies(factories, factory_name))
         for factory_name in factories.keys()
     }
     while len(devices) + len(exceptions) < len(factories):
@@ -201,7 +201,7 @@ def invoke_factories(
     return DevicesAndExceptions(all_devices, exceptions)
 
 
-def extract_dependencies(
+def _extract_dependencies(
     factories: Mapping[str, Callable[..., Any]], factory_name: str
 ) -> Iterable[str]:
     for name, param in inspect.signature(factories[factory_name]).parameters.items():
@@ -209,7 +209,7 @@ def extract_dependencies(
             yield name
 
 
-def collect_factories(module: ModuleType) -> Mapping[str, Callable[..., Any]]:
+def _collect_factories(module: ModuleType) -> Mapping[str, Callable[..., Any]]:
     factories = {}
     for var in module.__dict__.values():
         if callable(var) and _is_device_factory(var) and not _is_device_skipped(var):

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -130,7 +130,7 @@ def make_all_devices(
     devices_and_exceptions = make_all_devices_without_throwing(module, **kwargs)
     if devices_and_exceptions.exceptions:
         raise ExceptionBundle(
-            msg=f"Multiple exceptions while executing device factories: {list(devices_and_exceptions.exceptions.keys())}",
+            msg=f"Exception(s) while executing device factories: {list(devices_and_exceptions.exceptions.keys())}",
             exceptions=devices_and_exceptions.exceptions,
         )
     return devices_and_exceptions.devices

--- a/tests/test_beamline_disordered_and_broken.py
+++ b/tests/test_beamline_disordered_and_broken.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from bluesky.protocols import Readable
+from ophyd import EpicsMotor
+from ophyd.utils import DisconnectedError
+
+from dodal.devices.cryostream import Cryo
+
+
+def device_z(device_x: Readable, device_y: EpicsMotor) -> Cryo:
+    raise DisconnectedError
+
+
+def device_x() -> Readable:
+    raise DisconnectedError
+
+
+def device_y() -> EpicsMotor:
+    return _mock_with_name("motor")
+
+
+def _mock_with_name(name: str) -> MagicMock:
+    mock = MagicMock()
+    mock.name = name
+    return mock

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from ophyd import EpicsMotor
 from ophyd.utils import DisconnectedError, ExceptionBundle
 
 from dodal.utils import (
-    collect_factories,
+    _collect_factories,
     get_hostname,
     make_all_devices,
     make_all_devices_without_throwing,
@@ -16,7 +16,7 @@ from dodal.utils import (
 def test_finds_device_factories() -> None:
     import tests.fake_beamline as fake_beamline
 
-    factories = collect_factories(fake_beamline)
+    factories = _collect_factories(fake_beamline)
 
     from tests.fake_beamline import device_a, device_b, device_c
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,13 +75,11 @@ def test_dependent_devices_not_instantiated_when_dependency_fails() -> None:
     x_exception = exceptions["device_x"]
     assert isinstance(x_exception, ExceptionInformation)
     assert x_exception.return_type is Readable
-    assert x_exception.call_args == {}
     assert isinstance(x_exception.exception, DisconnectedError)
     assert "device_z" in exceptions
     z_exception = exceptions["device_z"]
     assert isinstance(z_exception, ExceptionInformation)
     assert z_exception.return_type is Cryo
-    assert z_exception.call_args == {"device_y": devices["motor"]}
     assert isinstance(z_exception.exception, ExceptionBundle)
     assert x_exception.exception in z_exception.exception.exceptions.values()
 


### PR DESCRIPTION
Closes #58 but as an optional behaviour. Changes the behaviour of make_all_devices to not fail at the first exception, but to collect all exceptions from devices that failed to instantiate and raise an ExceptionBundle with them all (unless there is only 1 device, with no dependencies that fails to instantiate, then the raise is just delayed until all other devices are tried)

Requires #61 (to allow importing an Exception that is thrown by the device instantiation)