### PR TITLE
Fix type of detector size constants

### DIFF
--- a/src/dodal/devices/det_dim_constants.py
+++ b/src/dodal/devices/det_dim_constants.py
@@ -1,12 +1,14 @@
-from typing import Dict, Union
+from typing import Dict, Generic, TypeVar, Union
 
 from pydantic.dataclasses import dataclass
 
+T = TypeVar("T", bound=Union[float, int])
+
 
 @dataclass
-class DetectorSize:
-    width: Union[float, int]
-    height: Union[float, int]
+class DetectorSize(Generic[T]):
+    width: T
+    height: T
 
 
 ALL_DETECTORS: Dict[str, "DetectorSizeConstants"] = {}
@@ -15,10 +17,10 @@ ALL_DETECTORS: Dict[str, "DetectorSizeConstants"] = {}
 @dataclass
 class DetectorSizeConstants:
     det_type_string: str
-    det_dimension: DetectorSize
-    det_size_pixels: DetectorSize
-    roi_dimension: DetectorSize
-    roi_size_pixels: DetectorSize
+    det_dimension: DetectorSize[float]
+    det_size_pixels: DetectorSize[int]
+    roi_dimension: DetectorSize[float]
+    roi_size_pixels: DetectorSize[int]
 
     def __post_init__(self):
         ALL_DETECTORS[self.det_type_string] = self


### PR DESCRIPTION
Detector dimensions are measured in floats and pixel size in integers, this actually enforces this rather than saying both could be floats or ints

### Instructions to reviewer on how to test:
1. Confirm this fixes the typing error on `get_data_shape` in `GridscanInternalParameters` in Hyperion

### Checks for reviewer
- [x] Would the PR title make sense to a scientist on a set of release notes
- [x] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)