### PR TITLE
Create constants for pausing xbpm and remove feedback stability time as no longer used

### DIFF
--- a/src/dodal/devices/xbpm_feedback.py
+++ b/src/dodal/devices/xbpm_feedback.py
@@ -6,9 +6,9 @@ class XBPMFeedback(Device):
     """The XBPM feedback device is an IOC that moves the DCM, HFM and VFM to automatically
     hold the beam into place, as measured by the XBPM sensor."""
 
-    # We need to wait for the beam to be locked into position for this amount of time
-    # until we are certain that it is stable.
-    STABILITY_TIME = 3
+    # Values to set to pause_feedback
+    PAUSE = 0
+    RUN = 1
 
     pos_ok: EpicsSignalRO = Component(EpicsSignalRO, "-EA-FDBK-01:XBPM2POSITION_OK")
     pos_stable: EpicsSignalRO = Component(EpicsSignalRO, "-EA-FDBK-01:XBPM2_STABLE")


### PR DESCRIPTION
See https://github.com/DiamondLightSource/hyperion/issues/921

Stability should have been removed in https://github.com/DiamondLightSource/dodal/pull/160/commits/f2677a245698b460c38ab88cecf33df27d1bcb07 as it's being done in the IOC, not in ophyd