### PR TITLE
(#282) Extend DCM energy timeout from 10s to 30s

### DIFF
--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -7,7 +7,8 @@ from dodal.devices.DCM import DCM
 from dodal.devices.undulator import Undulator, UndulatorGapAccess
 from dodal.log import LOGGER
 
-STATUS_TIMEOUT = 10
+ENERGY_TIMEOUT_S = 30
+STATUS_TIMEOUT_S = 10
 
 
 class AccessError(Exception):
@@ -47,7 +48,7 @@ class UndulatorDCM(Device):
             )
             LOGGER.info(f"Setting DCM energy to {value:.2f} kev")
 
-            status = self.parent.dcm.energy_in_kev.move(value, timeout=STATUS_TIMEOUT)
+            status = self.parent.dcm.energy_in_kev.move(value, timeout=ENERGY_TIMEOUT_S)
 
             # Use the lookup table to get the undulator gap associated with this dcm energy
             gap_to_match_dcm_energy = _get_closest_gap_for_energy(
@@ -66,7 +67,7 @@ class UndulatorDCM(Device):
                     Moving gap to nominal value, {gap_to_match_dcm_energy:.3f}mm"
                 )
                 status &= self.parent.undulator.gap_motor.move(
-                    gap_to_match_dcm_energy, timeout=STATUS_TIMEOUT
+                    gap_to_match_dcm_energy, timeout=STATUS_TIMEOUT_S
                 )
 
             return status

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -68,7 +68,7 @@ def test_if_gap_is_wrong_then_logger_info_is_called_and_gap_is_set_correctly(
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
     fake_undulator_dcm.dcm.energy_in_kev.user_readback.sim_put(5700)  # type: ignore
     fake_undulator_dcm.energy_kev.set(6900)
-    fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6900, timeout=10)
+    fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6900, timeout=30)
     fake_undulator_dcm.undulator.gap_motor.move.assert_called_once_with(
         6.045, timeout=10
     )


### PR DESCRIPTION
Fixes #282 

### Instructions to reviewer on how to test:
1. Tests pass and changes are sensible.
2. Energy can now vary through the whole range without timeout

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)