### PR TITLE
pin ophyd-async to <0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
     "ophyd",
-    "ophyd-async",
+    "ophyd-async<0.2",
     "bluesky",
     "pyepics",
     "dataclasses-json",


### PR DESCRIPTION
As of 0.2, ophyd-async requires bluesky 1.12
this is incompatible with blueAPI which requires <=1.11
when blueAPI is updated we should remove this pin