### PR TITLE
Rename project on pypi to dls-dodal

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -176,6 +176,10 @@ jobs:
     env:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
 
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dodal-dls
+
     steps:
       - uses: actions/download-artifact@v3
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -178,7 +178,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/p/dodal-dls
+      url: https://pypi.org/p/dls-dodal
 
     steps:
       - uses: actions/download-artifact@v3

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ dodal
 Ophyd devices and other utils that could be used across DLS beamlines
 
 ============== ==============================================================
-PyPI           ``pip install dodal-dls``
+PyPI           ``pip install dls-dodal``
 Source code    https://github.com/DiamondLightSource/dodal
 Documentation  https://DiamondLightSource.github.io/dodal
 Releases       https://github.com/DiamondLightSource/dodal/releases

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ dodal
 Ophyd devices and other utils that could be used across DLS beamlines
 
 ============== ==============================================================
-PyPI           ``pip install dodal``
+PyPI           ``pip install dodal-dls``
 Source code    https://github.com/DiamondLightSource/dodal
 Documentation  https://DiamondLightSource.github.io/dodal
 Releases       https://github.com/DiamondLightSource/dodal/releases

--- a/docs/user/tutorials/installation.rst
+++ b/docs/user/tutorials/installation.rst
@@ -25,7 +25,7 @@ Installing the library
 
 You can now use ``pip`` to install the library and its dependencies::
 
-    $ python3 -m pip install dodal
+    $ python3 -m pip install dodal-dls
 
 If you require a feature that is not currently released you can also install
 from github::

--- a/docs/user/tutorials/installation.rst
+++ b/docs/user/tutorials/installation.rst
@@ -25,7 +25,7 @@ Installing the library
 
 You can now use ``pip`` to install the library and its dependencies::
 
-    $ python3 -m pip install dodal-dls
+    $ python3 -m pip install dls-dodal
 
 If you require a feature that is not currently released you can also install
 from github::


### PR DESCRIPTION
The dodal name conflict on pypi is unlikely to be resolved soon. I suggest releasing as dodal-dls for the time being. If the dodal name is released to us we can deprecate and move.