### PR TITLE
Fix the indexing on the grid positions

### DIFF
--- a/src/dodal/devices/fast_grid_scan.py
+++ b/src/dodal/devices/fast_grid_scan.py
@@ -35,7 +35,7 @@ class GridAxis:
     @property
     def end(self):
         """Gives the point where the final frame is taken"""
-        # Not that full_steps is one indexed e.g. if there is one step then the end is
+        # Note that full_steps is one indexed e.g. if there is one step then the end is
         # refering to the first position
         return self.steps_to_motor_position(self.full_steps - 1)
 

--- a/src/dodal/devices/fast_grid_scan.py
+++ b/src/dodal/devices/fast_grid_scan.py
@@ -29,11 +29,15 @@ class GridAxis:
     full_steps: int
 
     def steps_to_motor_position(self, steps):
-        return self.start + self.step_size * (steps - 1)
+        """Gives the motor position based on steps, where steps are 0 indexed"""
+        return self.start + self.step_size * steps
 
     @property
     def end(self):
-        return self.steps_to_motor_position(self.full_steps)
+        """Gives the point where the final frame is taken"""
+        # Not that full_steps is one indexed e.g. if there is one step then the end is
+        # refering to the first position
+        return self.steps_to_motor_position(self.full_steps - 1)
 
     def is_within(self, steps):
         return 0 <= steps <= self.full_steps
@@ -45,7 +49,10 @@ class GridScanParams(BaseModel, AbstractExperimentParameterBase):
     layout to EPICS.
 
     Motion program will do a grid in x-y then rotate omega +90 and perform
-    a grid in x-z
+    a grid in x-z.
+
+    The grid specified is where data is taken e.g. it can be assumed the first frame is
+    at x_start, y1_start, z1_start and subsequent frames are N*step_size away.
     """
 
     x_steps: int = 1

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -302,22 +302,22 @@ def test_given_x_y_z_of_origin_when_get_motor_positions_then_initial_positions_r
     motor_positions = grid_scan_params.grid_position_to_motor_position(
         np.array([0, 0, 0])
     )
-    assert np.allclose(motor_positions, np.array([-0.3, 0.8, 3.9]))
+    assert np.allclose(motor_positions, np.array([0, 1, 4]))
 
 
 @pytest.mark.parametrize(
     "grid_position, expected_x, expected_y, expected_z",
     [
-        (np.array([1, 1, 1]), 0.0, 1.0, 4.0),
-        (np.array([2, 11, 16]), 0.3, 3.0, 5.5),
-        (np.array([6, 5, 5]), 1.5, 1.8, 4.4),
+        (np.array([1, 1, 1]), 0.3, 1.2, 4.1),
+        (np.array([2, 11, 16]), 0.6, 3.2, 5.6),
+        (np.array([6, 5, 5]), 1.8, 2.0, 4.5),
     ],
 )
 def test_given_various_x_y_z_when_get_motor_positions_then_expected_positions_returned(
     grid_scan_params: GridScanParams, grid_position, expected_x, expected_y, expected_z
 ):
     motor_positions = grid_scan_params.grid_position_to_motor_position(grid_position)
-    np.testing.assert_array_equal(
+    np.testing.assert_allclose(
         motor_positions, np.array([expected_x, expected_y, expected_z])
     )
 


### PR DESCRIPTION
See https://github.com/DiamondLightSource/python-artemis/issues/767

To test:
* Confirm co-ordnate system makes sense compared to motion program in `/dls_sw/work/motion/BL03I/Settings/BL03I-MO-PMAC-03/PLCs/11_fast_grid_scans.pmc`
* Confirm comments make sense to explain what is going on
* Confirm tests make more sense now