### PR TITLE
Clean up warning caused by leftover pin detect status

### DIFF
--- a/src/dodal/devices/areadetector/plugins/MXSC.py
+++ b/src/dodal/devices/areadetector/plugins/MXSC.py
@@ -27,20 +27,23 @@ class PinTipDetect(Device):
             return True
 
     def trigger(self) -> Status:
-        subscription_status = SubscriptionStatus(self.tip_x, self.update_tip_if_valid)
+        subscription_status = SubscriptionStatus(
+            self.tip_x, self.update_tip_if_valid, run=False
+        )  # Do not run on creation as the PV updates often and can cause race conditions
 
-        def set_to_default_and_finish(_):
+        def set_to_default_and_finish(timeout_status: Status):
             try:
-                self.triggered_tip.set(self.INVALID_POSITION)
-                subscription_status.set_finished()
+                if not timeout_status.success:
+                    self.triggered_tip.set(self.INVALID_POSITION)
+                    subscription_status.set_finished()
             except Exception as e:
                 subscription_status.set_exception(e)
 
         # We use a separate status for measuring the timeout as we don't want an error
         # on the returned status
-        Status(self, timeout=self.validity_timeout.get()).add_callback(
-            set_to_default_and_finish
-        )
+        self._timeout_status = Status(self, timeout=self.validity_timeout.get())
+        self._timeout_status.add_callback(set_to_default_and_finish)
+        subscription_status.add_callback(lambda _: self._timeout_status.set_finished())
 
         return subscription_status
 

--- a/tests/devices/unit_tests/test_pin_tip_detect.py
+++ b/tests/devices/unit_tests/test_pin_tip_detect.py
@@ -13,17 +13,24 @@ def fake_pin_tip_detect() -> PinTipDetect:
     yield pin_tip_detect
 
 
+def trigger_and_read(fake_pin_tip_detect, value_to_set_during_trigger=None):
+    yield from bps.trigger(fake_pin_tip_detect)
+    if value_to_set_during_trigger:
+        fake_pin_tip_detect.tip_y.sim_put(value_to_set_during_trigger[1])
+        fake_pin_tip_detect.tip_x.sim_put(value_to_set_during_trigger[0])
+    yield from bps.wait()
+    return (yield from bps.rd(fake_pin_tip_detect))
+
+
 def test_given_pin_tip_stays_invalid_when_triggered_then_return_(
     fake_pin_tip_detect: PinTipDetect,
 ):
-    def trigger_and_read():
+    def set_small_timeout_then_trigger_and_read():
         yield from bps.abs_set(fake_pin_tip_detect.validity_timeout, 0.01)
-        yield from bps.trigger(fake_pin_tip_detect)
-        yield from bps.wait()
-        return (yield from bps.rd(fake_pin_tip_detect))
+        return (yield from trigger_and_read(fake_pin_tip_detect))
 
     RE = RunEngine(call_returns_result=True)
-    result = RE(trigger_and_read())
+    result = RE(set_small_timeout_then_trigger_and_read())
 
     assert result.plan_result == fake_pin_tip_detect.INVALID_POSITION
 
@@ -31,14 +38,16 @@ def test_given_pin_tip_stays_invalid_when_triggered_then_return_(
 def test_given_pin_tip_invalid_when_triggered_and_set_then_rd_returns_value(
     fake_pin_tip_detect: PinTipDetect,
 ):
-    def trigger_and_read():
-        yield from bps.trigger(fake_pin_tip_detect)
-        fake_pin_tip_detect.tip_y.sim_put(100)
-        fake_pin_tip_detect.tip_x.sim_put(200)
-        yield from bps.wait()
-        return (yield from bps.rd(fake_pin_tip_detect))
-
     RE = RunEngine(call_returns_result=True)
-    result = RE(trigger_and_read())
+    result = RE(trigger_and_read(fake_pin_tip_detect, (200, 100)))
 
     assert result.plan_result == (200, 100)
+
+
+def test_given_pin_tip_found_before_timeout_then_timeout_status_cleaned_up_and_tip_value_remains(
+    fake_pin_tip_detect: PinTipDetect,
+):
+    RE = RunEngine(call_returns_result=True)
+    RE(trigger_and_read(fake_pin_tip_detect, (100, 200)))
+    assert fake_pin_tip_detect._timeout_status.done
+    assert fake_pin_tip_detect.triggered_tip.get() == (100, 200)


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/python-artemis/issues/789

To Test:
* Ensure new test passes
* Run all the tests and confirm you don't get the warning as in the linked issue (these warnings seem a little flaky for me on main too though)