### PR TITLE
334 Clean up after tests

### DIFF
--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -27,22 +27,22 @@ def test_instantiate_function_makes_supplied_device():
     for device in device_types:
         beamline_utils.clear_devices()
         dev = beamline_utils.device_instantiation(
-            device, "device", "", False, False, None
+            device, device.__name__, "", False, True, None
         )
         assert isinstance(dev, device)
 
 
 def test_instantiating_different_device_with_same_name(reset_i03):
     dev1 = beamline_utils.device_instantiation(  # noqa
-        Zebra, "device", "", False, False, None
+        Zebra, "device", "", False, True, None
     )
     with pytest.raises(TypeError):
         dev2 = beamline_utils.device_instantiation(
-            Smargon, "device", "", False, False, None
+            Smargon, "device", "", False, True, None
         )
     beamline_utils.clear_device("device")
     dev2 = beamline_utils.device_instantiation(  # noqa
-        Smargon, "device", "", False, False, None
+        Smargon, "device", "", False, True, None
     )
     assert dev1.name == dev2.name
     assert type(dev1) != type(dev2)

--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -17,6 +17,7 @@ from ...conftest import mock_beamline_module_filepaths
 
 
 def setup_module():
+    beamline_utils.clear_devices()
     mock_beamline_module_filepaths("i03", i03)
 
 

--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -16,9 +16,7 @@ from dodal.utils import make_all_devices
 from ...conftest import mock_beamline_module_filepaths
 
 
-@pytest.fixture
-def reset_i03():
-    beamline_utils.clear_devices()
+def setup_module():
     mock_beamline_module_filepaths("i03", i03)
 
 
@@ -32,7 +30,8 @@ def test_instantiate_function_makes_supplied_device():
         assert isinstance(dev, device)
 
 
-def test_instantiating_different_device_with_same_name(reset_i03):
+def test_instantiating_different_device_with_same_name():
+    beamline_utils.clear_devices()
     dev1 = beamline_utils.device_instantiation(  # noqa
         Zebra, "device", "", False, True, None
     )
@@ -50,7 +49,8 @@ def test_instantiating_different_device_with_same_name(reset_i03):
     assert dev2 in beamline_utils.ACTIVE_DEVICES.values()
 
 
-def test_instantiate_function_fake_makes_fake(reset_i03):
+def test_instantiate_function_fake_makes_fake():
+    beamline_utils.clear_devices()
     fake_zeb: Zebra = beamline_utils.device_instantiation(
         i03.Zebra, "zebra", "", True, True, None
     )
@@ -58,8 +58,8 @@ def test_instantiate_function_fake_makes_fake(reset_i03):
     assert isinstance(fake_zeb.pc.arm_source, FakeEpicsSignal)
 
 
