### PR TITLE
Remove ophyd dependency pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
-    "ophyd@git+https://github.com/DominicOram/ophyd@31a1762435bcb275d2555068233549885eab02e7", # Switch back to just "ophyd" once ophyd#1148, ophyd#1155, ophyd#1140 merged.
+    "ophyd",
     "bluesky",
     "pyepics",
     "dataclasses-json",


### PR DESCRIPTION
fixes #132 
Since Ophyd v1.9.0 is now compatible, we can remove the commit pin