### PR TITLE
Fix pin tip detection to not use set_sim_value in production

### DIFF
--- a/src/dodal/devices/oav/pin_image_recognition/__init__.py
+++ b/src/dodal/devices/oav/pin_image_recognition/__init__.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 from numpy.typing import NDArray
-from ophyd_async.core import AsyncStatus, StandardReadable, observe_value, set_sim_value
+from ophyd_async.core import AsyncStatus, StandardReadable, observe_value
 from ophyd_async.epics.signal import epics_signal_r
 
 from dodal.devices.oav.pin_image_recognition.utils import (
@@ -34,8 +34,9 @@ class PinTipDetection(StandardReadable):
     the "edge" of the image.
 
     If no tip is found it will return {INVALID_POSITION}. However, it will also
-    occassionally give incorrect data. Therefore, it is recommended that you trigger
-    this device, which will attempt to find a pin within {validity_timeout} seconds.
+    occasionally give incorrect data. Therefore, it is recommended that you trigger
+    this device, which will attempt to find a pin within {validity_timeout} seconds if
+    no tip is found after this time it will not error but instead return {INVALID_POSITION}.
     """
 
     INVALID_POSITION = (None, None)
@@ -171,4 +172,4 @@ class PinTipDetection(StandardReadable):
             LOGGER.error(
                 f"No tip found in {await self.validity_timeout.get_value()} seconds."
             )
-            set_sim_value(self.triggered_tip, self.INVALID_POSITION)
+            await self.triggered_tip._backend.put(self.INVALID_POSITION)


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/hyperion/issues/1181

### Instructions to reviewer on how to test:
1. Add:
```python 
@patch(
    "dodal.devices.oav.pin_image_recognition.set_sim_value",
    new=MagicMock(side_effect=Exception()),
)
```
onto `test_given_find_tip_fails_twice_when_triggered_then_tip_invalid_and_tried_twice` to simulate the issue mentioned in https://github.com/DiamondLightSource/hyperion/issues/1176. Confirm it fails on main and passes here


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)