### PR TITLE
Fix tests around moving between beamlines

### DIFF
--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -16,7 +16,8 @@ from dodal.utils import make_all_devices
 from ...conftest import mock_beamline_module_filepaths
 
 
-def setup_module():
+@pytest.fixture(autouse=True)
+def setup():
     beamline_utils.clear_devices()
     mock_beamline_module_filepaths("i03", i03)
 
@@ -24,7 +25,6 @@ def setup_module():
 def test_instantiate_function_makes_supplied_device():
     device_types = [Zebra, ApertureScatterguard, Smargon]
     for device in device_types:
-        beamline_utils.clear_devices()
         dev = beamline_utils.device_instantiation(
             device, device.__name__, "", False, True, None
         )
@@ -32,7 +32,6 @@ def test_instantiate_function_makes_supplied_device():
 
 
 def test_instantiating_different_device_with_same_name():
-    beamline_utils.clear_devices()
     dev1 = beamline_utils.device_instantiation(  # noqa
         Zebra, "device", "", False, True, None
     )
@@ -51,7 +50,6 @@ def test_instantiating_different_device_with_same_name():
 
 
 def test_instantiate_function_fake_makes_fake():
-    beamline_utils.clear_devices()
     fake_zeb: Zebra = beamline_utils.device_instantiation(
         i03.Zebra, "zebra", "", True, True, None
     )
@@ -60,7 +58,6 @@ def test_instantiate_function_fake_makes_fake():
 
 
 def test_clear_devices(RE):
-    beamline_utils.clear_devices()
     devices = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys())
     beamline_utils.clear_devices()

--- a/tests/beamlines/unit_tests/test_device_instantiation.py
+++ b/tests/beamlines/unit_tests/test_device_instantiation.py
@@ -1,14 +1,9 @@
-import importlib
-import os
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 
 from dodal.beamlines import beamline_utils
 from dodal.utils import BLUESKY_PROTOCOLS, make_all_devices
-
-from ...conftest import mock_beamline_module_filepaths
 
 ALL_BEAMLINES = {"i03", "i04", "i04_1", "i23", "i24", "p38", "p45"}
 
@@ -17,45 +12,29 @@ def follows_bluesky_protocols(obj: Any) -> bool:
     return any((isinstance(obj, protocol) for protocol in BLUESKY_PROTOCOLS))
 
 
-def mock_bl(beamline):
-    bl_mod = importlib.import_module("dodal.beamlines." + beamline)
-    mock_beamline_module_filepaths(beamline, bl_mod)
-    return bl_mod
-
-
-@pytest.mark.parametrize("beamline", ALL_BEAMLINES)
-def test_device_creation(RE, beamline):
+@pytest.mark.parametrize(
+    "module_and_devices_for_beamline", ALL_BEAMLINES, indirect=True
+)
+def test_device_creation(RE, module_and_devices_for_beamline):
     """
     Ensures that for every beamline all device factories are using valid args
     and creating types that conform to Bluesky protocols.
     """
-    with patch.dict(os.environ, {"BEAMLINE": beamline}, clear=True):
-        bl_mod = mock_bl(beamline)
-        devices = make_all_devices(
-            bl_mod, include_skipped=True, fake_with_ophyd_sim=True
-        )
-        for device_name, device in devices.items():
-            assert device_name in beamline_utils.ACTIVE_DEVICES
-            assert follows_bluesky_protocols(device)
-        assert len(beamline_utils.ACTIVE_DEVICES) == len(devices)
-        beamline_utils.clear_devices()
-        del bl_mod
+    module, devices = module_and_devices_for_beamline
+    for device_name, device in devices.items():
+        assert device_name in beamline_utils.ACTIVE_DEVICES
+        assert follows_bluesky_protocols(device)
+    assert len(beamline_utils.ACTIVE_DEVICES) == len(devices)
 
 
-@pytest.mark.parametrize("beamline", ALL_BEAMLINES)
-def test_devices_are_identical(RE, beamline):
+@pytest.mark.parametrize(
+    "module_and_devices_for_beamline", ALL_BEAMLINES, indirect=True
+)
+def test_devices_are_identical(RE, module_and_devices_for_beamline):
     """
     Ensures that for every beamline all device functions prevent duplicate instantiation.
     """
