### PR TITLE
Use asyncio_mode=auto in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ ignore_missing_imports = true # Ignore missing stubs in imported modules
 
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error
+asyncio_mode = "auto"
 markers = [
     "s03: marks tests as requiring the s03 simulator running (deselect with '-m \"not s03\"')",
 ]

--- a/tests/devices/system_tests/test_zocalo_results.py
+++ b/tests/devices/system_tests/test_zocalo_results.py
@@ -4,7 +4,6 @@ import os
 import bluesky.plan_stubs as bps
 import psutil
 import pytest
-import pytest_asyncio
 from bluesky.preprocessors import stage_decorator
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
@@ -27,7 +26,7 @@ TEST_RESULT_LARGE: XrcResult = {
 }
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def zocalo_device():
     zd = ZocaloResults()
     await zd.connect()
@@ -35,7 +34,6 @@ async def zocalo_device():
 
 
 @pytest.mark.s03
-@pytest.mark.asyncio
 async def test_read_results_from_fake_zocalo(zocalo_device: ZocaloResults):
     zocalo_device._subscribe_to_results()
     zc = ZocaloTrigger("dev_artemis")
@@ -56,7 +54,6 @@ async def test_read_results_from_fake_zocalo(zocalo_device: ZocaloResults):
 
 
 @pytest.mark.s03
-@pytest.mark.asyncio
 async def test_stage_unstage_controls_read_results_from_fake_zocalo(
     zocalo_device: ZocaloResults,
 ):
