### PR TITLE
Unpin pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "zocalo",
     "requests",
     "graypy",
-    "pydantic<2.0",
+    "pydantic",
     "opencv-python-headless",                                                                          # For pin-tip detection.
     "aioca",                                                                                           # Required for CA support with ophyd-async.
     "p4p",                                                                                             # Required for PVA support with ophyd-async.


### PR DESCRIPTION
Fixes #170

Makes dodal compatible with both pydantic 1&2.

### Instructions to reviewer on how to test:
1. Clone a new dodal repo and make a new .venv, run: `pip install -e .[dev]`
2. Run tests and see they pass on pydantic 1.10
3. run `pip install --upgrade pydantic`, to force installing 2.6
4. see tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)