### PR TITLE
Remove common prefix in OAV

### DIFF
--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -47,12 +47,12 @@ class ZoomController(Device):
 
 
 class OAV(AreaDetector):
-    cam: CamBase = ADC(CamBase, "-DI-OAV-01:CAM:")
-    roi: ADC = ADC(ROIPlugin, "-DI-OAV-01:ROI:")
-    proc: ADC = ADC(ProcessPlugin, "-DI-OAV-01:PROC:")
-    over: ADC = ADC(OverlayPlugin, "-DI-OAV-01:OVER:")
-    tiff: ADC = ADC(OverlayPlugin, "-DI-OAV-01:TIFF:")
-    hdf5: ADC = ADC(HDF5Plugin, "-DI-OAV-01:HDF5:")
-    snapshot: SnapshotWithGrid = Component(SnapshotWithGrid, "-DI-OAV-01:MJPG:")
-    mxsc: MXSC = ADC(MXSC, "-DI-OAV-01:MXSC:")
-    zoom_controller: ZoomController = ADC(ZoomController, "-EA-OAV-01:FZOOM:")
+    cam: CamBase = ADC(CamBase, "CAM:")
+    roi: ADC = ADC(ROIPlugin, "ROI:")
+    proc: ADC = ADC(ProcessPlugin, "PROC:")
+    over: ADC = ADC(OverlayPlugin, "OVER:")
+    tiff: ADC = ADC(OverlayPlugin, "TIFF:")
+    hdf5: ADC = ADC(HDF5Plugin, "HDF5:")
+    snapshot: SnapshotWithGrid = Component(SnapshotWithGrid, "MJPG:")
+    mxsc: MXSC = ADC(MXSC, "MXSC:")
+    zoom_controller: ZoomController = ADC(ZoomController, "FZOOM:")


### PR DESCRIPTION
Fixes a part of https://github.com/DiamondLightSource/python-artemis/issues/738

To test:
* Clear your EPICS env from the simulated ones:
```
unset EPICS_CA_REPEATER_PORT
unset EPICS_CA_SERVER_PORT
```
* Run the following and confirm you get a real device that connects:
```python
from dodal.beamlines.beamline_utils import set_beamline
from dodal.beamlines import i03
set_beamline("i03")
i03.oav()
```