### PR TITLE
Pin ophyd-async to working version (0.1.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
     "ophyd",
-    "ophyd-async",
+    "ophyd-async==0.1.0",
     "bluesky",
     "pyepics",
     "dataclasses-json",


### PR DESCRIPTION
Fixes Hyperion [#1006](https://github.com/DiamondLightSource/hyperion/issues/1006)

### Instructions to reviewer on how to test:
Confirm this change makes the correct version of ophyd-async install when creating Hyperion's virtual environment

### Checks for reviewer
- [x] Would the PR title make sense to a scientist on a set of release notes
- [x] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)