### PR TITLE
Fix tests and race condition in finding pin tip

### DIFF
--- a/src/dodal/devices/areadetector/plugins/MXSC.py
+++ b/src/dodal/devices/areadetector/plugins/MXSC.py
@@ -23,13 +23,13 @@ class PinTipDetect(Device):
     def update_tip_if_valid(self, value, **_):
         current_value = (value, self.tip_y.get())
         if current_value != self.INVALID_POSITION:
-            self.triggered_tip.set(current_value)
+            self.triggered_tip.put(current_value)
             return True
 
     def trigger(self) -> Status:
         subscription_status = SubscriptionStatus(
-            self.tip_x, self.update_tip_if_valid, run=False
-        )  # Do not run on creation as the PV updates often and can cause race conditions
+            self.tip_x, self.update_tip_if_valid, run=True
+        )
 
         def set_to_default_and_finish(timeout_status: Status):
             try:


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/python-artemis/issues/808

I couldn't find a way to reproduce this in a simulated way, you can reproduce using real PVs:
```python
from ophyd import Component, Device, EpicsSignal, EpicsSignalRO, Kind, Signal
from ophyd.status import Status, SubscriptionStatus


class PinTipDetect(Device):
    INVALID_POSITION = (-1, -1)
    tip_x: EpicsSignalRO = Component(EpicsSignal, "SR-CS-FILL-01:COUNTDOWN")

    triggered_tip: Signal = Component(Signal, kind=Kind.hinted, value=INVALID_POSITION)
    validity_timeout: Signal = Component(Signal, value=5)

    def update_tip_if_valid(self, value, **_):
        if value != self.INVALID_POSITION:
            self.triggered_tip.set(value)
            return True

    def trigger(self) -> Status:
        subscription_status = SubscriptionStatus(
            self.tip_x, self.update_tip_if_valid, run=True
        )

        def set_to_default_and_finish(timeout_status: Status):
            try:
                if not timeout_status.success:
                    self.triggered_tip.set(self.INVALID_POSITION)
                    subscription_status.set_finished()
            except Exception as e:
                subscription_status.set_exception(e)

        # We use a separate status for measuring the timeout as we don't want an error
        # on the returned status
        self._timeout_status = Status(self, timeout=self.validity_timeout.get())
        self._timeout_status.add_callback(set_to_default_and_finish)
        subscription_status.add_callback(lambda _: self._timeout_status.set_finished())

        return subscription_status


device = PinTipDetect(name="test", prefix="")
device.wait_for_connection()

status = device.trigger()
status.wait()
```

Note this has `run=True`, which should fix the original issue seen. But will produce an exception like:
```
Traceback (most recent call last):
  File "/scratch/ffv81422/artemis/python-artemis/.venv/lib/python3.10/site-packages/ophyd/ophydobj.py", line 492, in inner
    cb(*args, **kwargs)
  File "/scratch/ffv81422/artemis/python-artemis/.venv/lib/python3.10/site-packages/ophyd/status.py", line 730, in check_value
    self._finished(success=True)
  File "/scratch/ffv81422/artemis/python-artemis/.venv/lib/python3.10/site-packages/ophyd/status.py", line 372, in _finished
    self.set_finished()
  File "/scratch/ffv81422/artemis/python-artemis/.venv/lib/python3.10/site-packages/ophyd/status.py", line 742, in set_finished
    super().set_finished()
  File "/scratch/ffv81422/artemis/python-artemis/.venv/lib/python3.10/site-packages/ophyd/status.py", line 337, in set_finished
    raise InvalidState(
ophyd.utils.errors.InvalidState: Either set_finished() or set_exception() has already been called on SubscriptionStatus(device=test_tip_x, done=False, success=False)
```

Using `self.triggered_tip.put(value)` instead (as in this PR) removes this error.

To test this PR:
* Confirm above description matches this PR
* Confirm running Artemis against this commit fixes the original issue
