### PR TITLE
Remove use of Annotated from return types of plans

### DIFF
--- a/src/dodal/common/types.py
+++ b/src/dodal/common/types.py
@@ -1,5 +1,4 @@
 from typing import (
-    Annotated,
     Any,
     Callable,
     Generator,
@@ -7,11 +6,9 @@ from typing import (
 
 from bluesky.utils import Msg
 
-Group = Annotated[str, "String identifier used by 'wait' or stubs that await"]
-MsgGenerator = Annotated[
-    Generator[Msg, Any, None],
-    "A true 'plan', usually the output of a generator function",
-]
-PlanGenerator = Annotated[
-    Callable[..., MsgGenerator], "A function that generates a plan"
-]
+# String identifier used by 'wait' or stubs that await
+Group = str
+# A true 'plan', usually the output of a generator function
+MsgGenerator = Generator[Msg, Any, None]
+# A function that generates a plan
+PlanGenerator = Callable[..., MsgGenerator]


### PR DESCRIPTION
typing.get_type_hints(function) strips annotated metadata, and prevents checking for equality

Fixes trying to import plans to blueapi after moving PlanGenerator, MsgGenerator to dodal, as blueapi imports all functions that have the return type.

### Instructions to reviewer on how to test:
1. Call typing.get_type_hints(func) on a function that has a return type of MsgGenerator
2. Compare the value of get_type_hints(func)["return"] to MsgGenerator

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)