### PR TITLE
Remove Tetramm exception when num != 0 is passed into it

### DIFF
--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -124,11 +124,13 @@ class TetrammController(DetectorControl):
     async def arm(
         self,
         trigger: DetectorTrigger = DetectorTrigger.internal,
-        num: int = 0,
+        num: int,
         exposure: Optional[float] = None,
     ) -> AsyncStatus:
-        if num != 0:
-            raise Exception("Tetramm has no concept of setting a number of exposures.")
+        """Arms the tetramm.
+        
+        Note that num is meaningless in this context, and is ignored.
+        """
         if exposure is None:
             raise ValueError("Exposure time is required")
         if trigger not in {DetectorTrigger.edge_trigger, DetectorTrigger.constant_gate}:


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd-async/issues/106

### Instructions to reviewer on how to test:
The easiest way to test this is on a Tuesday beamline test. Please speak to @Tom-Willemsen about the process for this.
An actual test should be written for this. But also, this entire branch needs to be reformatted to go into main anyways. 

### Checks for reviewer
- [x] Would the PR title make sense to a scientist on a set of release notes
- [x] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards) - NO NEW DEVICE ADDED.