### PR TITLE
Fix for #283 undulator gap access check still passes even when undulator gap is disabled

### DIFF
--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -10,6 +10,9 @@ from dodal.log import LOGGER
 ENERGY_TIMEOUT_S = 30
 STATUS_TIMEOUT_S = 10
 
+# Enable to allow testing when the beamline is down, do not change in production!
+TEST_MODE = False
+
 
 class AccessError(Exception):
     pass
@@ -37,7 +40,7 @@ class UndulatorDCM(Device):
 
         def set(self, value, *, timeout=None, settle_time=None, **kwargs) -> Status:
             access_level = self.parent.undulator.gap_access.get()
-            if access_level == UndulatorGapAccess.DISABLED.value:
+            if access_level == UndulatorGapAccess.DISABLED.value and not TEST_MODE:
                 raise AccessError(
                     "Undulator gap access is disabled. Contact Control Room"
                 )

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -39,7 +39,7 @@ class UndulatorDCM(Device):
         parent: "UndulatorDCM"
 
         def set(self, value, *, timeout=None, settle_time=None, **kwargs) -> Status:
-            access_level = self.parent.undulator.gap_access.get()
+            access_level = self.parent.undulator.gap_access.get(as_string=True)
             if access_level == UndulatorGapAccess.DISABLED.value and not TEST_MODE:
                 raise AccessError(
                     "Undulator gap access is disabled. Contact Control Room"

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -67,7 +67,31 @@ def test_if_gap_is_wrong_then_logger_info_is_called_and_gap_is_set_correctly(
     fake_undulator_dcm.dcm.energy_in_kev.move = MagicMock()
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
     fake_undulator_dcm.dcm.energy_in_kev.user_readback.sim_put(5700)  # type: ignore
+
     fake_undulator_dcm.energy_kev.set(6900)
+
+    fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6900, timeout=30)
+    fake_undulator_dcm.undulator.gap_motor.move.assert_called_once_with(
+        6.045, timeout=10
+    )
+    mock_logger.info.assert_called()
+
+
+@patch("dodal.devices.undulator_dcm.loadtxt")
+@patch("dodal.devices.undulator_dcm.LOGGER")
+@patch("dodal.devices.undulator_dcm.TEST_MODE", True)
+def test_when_gap_access_is_not_checked_if_test_mode_enabled(
+    mock_logger: MagicMock, mock_load: MagicMock, fake_undulator_dcm: UndulatorDCM
+):
+    fake_undulator_dcm.undulator.gap_access.sim_put(UndulatorGapAccess.DISABLED.value)  # type: ignore
+    fake_undulator_dcm.undulator.current_gap.sim_put(5.3)  # type: ignore
+    fake_undulator_dcm.undulator.gap_motor.move = MagicMock()
+    fake_undulator_dcm.dcm.energy_in_kev.move = MagicMock()
+    mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
+    fake_undulator_dcm.dcm.energy_in_kev.user_readback.sim_put(5700)  # type: ignore
+
+    fake_undulator_dcm.energy_kev.set(6900)
+
     fake_undulator_dcm.dcm.energy_in_kev.move.assert_called_once_with(6900, timeout=30)
     fake_undulator_dcm.undulator.gap_motor.move.assert_called_once_with(
         6.045, timeout=10


### PR DESCRIPTION
Fixes #283 

### Instructions to reviewer on how to test:
1. Energy change should be correctly rejected when undulator gap access is disabled
2. This can be overridden by setting TEST_MODE=True in the undulator_dcm module

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)