### PR TITLE
Fix flaky unit test and use correct timeout in zocalo results

### DIFF
--- a/src/dodal/devices/zocalo/zocalo_results.py
+++ b/src/dodal/devices/zocalo/zocalo_results.py
@@ -56,7 +56,7 @@ def create_loop():
     """Needed as loops are instantiated differently in different python versions.
     Remove when we drop support for Python 3.9"""
     if version.parse(platform.python_version()) < version.parse("3.10"):
-        return asyncio.Queue(loop=get_bluesky_event_loop())
+        return asyncio.Queue(loop=get_bluesky_event_loop())  # type: ignore
     else:
         return asyncio.Queue()
 

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -11,6 +11,7 @@ from ophyd_async.core.async_status import AsyncStatus
 
 from dodal.devices.zocalo.zocalo_results import (
     ZOCALO_READING_PLAN_NAME,
+    NoResultsFromZocalo,
     XrcResult,
     ZocaloResults,
     get_processing_result,
@@ -199,11 +200,9 @@ def test_when_exception_caused_by_zocalo_message_then_exception_propagated(
 ):
     RE = RunEngine()
     zocalo_results = ZocaloResults(
-        name="zocalo", zocalo_environment="dev_artemis", timeout_s=2
+        name="zocalo", zocalo_environment="dev_artemis", timeout_s=0.1
     )
     with pytest.raises(FailedStatus) as e:
         RE(bps.trigger(zocalo_results, wait=True))
 
-    tb = str(e.getrepr())
-    assert "exceptions.CancelledError" in tb
-    assert "TimeoutError" in tb
+    assert isinstance(e.value.__cause__, NoResultsFromZocalo)

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -178,7 +178,9 @@ async def test_extraction_plan(mocked_zocalo_device, RE) -> None:
     "dodal.devices.zocalo.zocalo_results.workflows.recipe.wrap_subscribe", autospec=True
 )
 @patch("dodal.devices.zocalo.zocalo_results._get_zocalo_connection", autospec=True)
+@patch("dodal.devices.zocalo.zocalo_results.asyncio.wait_for")
 def test_subscribe_only_called_once_on_first_trigger(
+    mock_await_for: MagicMock,
     mock_connection: MagicMock,
     mock_wrap_subscribe: MagicMock,
 ):


### PR DESCRIPTION
Fixes #269

### Instructions to reviewer on how to test:
1. Confirm tests still passes and is faster than main

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)