### PR TITLE
correct return type for XBPMFeedback factory

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -289,7 +289,7 @@ def flux(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) ->
 
 def xbpm_feedback(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Flux:
+) -> XBPMFeedback:
     """Get the i03 XBPM feeback device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """


### PR DESCRIPTION
No relevant issue, shouldn't really affect anything except static checking