### PR TITLE
Automatically find next run_number by default

### DIFF
--- a/src/dodal/devices/detector.py
+++ b/src/dodal/devices/detector.py
@@ -1,6 +1,7 @@
 from enum import Enum, auto
 from typing import Any, Optional, Tuple
 
+from hyperion.utils.get_run_number import get_run_number
 from pydantic import BaseModel, validator
 
 from dodal.devices.det_dim_constants import (
@@ -31,7 +32,6 @@ class DetectorParams(BaseModel):
     exposure_time: float
     directory: str
     prefix: str
-    run_number: int
     detector_distance: float
     omega_start: float
     omega_increment: float
@@ -42,6 +42,7 @@ class DetectorParams(BaseModel):
     trigger_mode: TriggerMode = TriggerMode.SET_FRAMES
     detector_size_constants: DetectorSizeConstants = EIGER2_X_16M_SIZE
     beam_xy_converter: DetectorDistanceToBeamXYConverter = None
+    run_number: int = 0
 
     class Config:
         arbitrary_types_allowed = True
@@ -71,6 +72,13 @@ class DetectorParams(BaseModel):
         return DetectorDistanceToBeamXYConverter(
             values["det_dist_to_beam_converter_path"]
         )
+
+    @validator("run_number", always=True)
+    def _set_run_number(cls, run_number: int, values: dict[str, Any]):
+        if values["run_number"] == 0:
+            return get_run_number(values["directory"])
+        else:
+            return values["run_number"]
 
     # The following are optional from GDA as populated internally
     # Where the VDS start index should be in the Nexus file

--- a/src/dodal/devices/detector.py
+++ b/src/dodal/devices/detector.py
@@ -1,7 +1,6 @@
 from enum import Enum, auto
 from typing import Any, Optional, Tuple
 
-from hyperion.utils.get_run_number import get_run_number
 from pydantic import BaseModel, validator
 
 from dodal.devices.det_dim_constants import (
@@ -14,6 +13,7 @@ from dodal.devices.det_dist_to_beam_converter import (
     Axis,
     DetectorDistanceToBeamXYConverter,
 )
+from dodal.utils import get_run_number
 
 
 class TriggerMode(Enum):
@@ -42,7 +42,7 @@ class DetectorParams(BaseModel):
     trigger_mode: TriggerMode = TriggerMode.SET_FRAMES
     detector_size_constants: DetectorSizeConstants = EIGER2_X_16M_SIZE
     beam_xy_converter: DetectorDistanceToBeamXYConverter = None
-    run_number: int = 0
+    run_number: Optional[int] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -75,10 +75,10 @@ class DetectorParams(BaseModel):
 
     @validator("run_number", always=True)
     def _set_run_number(cls, run_number: int, values: dict[str, Any]):
-        if values["run_number"] == 0:
+        if run_number is None:
             return get_run_number(values["directory"])
         else:
-            return values["run_number"]
+            return run_number
 
     # The following are optional from GDA as populated internally
     # Where the VDS start index should be in the Nexus file

--- a/src/dodal/devices/smargon.py
+++ b/src/dodal/devices/smargon.py
@@ -64,7 +64,7 @@ class Smargon(MotorBundle):
 
     stub_offsets = Cpt(StubOffsets, "")
 
-    disabled: EpicsSignal = Cpt(EpicsSignal, "DISABLED")
+    disabled = Cpt(EpicsSignal, "DISABLED")
 
     def get_xyz_limits(self) -> XYZLimitBundle:
         """Get the limits for the x, y and z axes.

--- a/src/dodal/devices/smargon.py
+++ b/src/dodal/devices/smargon.py
@@ -64,7 +64,7 @@ class Smargon(MotorBundle):
 
     stub_offsets = Cpt(StubOffsets, "")
 
-    disabled = Cpt(EpicsSignal, "DISABLED")
+    disabled: EpicsSignal = Cpt(EpicsSignal, "DISABLED")
 
     def get_xyz_limits(self) -> XYZLimitBundle:
         """Get the limits for the x, y and z axes.

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -1,5 +1,7 @@
 import importlib
 import inspect
+import os
+import re
 import socket
 import string
 from dataclasses import dataclass
@@ -13,6 +15,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     Mapping,
     Optional,
     Type,
@@ -38,6 +41,8 @@ from bluesky.protocols import (
 )
 from ophyd.device import Device as OphydV1Device
 from ophyd_async.core import Device as OphydV2Device
+
+import dodal.log
 
 try:
     from typing import TypeAlias
@@ -243,3 +248,33 @@ def get_beamline_based_on_environment_variable() -> ModuleType:
             f"Failed to import beamline-specific dodal module 'dodal.beamlines.{beamline}'."
             " Ensure your BEAMLINE environment variable is set to a known instrument."
         ) from e
+
+
+def _find_next_run_number_from_files(file_names: List[str]) -> int:
+    valid_numbers = []
+
+    for file_name in file_names:
+        file_name = file_name.strip(".nxs")
+        # Give warning if nexus file name isn't in expcted format, xxx_number.nxs
+        match = re.search(r"_\d+$", file_name)
+        if match is not None:
+            valid_numbers.append(int(re.findall(r"\d+", file_name)[-1]))
+        else:
+            dodal.log.LOGGER.warning(
+                f"Identified nexus file {file_name} with unexpected format"
+            )
+    if len(valid_numbers) != 0:
+        return max(valid_numbers) + 1
+    else:
+        return 1
+
+
+def get_run_number(directory: str) -> int:
+    """Looks at the numbers coming from all nexus files with the format "xxx_(any number}.nxs", and returns the highest number + 1,
+    or 1 if there are no numbers found"""
+    nexus_file_names = [file for file in os.listdir(directory) if file.endswith(".nxs")]
+
+    if len(nexus_file_names) == 0:
+        return 1
+    else:
+        return _find_next_run_number_from_files(nexus_file_names)

--- a/tests/devices/unit_tests/test_detector.py
+++ b/tests/devices/unit_tests/test_detector.py
@@ -52,3 +52,46 @@ def test_correct_det_dist_to_beam_converter_path_passed_in(mocked_parse_table):
     )
     params.json()
     assert params.beam_xy_converter.lookup_file == "a fake directory"
