### PR TITLE
call precondition

### DIFF
--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -86,7 +86,7 @@ def skip_device(precondition=lambda: True):
         def wrapper(*args, **kwds) -> T:
             return func(*args, **kwds)
 
-        if precondition:
+        if precondition():
             wrapper.__skip__ = True  # type: ignore
         return wrapper
 


### PR DESCRIPTION
`skip_device` was checking for the existence of the precondition rather than the return value