-def test_clear_devices(RE, reset_i03):
-    mock_beamline_module_filepaths("i03", i03)
+def test_clear_devices(RE):
+    beamline_utils.clear_devices()
     devices = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys())
     beamline_utils.clear_devices()

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -53,16 +53,20 @@ def test_when_zoom_level_changed_then_oav_rewired(zoom, expected_plugin, oav: OA
 def test_when_zoom_level_changed_then_status_waits_for_all_plugins_to_be_updated(
     oav: OAV,
 ):
-    mxsc_status = Status()
+    mxsc_status = Status(obj="msxc - test_when_zoom_level...")
     oav.mxsc.input_plugin.set = MagicMock(return_value=mxsc_status)
 
-    mjpg_status = Status()
+    mjpg_status = Status("mjpg - test_when_zoom_level...")
     oav.snapshot.input_plugin.set = MagicMock(return_value=mjpg_status)
 
     full_status = oav.zoom_controller.set("1.0x")
 
     assert mxsc_status in full_status
     assert mjpg_status in full_status
+
+    mxsc_status.set_finished()
+    mjpg_status.set_finished()
+    full_status.wait()
 
 
 def test_load_microns_per_pixel_entry_not_found(oav: OAV):

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -55,7 +55,7 @@ def create_new_params() -> DetectorParams:
 def fake_eiger(request):
     FakeEigerDetector: EigerDetector = make_fake_device(EigerDetector)
     fake_eiger: EigerDetector = FakeEigerDetector.with_params(
-        params=create_new_params(), name="test fake Eiger: " + request.node.name
+        params=create_new_params(), name=f"test fake Eiger: {request.node.name}"
     )
     return fake_eiger
 

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -52,12 +52,24 @@ def create_new_params() -> DetectorParams:
 
 
 @pytest.fixture
-def fake_eiger():
+def fake_eiger(request):
     FakeEigerDetector: EigerDetector = make_fake_device(EigerDetector)
     fake_eiger: EigerDetector = FakeEigerDetector.with_params(
-        params=create_new_params(), name="test fake Eiger"
+        params=create_new_params(), name="test fake Eiger: " + request.node.name
     )
     return fake_eiger
+
+
+def get_good_status():
+    status = Status()
+    status.set_finished()
+    return status
+
+
+def mock_eiger_odin_statuses(eiger):
+    eiger.set_odin_pvs = MagicMock(return_value=get_good_status())
+    eiger._wait_for_odin_status = MagicMock(return_value=get_good_status())
+    eiger._wait_fan_ready = MagicMock(return_value=get_good_status())
 
 
 def finished_status():
@@ -356,12 +368,14 @@ def test_given_stale_parameters_goes_high_before_callbacks_then_stale_parameters
 ):
     mock_await.return_value = Status(done=True)
     fake_eiger.odin.nodes.clear_odin_errors = MagicMock()
-    fake_eiger.odin.check_odin_initialised = MagicMock()
-    fake_eiger.odin.check_odin_initialised.return_value = (True, "")
+    fake_eiger.odin.check_odin_initialised = MagicMock(return_value=(True, ""))
     fake_eiger.odin.file_writer.file_path.put(True)
 
+    mock_eiger_odin_statuses(fake_eiger)
+
     def wait_on_staging():
-        fake_eiger.async_stage()
+        st = fake_eiger.async_stage()
+        st.wait()
 
     waiting_status = Status()
     fake_eiger.cam.num_images.set = MagicMock(return_value=waiting_status)
@@ -462,20 +476,10 @@ def test_when_stage_called_then_finish_arm_on_fan_ready(
     range(10),
 )
 def test_check_callback_error(fake_eiger: EigerDetector, iteration):
-    def get_good_status():
-        status = Status()
-        status.set_finished()
-        return status
-
     LOGGER.error = MagicMock()
 
     # These functions timeout without extra tweaking rather than give us the specific status error for the test
