### PR TITLE
Fix precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -8,7 +8,7 @@ repos:
 
   # Automatic source code formatting
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         args: [--safe, --quiet]
@@ -29,7 +29,7 @@ repos:
 
   # Linting
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
@@ -38,7 +38,7 @@ repos:
 
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v1.4.1
     hooks:
       - id: mypy
         files: 'src/.*\.py$'


### PR DESCRIPTION
To test:
* Run the following and confirm it passes:
```bash
module load python/3.11
mkdir .venv
python -m venv .venv
source .venv/bin/activate
pip install -e .[dev]
pre-commit run --all-files
```