### PR TITLE
1163 ispyb comment field grid coords incorrect due to pixels per micron/microns per pixel

### DIFF
--- a/src/dodal/devices/oav/utils.py
+++ b/src/dodal/devices/oav/utils.py
@@ -9,14 +9,14 @@ def bottom_right_from_top_left(
     steps_y: int,
     step_size_x: float,
     step_size_y: float,
-    pix_per_um_x: float,
-    pix_per_um_y: float,
+    um_per_pix_x: float,
+    um_per_pix_y: float,
 ) -> np.ndarray:
     return np.array(
         [
             # step size is given in mm, pix in um
-            int(steps_x * step_size_x * 1000 * pix_per_um_x + top_left[0]),
-            int(steps_y * step_size_y * 1000 * pix_per_um_y + top_left[1]),
+            int(steps_x * step_size_x * 1000 / um_per_pix_x + top_left[0]),
+            int(steps_y * step_size_y * 1000 / um_per_pix_y + top_left[1]),
         ],
         dtype=np.dtype(int),
     )

--- a/tests/devices/unit_tests/test_oav.py
+++ b/tests/devices/unit_tests/test_oav.py
@@ -108,7 +108,7 @@ def test_correct_grid_drawn_on_image(
 def test_bottom_right_from_top_left():
     top_left = np.array([123, 123])
     bottom_right = oav_utils.bottom_right_from_top_left(
-        top_left, 20, 30, 0.1, 0.15, 0.37, 0.37
+        top_left, 20, 30, 0.1, 0.15, 2.7027, 2.7027
     )
     assert bottom_right[0] == 863 and bottom_right[1] == 1788
     bottom_right = oav_utils.bottom_right_from_top_left(
@@ -151,15 +151,19 @@ def test_get_beam_position_from_zoom_only_called_once_on_multiple_connects(
     fake_oav.wait_for_connection()
     fake_oav.wait_for_connection()
 
-    with patch(
-        "dodal.devices.oav.oav_detector.OAVConfigParams.update_on_zoom",
-        MagicMock(),
-    ), patch(
-        "dodal.devices.oav.oav_detector.OAVConfigParams.get_beam_position_from_zoom",
-        MagicMock(),
-    ) as mock_get_beam_position_from_zoom, patch(
-        "dodal.devices.oav.oav_detector.OAVConfigParams.load_microns_per_pixel",
-        MagicMock(),
+    with (
+        patch(
+            "dodal.devices.oav.oav_detector.OAVConfigParams.update_on_zoom",
+            MagicMock(),
+        ),
+        patch(
+            "dodal.devices.oav.oav_detector.OAVConfigParams.get_beam_position_from_zoom",
+            MagicMock(),
+        ) as mock_get_beam_position_from_zoom,
+        patch(
+            "dodal.devices.oav.oav_detector.OAVConfigParams.load_microns_per_pixel",
+            MagicMock(),
+        ),
     ):
         fake_oav.zoom_controller.level.sim_put("2.0x")  # type: ignore
         assert mock_get_beam_position_from_zoom.call_count == 1


### PR DESCRIPTION
Fixes DiamondLightSource/Hyperion#1163 

See corresponding hyperion PR TBD

### Instructions to reviewer on how to test:
1. Comments in ispyb should now have the correct coordinate for the bottom-right which was previously incorrect

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