+
+
+@patch(
+    "src.dodal.devices.detector.DetectorDistanceToBeamXYConverter.parse_table",
+)
+def test_run_number_correct_when_not_specified(mocked_parse_table, tmpdir):
+    params = DetectorParams(
+        current_energy_ev=100,
+        exposure_time=1.0,
+        directory=str(tmpdir),
+        prefix="test",
+        detector_distance=1.0,
+        omega_start=0.0,
+        omega_increment=0.0,
+        num_images_per_trigger=1,
+        num_triggers=1,
+        use_roi_mode=False,
+        det_dist_to_beam_converter_path="a fake directory",
+        detector_size_constants="EIGER2_X_16M",
+    )
+    assert params.run_number == 1
+
+
+@patch(
+    "src.dodal.devices.detector.DetectorDistanceToBeamXYConverter.parse_table",
+)
+def test_run_number_correct_when_specified(mocked_parse_table, tmpdir):
+    params = DetectorParams(
+        current_energy_ev=100,
+        exposure_time=1.0,
+        directory=str(tmpdir),
+        run_number=6,
+        prefix="test",
+        detector_distance=1.0,
+        omega_start=0.0,
+        omega_increment=0.0,
+        num_images_per_trigger=1,
+        num_triggers=1,
+        use_roi_mode=False,
+        det_dist_to_beam_converter_path="a fake directory",
+        detector_size_constants="EIGER2_X_16M",
+    )
+    assert params.run_number == 6

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,9 +7,11 @@ from ophyd import EpicsMotor
 
 from dodal.beamlines import i03, i23
 from dodal.utils import (
+    _find_next_run_number_from_files,
     collect_factories,
     get_beamline_based_on_environment_variable,
     get_hostname,
+    get_run_number,
     make_all_devices,
 )
 
@@ -85,3 +87,54 @@ def test_invalid_beamline_variable_causes_get_device_module_to_raise(bl):
 def test_valid_beamline_variable_causes_get_device_module_to_return_module(bl, module):
     with patch.dict(os.environ, {"BEAMLINE": bl}):
         assert get_beamline_based_on_environment_variable() == module
+
+
+def test_find_next_run_number_from_files_gets_correct_number():
+    assert (
+        _find_next_run_number_from_files(
+            ["V31-1-x0093_1.nxs", "V31-1-x0093_2.nxs", "V31-1-x0093_265.nxs"]
+        )
+        == 266
+    )
+
+
+@patch("dodal.log.LOGGER.warning")
+def test_find_next_run_number_gives_warning_with_wrong_nexus_names(
+    mock_logger: MagicMock,
+):
+    assert (
+        _find_next_run_number_from_files(
+            ["V31-1-x0093.nxs", "eggs", "V31-1-x0093_1.nxs"]
+        )
+        == 2
+    )
+    assert mock_logger.call_count == 2
+
+
+@patch("os.listdir")
+@patch("dodal.utils._find_next_run_number_from_files")
+def test_get_run_number_finds_all_nexus_files(
+    mock_find_next_run_number: MagicMock, mock_list_dir: MagicMock
+):
+    files = ["blah.nxs", "foo", "bar.nxs", "ham.h5"]
+    mock_list_dir.return_value = files
+    get_run_number("dir")
+    mock_find_next_run_number.assert_called_once_with(["blah.nxs", "bar.nxs"])
+
+
+@patch("os.listdir")
+def test_if_nexus_files_are_unnumbered_then_return_one(
+    mock_list_dir: MagicMock,
+):
+    assert _find_next_run_number_from_files(["file.nxs", "foo.nxs", "ham.nxs"]) == 1
+
+
+@patch("os.listdir")
+@patch("dodal.utils._find_next_run_number_from_files")
+def test_run_number_1_given_on_first_nexus_file(
+    mock_find_next_run_number: MagicMock, mock_list_dir: MagicMock
+):
+    files = ["blah", "foo", "bar"]
+    mock_list_dir.return_value = files
+    assert get_run_number("dir") == 1
+    mock_find_next_run_number.assert_not_called()


### PR DESCRIPTION
Partially fixes https://github.com/DiamondLightSource/hyperion/issues/1008

I have added a function in dodal's utilities to look at all nexus files in a specified directory to find the next run number. `DetectorParams` is changed so that it uses this function for `run_number` by default, but so that it can still be overridden if explicitly provided.

### Instructions to reviewer on how to test:
1. Check that the above solution is sensible and implemented correctly
2. Check new tests

### Checks for reviewer
- [x] Would the PR title make sense to a scientist on a set of release notes
- [x] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)