### PR TITLE
Use ophyd-async DirectoryProvider

### DIFF
--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -102,3 +102,23 @@ def test_wait_for_v2_device_connection_passes_through_timeout(
     beamline_utils._wait_for_connection(device, **kwargs)
 
     call_in_bluesky_el.assert_called_once_with(ANY, timeout=expected_timeout)
+
+
+def test_default_directory_provider_is_singleton():
+    provider1 = beamline_utils.get_directory_provider()
+    provider2 = beamline_utils.get_directory_provider()
+    assert provider1 is provider2
+
+
+def test_set_directory_provider_is_singleton():
+    beamline_utils.set_directory_provider(lambda: "")
+    provider1 = beamline_utils.get_directory_provider()
+    provider2 = beamline_utils.get_directory_provider()
+    assert provider1 is provider2
+
+
+def test_set_overrides_singleton():
+    provider1 = beamline_utils.get_directory_provider()
+    beamline_utils.set_directory_provider(lambda: "")
+    provider2 = beamline_utils.get_directory_provider()
+    assert provider1 is not provider2


### PR DESCRIPTION
Exposes a global DirectoryProvider for ophyd-async devices to make use of, with a setter for services making use of dodal (e.g. BlueAPI) to choose their own implementation. Solves #305 
Extracted from https://github.com/DiamondLightSource/dodal/tree/directory_provider to allow i22 changes to be isolated and 

### Instructions to reviewer on how to test:
1. Instantiate an Ophyd-async device which requires a DirectoryProvider in its init
2. Confirm that the device can write to the directory provided.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)