-    with patch.dict(os.environ, {"BEAMLINE": beamline}, clear=True):
-        bl_mod = mock_bl(beamline)
-        devices_a = make_all_devices(
-            bl_mod, include_skipped=True, fake_with_ophyd_sim=True
-        )
-        devices_b = make_all_devices(
-            bl_mod, include_skipped=True, fake_with_ophyd_sim=True
-        )
-        for device_name in devices_a.keys():
-            assert devices_a[device_name] is devices_b[device_name]
-        beamline_utils.clear_devices()
-        del bl_mod
+    bl_mod, devices_a = module_and_devices_for_beamline
+    devices_b = make_all_devices(bl_mod, include_skipped=True, fake_with_ophyd_sim=True)
+    for device_name in devices_a.keys():
+        assert devices_a[device_name] is devices_b[device_name]

--- a/tests/beamlines/unit_tests/test_i24.py
+++ b/tests/beamlines/unit_tests/test_i24.py
@@ -1,30 +1,11 @@
-import os
-from unittest.mock import patch
+import pytest
 
 from dodal.devices.i24.i24_vgonio import VGonio
 
-with patch.dict(os.environ, {"BEAMLINE": "i24"}, clear=True):
-    from dodal.beamlines import beamline_utils, i24
-    from dodal.utils import make_all_devices
 
-
-def setup_module():
-    beamline_utils.set_beamline("i24")
-
-
-def test_device_creation():
-    i24.BL = "i24"
-    devices = make_all_devices(i24, fake_with_ophyd_sim=True)
-    assert len(devices) > 0
-    for device_name in devices.keys():
-        assert device_name in beamline_utils.ACTIVE_DEVICES
-    assert len(beamline_utils.ACTIVE_DEVICES) == len(devices)
-
-    vgonio: VGonio = beamline_utils.ACTIVE_DEVICES["vgonio"]  # type: ignore
+@pytest.mark.parametrize("module_and_devices_for_beamline", ["i24"], indirect=True)
+def test_device_creation(module_and_devices_for_beamline):
+    _, devices = module_and_devices_for_beamline
+    vgonio: VGonio = devices["vgonio"]  # type: ignore
     assert vgonio.prefix == "BL24I-MO-VGON-01:"
     assert vgonio.kappa.prefix == "BL24I-MO-VGON-01:KAPPA"
-
-
-def teardown_module():
-    beamline_utils.set_beamline("i24")
-    beamline_utils.clear_devices()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import importlib
 import logging
+import os
 import sys
 from os import environ, getenv
 from pathlib import Path
@@ -12,6 +14,7 @@ from ophyd.sim import make_fake_device
 from dodal.beamlines import beamline_utils, i03
 from dodal.devices.focusing_mirror import VFMMirrorVoltages
 from dodal.log import LOGGER, GELFTCPHandler, set_up_all_logging_handlers
+from dodal.utils import make_all_devices
 
 MOCK_DAQ_CONFIG_PATH = "tests/devices/unit_tests/test_daq_configuration"
 mock_paths = [
@@ -30,6 +33,20 @@ mock_attributes_table = {
 def mock_beamline_module_filepaths(bl_name, bl_module):
     if mock_attributes := mock_attributes_table.get(bl_name):
         [bl_module.__setattr__(attr[0], attr[1]) for attr in mock_attributes]
+
+
+@pytest.fixture(scope="function")
+def module_and_devices_for_beamline(request):
+    beamline = request.param
+    with patch.dict(os.environ, {"BEAMLINE": beamline}, clear=True):
+        bl_mod = importlib.import_module("dodal.beamlines." + beamline)
+        importlib.reload(bl_mod)
+        mock_beamline_module_filepaths(beamline, bl_mod)
+        yield bl_mod, make_all_devices(
+            bl_mod, include_skipped=True, fake_with_ophyd_sim=True
+        )
+        beamline_utils.clear_devices()
+        del bl_mod
 
 
 def pytest_runtest_setup(item):

--- a/tests/devices/system_tests/test_aperturescatterguard_system.py
+++ b/tests/devices/system_tests/test_aperturescatterguard_system.py
@@ -14,7 +14,7 @@ from dodal.devices.aperturescatterguard import (
 )
 
 I03_BEAMLINE_PARAMETER_PATH = (
-    "/dls_sw/i03/software/daq_configuration/domain/beamlineParameters"
+    "/dls_sw/i03/software/daq_configuration/domain/beamlineParameterspp"
 )
 BEAMLINE_PARAMETER_KEYWORDS = ["FB", "FULL", "deadtime"]
 


### PR DESCRIPTION
Fixes #344

### Instructions to reviewer on how to test:
1. In `i03.py` change `DAQ_CONFIGURATION_PATH` to an invalid path
2. Confirm you can reproduce failures in original issue locally on `main`
3. Switch to this branch, keeping the changes in 1. Confirm all tests now pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)