-    fake_eiger.set_odin_pvs = MagicMock()
-    fake_eiger.set_odin_pvs.return_value = get_good_status()
-    fake_eiger._wait_for_odin_status = MagicMock()
-    fake_eiger._wait_for_odin_status.return_value = get_good_status()
-    fake_eiger._wait_fan_ready = MagicMock()
-    fake_eiger._wait_fan_ready.return_value = get_good_status()
+    mock_eiger_odin_statuses(fake_eiger)
 
     unwrapped_funcs = [
         (

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -60,16 +60,10 @@ def fake_eiger(request):
     return fake_eiger
 
 
-def get_good_status():
-    status = Status()
-    status.set_finished()
-    return status
-
-
 def mock_eiger_odin_statuses(eiger):
-    eiger.set_odin_pvs = MagicMock(return_value=get_good_status())
-    eiger._wait_for_odin_status = MagicMock(return_value=get_good_status())
-    eiger._wait_fan_ready = MagicMock(return_value=get_good_status())
+    eiger.set_odin_pvs = MagicMock(return_value=finished_status())
+    eiger._wait_for_odin_status = MagicMock(return_value=finished_status())
+    eiger._wait_fan_ready = MagicMock(return_value=finished_status())
 
 
 def finished_status():

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -29,7 +29,7 @@ def discard_status(st: Union[Status, DeviceStatus]):
 def fast_grid_scan(request):
     FakeFastGridScan = make_fake_device(FastGridScan)
     fast_grid_scan: FastGridScan = FakeFastGridScan(
-        name="test fake FGS: " + request.node.name
+        name=f"test fake FGS: {request.node.name}"
     )
     fast_grid_scan.scan_invalid.pvname = ""
     yield fast_grid_scan

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -6,6 +6,7 @@ from bluesky.run_engine import RunEngine
 from mockito import mock, verify, when
 from mockito.matchers import ANY, ARGS, KWARGS
 from ophyd.sim import make_fake_device
+from ophyd.status import DeviceStatus, Status
 
 from dodal.devices.fast_grid_scan import (
     FastGridScan,
@@ -13,6 +14,13 @@ from dodal.devices.fast_grid_scan import (
     set_fast_grid_scan_params,
 )
 from dodal.devices.smargon import Smargon
+
+
+def discard_status(st: Status | DeviceStatus):
+    try:
+        st.wait(0.01)
+    except BaseException:
+        pass
 
 
 @pytest.fixture
@@ -68,13 +76,15 @@ def run_test_on_complete_watcher(
 
 
 def test_when_new_image_then_complete_watcher_notified(fast_grid_scan: FastGridScan):
-    run_test_on_complete_watcher(fast_grid_scan, 2, 1, 3 / 4)
+    status = run_test_on_complete_watcher(fast_grid_scan, 2, 1, 3 / 4)
+    discard_status(status)
 
 
 def test_given_0_expected_images_then_complete_watcher_correct(
     fast_grid_scan: FastGridScan,
 ):
-    run_test_on_complete_watcher(fast_grid_scan, 0, 1, 0)
+    status = run_test_on_complete_watcher(fast_grid_scan, 0, 1, 0)
+    discard_status(status)
 
 
 @pytest.mark.parametrize(

--- a/tests/devices/unit_tests/test_panda_gridscan.py
+++ b/tests/devices/unit_tests/test_panda_gridscan.py
@@ -15,9 +15,9 @@ from dodal.devices.smargon import Smargon
 
 
 @pytest.fixture
-def fast_grid_scan():
+def fast_grid_scan(request):
     fast_grid_scan: PandAFastGridScan = instantiate_fake_device(
-        PandAFastGridScan, name="test fake FGS"
+        PandAFastGridScan, name=f"test fake FGS: {request.node.name}"
     )
     fast_grid_scan.scan_invalid.pvname = ""
 

--- a/tests/devices/unit_tests/test_xspress3mini.py
+++ b/tests/devices/unit_tests/test_xspress3mini.py
@@ -9,14 +9,8 @@ from ophyd.status import Status
 from dodal.devices.xspress3_mini.xspress3_mini import DetectorState, Xspress3Mini
 
 
-def get_good_status() -> Status:
-    status = Status()
-    status.set_finished()
-    return status
-
-
 def get_bad_status() -> Status:
-    status = Status()
+    status = Status("get_bad_status")
     status.set_exception(Exception)
     return status
 
@@ -51,8 +45,6 @@ def test_stage_in_busy_state(mock_await_value, fake_xspress3mini):
 
 
 def test_stage_fails_in_failed_acquire_state(fake_xspress3mini):
-    bad_status = Status()
-    bad_status.set_exception(Exception)
     RE = RunEngine()
     with pytest.raises(Exception):
         RE(bps.stage(fake_xspress3mini))


### PR DESCRIPTION
Fixes #334
- Cleans up after a bunch of statuses
- Adds more labels to devices and statuses to help identify tests which don't clean up

### Instructions to reviewer on how to test:
1. Look at changes
2. Run tests with random order on this branch and main a few times and convince yourself errors print after tests less often (there is at least one unlabeled `Status()` I didn't find). Some tests runs which might show errors more often:
  - `pytest --random-order-seed=739099 -m "not s03"`
  - `pytest --random-order-seed 766022 -m "not s03" --ignore tests/devices/unit_tests/test_detector.py`


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)