### PR TITLE
Allow ophyd_async timeout exception to propagate correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
     "ophyd",
-    "ophyd_async@git+https://github.com/bluesky/ophyd-async@ec5729640041ee5b77b4614158793af3a34cf9d8", #Use a specific branch from ophyd async until https://github.com/bluesky/ophyd-async/pull/101 is merged
+    "ophyd-async@git+https://github.com/bluesky/ophyd-async",
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/src/dodal/beamlines/beamline_utils.py
+++ b/src/dodal/beamlines/beamline_utils.py
@@ -52,8 +52,12 @@ def _wait_for_connection(
         device.wait_for_connection(timeout=timeout)
     elif isinstance(device, OphydV2Device):
         call_in_bluesky_event_loop(
-            v2_device_wait_for_connection(coros=device.connect(sim=sim)),
-            timeout=timeout,
+            v2_device_wait_for_connection(
+                coros=device.connect(
+                    sim=sim,
+                    timeout=timeout,
+                )
+            ),
         )
     else:
         raise TypeError(

--- a/src/dodal/devices/oav/pin_image_recognition/__init__.py
+++ b/src/dodal/devices/oav/pin_image_recognition/__init__.py
@@ -4,7 +4,12 @@ from typing import Optional
 
 import numpy as np
 from numpy.typing import NDArray
-from ophyd_async.core import AsyncStatus, StandardReadable, observe_value
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    AsyncStatus,
+    StandardReadable,
+    observe_value,
+)
 from ophyd_async.epics.signal import epics_signal_r
 
 from dodal.devices.oav.pin_image_recognition.utils import (
@@ -142,8 +147,8 @@ class PinTipDetection(StandardReadable):
         )
         return location
 
-    async def connect(self, sim: bool = False):
-        await super().connect(sim)
+    async def connect(self, sim: bool = False, timeout: float = DEFAULT_TIMEOUT):
+        await super().connect(sim, timeout)
 
         # Set defaults for soft parameters
         await self.validity_timeout.set(5.0)

--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 from bluesky.run_engine import RunEngine as RE
@@ -100,10 +100,14 @@ def test_wait_for_v2_device_connection_passes_through_timeout(
 ):
     RE()
     device = OphydV2Device()
+    device.connect = MagicMock()
 
     beamline_utils._wait_for_connection(device, **kwargs)
 
-    call_in_bluesky_el.assert_called_once_with(ANY, timeout=expected_timeout)
+    device.connect.assert_called_once_with(
+        sim=ANY,
+        timeout=expected_timeout,
+    )
 
 
 def test_default_directory_provider_is_singleton():

--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from bluesky.run_engine import RunEngine as RE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,9 @@ def module_and_devices_for_beamline(request):
         bl_mod = importlib.import_module("dodal.beamlines." + beamline)
         importlib.reload(bl_mod)
         mock_beamline_module_filepaths(beamline, bl_mod)
-        yield bl_mod, make_all_devices(
-            bl_mod, include_skipped=True, fake_with_ophyd_sim=True
+        yield (
+            bl_mod,
+            make_all_devices(bl_mod, include_skipped=True, fake_with_ophyd_sim=True),
         )
         beamline_utils.clear_devices()
         del bl_mod


### PR DESCRIPTION
Allows timeouts of ophyd_async devices to propagate their newly informative exceptions correctly.
Fixes #223 

### Instructions to reviewer on how to test:
1. Attempt to connect to a device that is not available with/without the change

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)