### PR TITLE
Hyperion 1036 Set energy: integrate set energy functions into hyperion plans

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -95,21 +95,6 @@ def vfm_mirror_voltages(
     )
 
 
-@skip_device(lambda: BL == "s03")
-def hfm(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> FocusingMirror:
-    return device_instantiation(
-        device_factory=FocusingMirror,
-        name="hfm",
-        prefix="-OP-HFM-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        bragg_to_lat_lut_path=DAQ_CONFIGURATION_PATH
-        + "/lookup/BeamLineEnergy_DCM_HFM_y_converter.txt",
-    )
-
-
 def aperture_scatterguard(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -20,6 +20,7 @@ from dodal.devices.sample_shutter import SampleShutter
 from dodal.devices.smargon import Smargon
 from dodal.devices.synchrotron import Synchrotron
 from dodal.devices.undulator import Undulator
+from dodal.devices.undulator_dcm import UndulatorDCM
 from dodal.devices.xbpm_feedback import XBPMFeedback
 from dodal.devices.xspress3_mini.xspress3_mini import Xspress3Mini
 from dodal.devices.zebra import Zebra
@@ -295,6 +296,24 @@ def undulator(
         wait_for_connection,
         fake_with_ophyd_sim,
         bl_prefix=False,
+    )
+
+
+@skip_device(lambda: BL == "s03")
+def undulator_dcm(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> UndulatorDCM:
+    """Get the i03 undulator DCM device, instantiate it if it hasn't already been.
+    If this is called when already instantiated in i03, it will return the existing object.
+    """
+    return device_instantiation(
+        UndulatorDCM,
+        name="undulator_dcm",
+        prefix="",
+        wait=wait_for_connection,
+        fake=fake_with_ophyd_sim,
+        undulator=undulator(wait_for_connection, fake_with_ophyd_sim),
+        dcm=dcm(wait_for_connection, fake_with_ophyd_sim),
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -39,7 +39,6 @@ set_log_beamline(BL)
 set_utils_beamline(BL)
 
 
-@skip_device(lambda: BL == "s03")
 def dcm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> DCM:
     """Get the i03 DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -284,7 +283,6 @@ def undulator(
     )
 
 
-@skip_device(lambda: BL == "s03")
 def undulator_dcm(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> UndulatorDCM:

--- a/src/dodal/devices/DCM.py
+++ b/src/dodal/devices/DCM.py
@@ -1,6 +1,8 @@
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsMotor, EpicsSignalRO, Kind
 
+from dodal.beamlines.beamline_parameters import get_beamline_parameters
+
 
 class DCM(Device):
     def __init__(self, *args, daq_configuration_path: str, **kwargs):
@@ -11,6 +13,9 @@ class DCM(Device):
         self.dcm_roll_converter_lookup_table_path = (
             daq_configuration_path + "/lookup/BeamLineEnergy_DCM_Roll_converter.txt"
         )
+        # I03 configures the DCM Perp as a side effect of applying this fixed value to the DCM Offset after an energy change
+        # Nb this parameter is misleadingly named to confuse you
+        self.fixed_offset_mm = get_beamline_parameters()["DCM_Perp_Offset_FIXED"]
 
     """
     A double crystal monochromator (DCM), used to select the energy of the beam.
@@ -37,9 +42,3 @@ class DCM(Device):
     backplate_temp = Cpt(EpicsSignalRO, "-MO-DCM-01:TEMP5")
     perp_temp = Cpt(EpicsSignalRO, "-MO-DCM-01:TEMP6")
     perp_sub_assembly_temp = Cpt(EpicsSignalRO, "-MO-DCM-01:TEMP7")
-
-
-def fixed_offset_from_beamline_params(gda_beamline_parameters):
-    """I03 configures the DCM Perp as a side effect of applying this fixed value to the DCM Offset after an energy change"""
-    # Nb this parameter is misleadingly named to confuse you
-    return gda_beamline_parameters["DCM_Perp_Offset_FIXED"]

--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -11,16 +11,19 @@ VOLTAGE_POLLING_DELAY_S = 0.5
 # The default timeout is 60 seconds as voltage slew rate is typically ~2V/s
 DEFAULT_SETTLE_TIME_S = 60
 
+
 class MirrorStripe(Enum):
     RHODIUM = "Rhodium"
     BARE = "Bare"
     PLATINUM = "Platinum"
+
 
 class MirrorVoltageDemand(IntEnum):
     N_A = 0
     OK = 1
     FAIL = 2
     SLEW = 3
+
 
 class MirrorVoltageDevice(Device):
     """Abstract the bimorph mirror voltage PVs into a single device that can be set asynchronously and returns when

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -78,6 +78,6 @@ class UndulatorDCM(Device):
     energy_kev = Component(EnergySignal)
 
     def __init__(self, undulator: Undulator, dcm: DCM, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.undulator = undulator
         self.dcm = dcm

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -13,7 +13,6 @@ STATUS_TIMEOUT_S = 10
 # Enable to allow testing when the beamline is down, do not change in production!
 TEST_MODE = False
 
-
 class AccessError(Exception):
     pass
 
@@ -23,10 +22,10 @@ def _get_energy_distance_table(lookup_table_path: str) -> ndarray:
 
 
 def _get_closest_gap_for_energy(
-    dcm_energy: float, energy_to_distance_table: ndarray
+    dcm_energy_ev: float, energy_to_distance_table: ndarray
 ) -> float:
     table = energy_to_distance_table.transpose()
-    idx = argmin(np.abs(table[0] - dcm_energy))
+    idx = argmin(np.abs(table[0] - dcm_energy_ev))
     return table[1][idx]
 
 
@@ -39,6 +38,7 @@ class UndulatorDCM(Device):
         parent: "UndulatorDCM"
 
         def set(self, value, *, timeout=None, settle_time=None, **kwargs) -> Status:
+            energy_kev = value
             access_level = self.parent.undulator.gap_access.get(as_string=True)
             if access_level == UndulatorGapAccess.DISABLED.value and not TEST_MODE:
                 raise AccessError(
@@ -49,13 +49,13 @@ class UndulatorDCM(Device):
             energy_to_distance_table = _get_energy_distance_table(
                 self.parent.undulator.lookup_table_path
             )
-            LOGGER.info(f"Setting DCM energy to {value:.2f} kev")
+            LOGGER.info(f"Setting DCM energy to {energy_kev:.2f} kev")
 
-            status = self.parent.dcm.energy_in_kev.move(value, timeout=ENERGY_TIMEOUT_S)
+            status = self.parent.dcm.energy_in_kev.move(energy_kev, timeout=ENERGY_TIMEOUT_S)
 
             # Use the lookup table to get the undulator gap associated with this dcm energy
             gap_to_match_dcm_energy = _get_closest_gap_for_energy(
-                value, energy_to_distance_table
+                energy_kev * 1000, energy_to_distance_table
             )
 
             # Check if undulator gap is close enough to the value from the DCM
@@ -69,9 +69,10 @@ class UndulatorDCM(Device):
                     f"Undulator gap mismatch. {abs(gap_to_match_dcm_energy-current_gap):.3f}mm is outside tolerance.\
                     Moving gap to nominal value, {gap_to_match_dcm_energy:.3f}mm"
                 )
-                status &= self.parent.undulator.gap_motor.move(
-                    gap_to_match_dcm_energy, timeout=STATUS_TIMEOUT_S
-                )
+                if not TEST_MODE:
+                    status &= self.parent.undulator.gap_motor.move(
+                        gap_to_match_dcm_energy, timeout=STATUS_TIMEOUT_S
+                    )
 
             return status
 

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -13,6 +13,7 @@ STATUS_TIMEOUT_S = 10
 # Enable to allow testing when the beamline is down, do not change in production!
 TEST_MODE = False
 
+
 class AccessError(Exception):
     pass
 
@@ -51,7 +52,9 @@ class UndulatorDCM(Device):
             )
             LOGGER.info(f"Setting DCM energy to {energy_kev:.2f} kev")
 
-            status = self.parent.dcm.energy_in_kev.move(energy_kev, timeout=ENERGY_TIMEOUT_S)
+            status = self.parent.dcm.energy_in_kev.move(
+                energy_kev, timeout=ENERGY_TIMEOUT_S
+            )
 
             # Use the lookup table to get the undulator gap associated with this dcm energy
             gap_to_match_dcm_energy = _get_closest_gap_for_energy(

--- a/src/dodal/parameters/experiment_parameter_base.py
+++ b/src/dodal/parameters/experiment_parameter_base.py
@@ -3,5 +3,5 @@ from abc import ABC, abstractmethod
 
 class AbstractExperimentParameterBase(ABC):
     @abstractmethod
-    def get_num_images(self):
+    def get_num_images(self) -> int:
         pass

--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -19,7 +19,6 @@ def test_device_creation():
     beamline_utils.clear_devices()
     devices = make_all_devices(i03, fake_with_ophyd_sim=True)
     for device_name in devices.keys():
-        print(device_name)
         assert device_name in beamline_utils.ACTIVE_DEVICES
     assert len(beamline_utils.ACTIVE_DEVICES) == len(devices)
 

--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -15,7 +15,7 @@ def test_list():
     ]
 
 
-def test_device_creation():
+def test_device_creation(RE):
     beamline_utils.clear_devices()
     devices = make_all_devices(i03, fake_with_ophyd_sim=True)
     for device_name in devices.keys():
@@ -23,7 +23,7 @@ def test_device_creation():
     assert len(beamline_utils.ACTIVE_DEVICES) == len(devices)
 
 
-def test_devices_are_identical():
+def test_devices_are_identical(RE):
     beamline_utils.clear_devices()
     devices_a = make_all_devices(i03, fake_with_ophyd_sim=True)
     devices_b = make_all_devices(i03, fake_with_ophyd_sim=True)

--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -19,6 +19,7 @@ def test_device_creation():
     beamline_utils.clear_devices()
     devices = make_all_devices(i03, fake_with_ophyd_sim=True)
     for device_name in devices.keys():
+        print(device_name)
         assert device_name in beamline_utils.ACTIVE_DEVICES
     assert len(beamline_utils.ACTIVE_DEVICES) == len(devices)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,13 @@ import pytest
 from bluesky.run_engine import RunEngine
 from ophyd.sim import make_fake_device
 
-from dodal.beamlines import i03
+from dodal.beamlines import beamline_utils, i03
 from dodal.devices.focusing_mirror import VFMMirrorVoltages
 from dodal.log import LOGGER, GELFTCPHandler, set_up_logging_handlers
 
 
 def pytest_runtest_setup(item):
-    if "dodal.beamlines.beamline_utils" in sys.modules:
-        sys.modules["dodal.beamlines.beamline_utils"].clear_devices()
-        assert sys.modules["dodal.beamlines.beamline_utils"].ACTIVE_DEVICES == {}
+    beamline_utils.clear_devices()
     if LOGGER.handlers == []:
         mock_graylog_handler = MagicMock(spec=GELFTCPHandler)
         mock_graylog_handler.return_value.level = logging.DEBUG

--- a/tests/devices/unit_tests/test_focusing_mirror.py
+++ b/tests/devices/unit_tests/test_focusing_mirror.py
@@ -6,7 +6,7 @@ from ophyd.sim import NullStatus
 from ophyd.status import Status, StatusBase
 
 from dodal.devices.focusing_mirror import (
-    DEMAND_ACCEPTED_OK,
+    MirrorVoltageDemand,
     MirrorVoltageDevice,
     VFMMirrorVoltages,
 )
@@ -14,18 +14,22 @@ from dodal.devices.focusing_mirror import (
 
 @pytest.fixture
 def vfm_mirror_voltages_not_ok(vfm_mirror_voltages) -> VFMMirrorVoltages:
-    vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(0)
+    vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(
+        MirrorVoltageDemand.FAIL
+    )
     return vfm_mirror_voltages
 
 
 @pytest.fixture
 def vfm_mirror_voltages_with_set(vfm_mirror_voltages) -> VFMMirrorVoltages:
     def not_ok_then_ok(_):
-        vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(0)
+        vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(
+            MirrorVoltageDemand.SLEW
+        )
         Timer(
             0.1,
             lambda: vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(
-                1
+                MirrorVoltageDemand.OK
             ),
         ).start()
         return DEFAULT
@@ -33,20 +37,26 @@ def vfm_mirror_voltages_with_set(vfm_mirror_voltages) -> VFMMirrorVoltages:
     vfm_mirror_voltages._channel14_voltage_device._setpoint_v.set = MagicMock(
         side_effect=not_ok_then_ok
     )
-    vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(1)
+    vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(
+        MirrorVoltageDemand.OK
+    )
     return vfm_mirror_voltages
 
 
 @pytest.fixture
 def vfm_mirror_voltages_with_set_timing_out(vfm_mirror_voltages) -> VFMMirrorVoltages:
     def not_ok(_):
-        vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(0)
+        vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(
+            MirrorVoltageDemand.SLEW
+        )
         return DEFAULT
 
     vfm_mirror_voltages._channel14_voltage_device._setpoint_v.set = MagicMock(
         side_effect=not_ok
     )
-    vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(1)
+    vfm_mirror_voltages._channel14_voltage_device._demand_accepted.sim_put(
+        MirrorVoltageDemand.OK
+    )
     return vfm_mirror_voltages
 
 
@@ -57,7 +67,7 @@ def test_mirror_set_voltage_sets_and_waits_happy_path(
         NullStatus()
     )
     vfm_mirror_voltages_with_set._channel14_voltage_device._demand_accepted.sim_put(
-        DEMAND_ACCEPTED_OK
+        MirrorVoltageDemand.OK
     )
 
     status: StatusBase = vfm_mirror_voltages_with_set.voltage_channels[0].set(100)

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -66,11 +66,11 @@ def test_if_gap_is_wrong_then_logger_info_is_called_and_gap_is_set_correctly(
     fake_undulator_dcm.undulator.gap_motor.move = MagicMock()
     fake_undulator_dcm.dcm.energy_in_kev.move = MagicMock()
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
-    fake_undulator_dcm.dcm.energy_in_kev.user_readback.sim_put(5700)  # type: ignore
+    fake_undulator_dcm.dcm.energy_in_kev.user_readback.sim_put(5.7)  # type: ignore
 
-    fake_undulator_dcm.energy_kev.set(6900)
+    fake_undulator_dcm.energy_kev.set(6.9)
 
-    fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6900, timeout=30)
+    fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6.9, timeout=30)
     fake_undulator_dcm.undulator.gap_motor.move.assert_called_once_with(
         6.045, timeout=10
     )
@@ -88,14 +88,12 @@ def test_when_gap_access_is_not_checked_if_test_mode_enabled(
     fake_undulator_dcm.undulator.gap_motor.move = MagicMock()
     fake_undulator_dcm.dcm.energy_in_kev.move = MagicMock()
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
-    fake_undulator_dcm.dcm.energy_in_kev.user_readback.sim_put(5700)  # type: ignore
+    fake_undulator_dcm.dcm.energy_in_kev.user_readback.sim_put(5.7)  # type: ignore
 
-    fake_undulator_dcm.energy_kev.set(6900)
+    fake_undulator_dcm.energy_kev.set(6.9)
 
-    fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6900, timeout=30)
-    fake_undulator_dcm.undulator.gap_motor.move.assert_called_once_with(
-        6.045, timeout=10
-    )
+    fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6.9, timeout=30)
+    fake_undulator_dcm.undulator.gap_motor.move.assert_not_called()
     mock_logger.info.assert_called()
 
 
@@ -108,7 +106,9 @@ def test_if_gap_is_already_correct_then_dont_move_gap(
     fake_undulator_dcm.dcm.energy_in_kev.move = MagicMock()
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
     fake_undulator_dcm.undulator.current_gap.sim_put(5.4605)  # type: ignore
-    fake_undulator_dcm.energy_kev.set(5800).wait(timeout=0.01)
+
+    fake_undulator_dcm.energy_kev.set(5.8).wait(timeout=0.01)
+
     fake_undulator_dcm.undulator.gap_motor.move.assert_not_called()
     mock_logger.info.assert_called_once()
 
@@ -128,7 +128,9 @@ def test_energy_set_only_complete_when_all_statuses_are_finished(
     _get_energy_distance_table = MagicMock()
     _get_closest_gap_for_energy = MagicMock(return_value=10)
     fake_undulator_dcm.undulator.current_gap.sim_put(5)  # type: ignore
-    status: Status = fake_undulator_dcm.energy_kev.set(5800)
+
+    status: Status = fake_undulator_dcm.energy_kev.set(5.8)
+
     assert not status.success
     dcm_energy_move_status.set_finished()
     assert not status.success

--- a/tests/unit_tests/test_log.py
+++ b/tests/unit_tests/test_log.py
@@ -178,7 +178,9 @@ def test_various_messages_to_graylog_get_beamline_filter(
 
     from dodal.beamlines import i03
 
-    _aperture_scatterguard = i03.aperture_scatterguard(fake_with_ophyd_sim=True)
+    _aperture_scatterguard = i03.aperture_scatterguard(
+        fake_with_ophyd_sim=True, wait_for_connection=True
+    )
     assert mock_GELFTCPHandler.emit.call_args.args[0].name == "ophyd"
     assert mock_GELFTCPHandler.emit.call_args.args[0].beamline == "dev"
 


### PR DESCRIPTION
Fixes DiamondLightSource/hyperion#1036

Refactors the DCM fixed offset so that now dodal populates an attribute on the device instead of making hyperion parse the beamline parameters.

Adds undulatorDCM as part of beamline I03 devices as it was missing.

### Instructions to reviewer on how to test:
- [x] Tests pass

### Checks for reviewer
- [x] Would the PR title make sense to a scientist on a set of release notes
- [x] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)