### PR TITLE
325 close zocalo connections

### DIFF
--- a/tests/beamlines/unit_tests/test_i24.py
+++ b/tests/beamlines/unit_tests/test_i24.py
@@ -9,6 +9,8 @@ with patch.dict("os.environ", {"BEAMLINE": "i24"}, clear=True):
 
 
 def test_device_creation():
+    beamline_utils.BL = "i24"
+    beamline_utils.clear_devices()
     devices = make_all_devices(i24, fake_with_ophyd_sim=True)
     assert len(devices) > 0
     for device_name in devices.keys():


### PR DESCRIPTION
Fixes #325
Holds on to the Zocalo transport object created during stage and disconnects from it during unstage

### Instructions to reviewer on how to test:
1. See changes make sense and tests aren't broken
2. Confirm with analysis that issues seen the week of 06/02 did not repeat the weekend of 10-11/02
3. Confirm that now we are really not receiving zocalo results with hyperion turned off

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)