### PR TITLE
Return a status that include OAV wiring changes in zoom level change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
-    "ophyd",
+    "ophyd @ git+https://github.com/bluesky/ophyd@58d6fadb632fa2e49273e9097c7deb57f6b34c68",
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -21,9 +21,8 @@ from dodal.devices.oav.grid_overlay import SnapshotWithGrid
 class ZoomController(Device):
     """
     Device to control the zoom level. This should be set like
-        >>> z = ZoomController(name="zoom")
-        >>> z.set("1.0x")
-        Status...
+        o = OAV(name="oav")
+        oav.zoom_controller.set("1.0x")
 
     Note that changing the zoom may change the AD wiring on the associated OAV, as such
     you should wait on any zoom changs to finish before changing the OAV wiring.

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -4,6 +4,7 @@ from ophyd import (
     CamBase,
     Component,
     Device,
+    DeviceStatus,
     EpicsSignal,
     HDF5Plugin,
     OverlayPlugin,
@@ -23,6 +24,9 @@ class ZoomController(Device):
         >>> z = ZoomController(name="zoom")
         >>> z.set("1.0x")
         Status...
+
+    Note that changing the zoom may change the AD wiring on the associated OAV, as such
+    you should wait on any zoom changs to finish before changing the OAV wiring.
     """
 
     percentage: EpicsSignal = Component(EpicsSignal, "ZOOMPOSCMD")
@@ -39,6 +43,20 @@ class ZoomController(Device):
     frst: EpicsSignal = Component(EpicsSignal, "MP:SELECT.FRST")
     fvst: EpicsSignal = Component(EpicsSignal, "MP:SELECT.FVST")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.flat_field_status = DeviceStatus(self, timeout=10)
+
+    def set_flatfield_on_zoom_level_one(self, value):
+        flat_applied = self.parent.proc.port_name.get()
+        no_flat_applied = self.parent.cam.port_name.get()
+
+        input_plugin = flat_applied if value == "1.0x" else no_flat_applied
+
+        flat_field_status = self.parent.mxsc.input_plugin.set(input_plugin)
+        return flat_field_status & self.parent.snapshot.input_plugin.set(input_plugin)
+
     @property
     def allowed_zoom_levels(self):
         return [
@@ -51,8 +69,10 @@ class ZoomController(Device):
         ]
 
     def set(self, level_to_set: str) -> StatusBase:
-        self._level_sp.set(level_to_set)
-        return self.level.set(level_to_set)
+        return_status = self._level_sp.set(level_to_set)
+        return_status &= self.level.set(level_to_set)
+        return_status &= self.set_flatfield_on_zoom_level_one(level_to_set)
+        return return_status
 
 
 class OAV(AreaDetector):
@@ -65,19 +85,3 @@ class OAV(AreaDetector):
     snapshot: SnapshotWithGrid = Component(SnapshotWithGrid, "-DI-OAV-01:MJPG:")
     mxsc: MXSC = ADC(MXSC, "-DI-OAV-01:MXSC:")
     zoom_controller: ZoomController = Component(ZoomController, "-EA-OAV-01:FZOOM:")
-
-    def set_flatfield_on_zoom_level_one(self, value=None, old_value=None, **kwargs):
-        flat_applied = self.proc.port_name.get()
-        no_flat_applied = self.cam.port_name.get()
-
-        input_plugin = flat_applied if value == "1.0x" else no_flat_applied
-
-        self.mxsc.input_plugin.put(input_plugin)
-        self.snapshot.input_plugin.put(input_plugin)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.zoom_controller._level_sp.subscribe(
-            self.set_flatfield_on_zoom_level_one,
-        )

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import pytest
+from ophyd.sim import instantiate_fake_device
+from ophyd.status import Status
+
+from dodal.devices.oav.oav_detector import OAV
+
+
+@pytest.fixture
+def oav() -> OAV:
+    oav: OAV = instantiate_fake_device(OAV)
+    oav.proc.port_name.sim_put("proc")
+    oav.cam.port_name.sim_put("CAM")
+
+    oav.zoom_controller.zrst.set("1.0x")
+    oav.zoom_controller.onst.set("2.0x")
+    oav.zoom_controller.twst.set("3.0x")
+    oav.zoom_controller.thst.set("5.0x")
+    oav.zoom_controller.frst.set("7.0x")
+    oav.zoom_controller.fvst.set("9.0x")
+
+    return oav
+
+
+@pytest.mark.parametrize(
+    "zoom, expected_plugin",
+    [
+        ("1.0x", "proc"),
+        ("7.0x", "CAM"),
+    ],
+)
+def test_when_zoom_level_changed_then_oav_rewired(zoom, expected_plugin, oav: OAV):
+    oav.zoom_controller.set(zoom).wait()
+
+    assert oav.mxsc.input_plugin.get() == expected_plugin
+    assert oav.snapshot.input_plugin.get() == "OAV.MXSC"
+
+
+def test_when_zoom_level_changed_then_status_waits_for_all_plugins_to_be_updated(
+    oav: OAV,
+):
+    expected_exception = Exception()
+    plugin_status = Status()
+    # We're using an exception as a proxy to tell that we're waiting on this set too
+    plugin_status.set_exception(expected_exception)
+    oav.mxsc.input_plugin.set = MagicMock(return_value=plugin_status)
+
+    full_status = oav.zoom_controller.set("1.0x")
+
+    assert full_status.exception == expected_exception

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 import pytest
 from ophyd.sim import instantiate_fake_device
 from ophyd.status import Status
-from ophyd.utils.errors import WaitTimeoutError
 
 from dodal.devices.oav.oav_detector import OAV
 


### PR DESCRIPTION
Changing zoom level now changes wiring so waiting on it to finish should also wait on these changes

Fixes issue seen in https://github.com/DiamondLightSource/python-artemis/issues/830