### PR TITLE
reset values after tests so following pass

### DIFF
--- a/tests/devices/unit_tests/test_beam_converter.py
+++ b/tests/devices/unit_tests/test_beam_converter.py
@@ -17,6 +17,23 @@ def fake_converter() -> DetectorDistanceToBeamXYConverter:
     return DetectorDistanceToBeamXYConverter("test.txt")
 
 
+def test_converter_eq():
+    test_file = "tests/devices/unit_tests/test_lookup_table.txt"
+    test_converter = DetectorDistanceToBeamXYConverter(test_file)
+    test_converter_dupe = DetectorDistanceToBeamXYConverter(test_file)
+    test_file_2 = "tests/devices/unit_tests/test_lookup_table_2.txt"
+    test_converter_2 = DetectorDistanceToBeamXYConverter(test_file_2)
+
+    assert test_converter == test_converter_dupe
+    assert test_converter != test_converter_2
+
+    test_converter_dupe.lookup_table_values[0] = (7.5, 23.5)
+
+    assert test_converter != test_converter_2
+
+    test_converter_dupe.lookup_table_values[0] = (100.0, 200.0)
+
+
 @pytest.mark.parametrize(
     "detector_distance, axis, expected_value",
     [
@@ -83,18 +100,3 @@ def test_parse_table():
 
     assert test_converter.lookup_file == test_file
     assert test_converter.lookup_table_values == LOOKUP_TABLE_TEST_VALUES
-
-
-def test_converter_eq():
-    test_file = "tests/devices/unit_tests/test_lookup_table.txt"
-    test_converter = DetectorDistanceToBeamXYConverter(test_file)
-    test_converter_dupe = DetectorDistanceToBeamXYConverter(test_file)
-    test_file_2 = "tests/devices/unit_tests/test_lookup_table_2.txt"
-    test_converter_2 = DetectorDistanceToBeamXYConverter(test_file_2)
-
-    assert test_converter == test_converter_dupe
-    assert test_converter != test_converter_2
-
-    test_converter_dupe.lookup_table_values[0] = (7.5, 23.5)
-
-    assert test_converter != test_converter_2

--- a/tests/devices/unit_tests/test_beam_converter.py
+++ b/tests/devices/unit_tests/test_beam_converter.py
@@ -27,11 +27,12 @@ def test_converter_eq():
     assert test_converter == test_converter_dupe
     assert test_converter != test_converter_2
 
+    previous_value = test_converter_dupe.lookup_table_values[0]
     test_converter_dupe.lookup_table_values[0] = (7.5, 23.5)
 
     assert test_converter != test_converter_2
 
-    test_converter_dupe.lookup_table_values[0] = (100.0, 200.0)
+    test_converter_dupe.lookup_table_values[0] = previous_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
some dependence between tests in test_beam_converter means they are intermittently failing. test values are now reset at the end of the test responsible, although this is not a satisfying solution because `test_interpolate_beam_xy_from_det_distance` should not be reusing these anyway, but parametrize makes that difficult to debug and inspect