@@ -104,7 +101,6 @@ async def test_stage_unstage_controls_read_results_from_fake_zocalo(
 
 
 @pytest.mark.s03
-@pytest.mark.asyncio
 async def test_stale_connections_closed_after_unstage(
     zocalo_device: ZocaloResults,
 ):

--- a/tests/devices/unit_tests/oav/image_recognition/test_pin_tip_detect.py
+++ b/tests/devices/unit_tests/oav/image_recognition/test_pin_tip_detect.py
@@ -2,7 +2,6 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
 from ophyd_async.core import set_sim_value
 
 from dodal.devices.oav.pin_image_recognition import MxSampleDetect, PinTipDetection
@@ -11,7 +10,6 @@ from dodal.devices.oav.pin_image_recognition.utils import SampleLocation
 EVENT_LOOP = asyncio.new_event_loop()
 
 
-pytest_plugins = ("pytest_asyncio",)
 DEVICE_NAME = "pin_tip_detection"
 TRIGGERED_TIP_READING = DEVICE_NAME + "-triggered_tip"
 TRIGGERED_TOP_EDGE_READING = DEVICE_NAME + "-triggered_top_edge"
@@ -24,13 +22,11 @@ async def _get_pin_tip_detection_device() -> PinTipDetection:
     return device
 
 
-@pytest.mark.asyncio
 async def test_pin_tip_detect_can_be_connected_in_sim_mode():
     device = await _get_pin_tip_detection_device()
     await device.connect(sim=True)
 
 
-@pytest.mark.asyncio
 async def test_soft_parameter_defaults_are_correct():
     device = await _get_pin_tip_detection_device()
 
@@ -46,7 +42,6 @@ async def test_soft_parameter_defaults_are_correct():
     assert await device.preprocess_ksize.get_value() == 5
 
 
-@pytest.mark.asyncio
 async def test_numeric_soft_parameters_can_be_changed():
     device = await _get_pin_tip_detection_device()
 
@@ -73,7 +68,6 @@ async def test_numeric_soft_parameters_can_be_changed():
     assert await device.preprocess_iterations.get_value() == 4
 
 
-@pytest.mark.asyncio
 async def test_invalid_processing_func_uses_identity_function():
     device = await _get_pin_tip_detection_device()
     test_sample_location = SampleLocation(100, 200, np.array([]), np.array([]))
@@ -95,7 +89,6 @@ async def test_invalid_processing_func_uses_identity_function():
     assert arg == captured_func(arg)
 
 
-@pytest.mark.asyncio
 async def test_given_valid_data_reading_then_used_to_find_location():
     device = await _get_pin_tip_detection_device()
     image_array = np.array([1, 2, 3])
@@ -125,7 +118,6 @@ async def test_given_valid_data_reading_then_used_to_find_location():
         assert location[TRIGGERED_TIP_READING]["timestamp"] > 0
 
 
-@pytest.mark.asyncio
 async def test_given_find_tip_fails_when_triggered_then_tip_invalid():
     device = await _get_pin_tip_detection_device()
     await device.validity_timeout.set(0.1)
@@ -142,7 +134,6 @@ async def test_given_find_tip_fails_when_triggered_then_tip_invalid():
         assert len(reading[TRIGGERED_BOTTOM_EDGE_READING]["value"]) == 0
 
 
-@pytest.mark.asyncio
 @patch("dodal.devices.oav.pin_image_recognition.observe_value")
 async def test_given_find_tip_fails_twice_when_triggered_then_tip_invalid_and_tried_twice(
     mock_image_read,
@@ -168,7 +159,6 @@ async def test_given_find_tip_fails_twice_when_triggered_then_tip_invalid_and_tr
         assert mock_process_array.call_count > 1
 
 
-@pytest.mark.asyncio
 @patch("dodal.devices.oav.pin_image_recognition.LOGGER.warn")
 @patch("dodal.devices.oav.pin_image_recognition.observe_value")
 async def test_given_tip_invalid_then_loop_keeps_retrying_until_valid(

--- a/tests/devices/unit_tests/test_bart_robot.py
+++ b/tests/devices/unit_tests/test_bart_robot.py
@@ -1,4 +1,3 @@
-import pytest
 from ophyd_async.core import set_sim_value
 
 from dodal.devices.robot import BartRobot
@@ -10,13 +9,11 @@ async def _get_bart_robot() -> BartRobot:
     return device
 
 
-@pytest.mark.asyncio
 async def test_bart_robot_can_be_connected_in_sim_mode():
     device = await _get_bart_robot()
     await device.connect(sim=True)
 
 
-@pytest.mark.asyncio
 async def test_when_barcode_updates_then_new_barcode_read():
     device = await _get_bart_robot()
     expected_barcode = "expected"

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import bluesky.plan_stubs as bps
 import numpy as np
 import pytest
-import pytest_asyncio
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
 from ophyd_async.core.async_status import AsyncStatus
@@ -81,7 +80,7 @@ test_ispyb_ids = {"dcid": 0, "dcgid": 0}
 
 
 @patch("dodal.devices.zocalo_results._get_zocalo_connection")
-@pytest_asyncio.fixture
+@pytest.fixture
 async def mocked_zocalo_device(RE):
     async def device(results, run_setup=False):
         zd = ZocaloResults(zocalo_environment="test_env")
@@ -106,7 +105,6 @@ async def mocked_zocalo_device(RE):
     return device
 
 
-@pytest.mark.asyncio
 async def test_put_result_read_results(
     mocked_zocalo_device,
     RE,
@@ -122,7 +120,6 @@ async def test_put_result_read_results(
     assert np.all(bboxes[0] == [2, 2, 1])
 
 
-@pytest.mark.asyncio
 async def test_rd_top_results(
     mocked_zocalo_device,
     RE,
@@ -141,7 +138,6 @@ async def test_rd_top_results(
     RE(test_plan())
 
 
-@pytest.mark.asyncio
 async def test_trigger_and_wait_puts_results(
     mocked_zocalo_device,
     RE,
@@ -159,7 +155,6 @@ async def test_trigger_and_wait_puts_results(
     zocalo_device._put_results.assert_called()
 
 
-@pytest.mark.asyncio
 async def test_extraction_plan(mocked_zocalo_device, RE) -> None:
     zocalo_device: ZocaloResults = await mocked_zocalo_device(
         TEST_RESULTS, run_setup=False
@@ -176,7 +171,6 @@ async def test_extraction_plan(mocked_zocalo_device, RE) -> None:
     RE(plan())
 
 
-@pytest.mark.asyncio
 @patch(
     "dodal.devices.zocalo.zocalo_results.workflows.recipe.wrap_subscribe", autospec=True
 )
@@ -202,7 +196,6 @@ async def test_subscribe_only_on_called_stage(
     mock_wrap_subscribe.assert_called_once()
 
 
-@pytest.mark.asyncio
 @patch("dodal.devices.zocalo.zocalo_results._get_zocalo_connection", autospec=True)
 async def test_when_exception_caused_by_zocalo_message_then_exception_propagated(
     mock_connection,


### PR DESCRIPTION
Makes writing asyncio tests simpler, removing decorator and explicit async fixtures

Fixes #375

### Instructions to reviewer on how to test:
1. Check that tests run does not decrease
2. Check that code coverage does not change

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)