### PR TITLE
Add Beam Current Monitors for I22 and P38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
     "ophyd",
-    "ophyd-async@git+https://github.com/bluesky/ophyd-async",
+    "ophyd-async>=0.3a1",
     "bluesky",
     "pyepics",
     "dataclasses-json",
@@ -23,9 +23,9 @@ dependencies = [
     "requests",
     "graypy",
     "pydantic",
-    "opencv-python-headless",                                 # For pin-tip detection.
-    "aioca",                                                  # Required for CA support with ophyd-async.
-    "p4p",                                                    # Required for PVA support with ophyd-async.
+    "opencv-python-headless", # For pin-tip detection.
+    "aioca",                  # Required for CA support with ophyd-async.
+    "p4p",                    # Required for PVA support with ophyd-async.
     "numpy",
 ]
 

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,39 +1,12 @@
 from dodal.beamlines.beamline_utils import device_instantiation, get_directory_provider
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.devices.areadetector import AdAravisDetector
 from dodal.devices.tetramm import TetrammDetector
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import get_beamline_name
 
-BL = get_beamline_name("p38")
+BL = get_beamline_name("i22")
 set_log_beamline(BL)
 set_utils_beamline(BL)
-
-
-def d11(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> AdAravisDetector:
-    return device_instantiation(
-        AdAravisDetector,
-        "D11",
-        "-DI-DCAM-03:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
-
-
-def d12(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> AdAravisDetector:
-    return device_instantiation(
-        AdAravisDetector,
-        "D12",
-        "-DI-DCAM-04:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
 
 
 def i0(
@@ -43,7 +16,21 @@ def i0(
     return device_instantiation(
         TetrammDetector,
         "i0",
-        "-EA-XBPM-01",
+        "-EA-XBPM-02",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
+    )
+
+
+def it(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> TetrammDetector:
+    return device_instantiation(
+        TetrammDetector,
+        "it",
+        "-EA-TTRM-02",
         wait_for_connection,
         fake_with_ophyd_sim,
         directory_provider=get_directory_provider(),

--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -1,0 +1,273 @@
+import asyncio
+from enum import Enum
+from typing import Generator, Sequence
+
+import bluesky.plan_stubs as bps
+from bluesky.protocols import Hints
+from ophyd_async.core import (
+    AsyncStatus,
+    DetectorControl,
+    DetectorTrigger,
+    Device,
+    DirectoryProvider,
+    ShapeProvider,
+    StandardDetector,
+    set_and_wait_for_value,
+    set_signal_values,
+    walk_rw_signals,
+)
+from ophyd_async.core.device_save_loader import Msg
+from ophyd_async.epics.areadetector.utils import ad_r, ad_rw, stop_busy_record
+from ophyd_async.epics.areadetector.writers import HDFWriter, NDFileHDF
+from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+
+
+class TetrammRange(str, Enum):
+    uA = "+- 120 uA"
+    nA = "+- 120 nA"
+
+
+class TetrammTrigger(str, Enum):
+    FreeRun = "Free run"
+    ExtTrigger = "Ext. trig."
+    ExtBulb = "Ext. bulb"
+    ExtGate = "Ext. gate"
+
+
+class TetrammChannels(str, Enum):
+    One = "1"
+    Two = "2"
+    Four = "4"
+
+
+class TetrammResolution(str, Enum):
+    SixteenBits = "16 bits"
+    TwentyFourBits = "24 bits"
+
+
+class TetrammGeometry(str, Enum):
+    Diamond = "Diamond"
+    Square = "Square"
+
+
+class TetrammDriver(Device):
+    def __init__(
+        self,
+        prefix: str,
+        name: str = "",
+    ):
+        self._prefix = prefix
+        self.range = ad_rw(TetrammRange, prefix + "Range")
+        self.sample_time = ad_r(float, prefix + "SampleTime")
+
+        self.values_per_reading = ad_rw(int, prefix + "ValuesPerRead")
+        self.averaging_time = ad_rw(float, prefix + "AveragingTime")
+        self.to_average = ad_r(int, prefix + "NumAverage")
+        self.averaged = ad_r(int, prefix + "NumAveraged")
+
+        self.acquire = ad_rw(bool, prefix + "Acquire")
+
+        # this PV is special, for some reason it doesn't have a _RBV suffix...
+        self.overflows = epics_signal_r(int, prefix + "RingOverflows")
+
+        self.num_channels = ad_rw(TetrammChannels, prefix + "NumChannels")
+        self.resolution = ad_rw(TetrammResolution, prefix + "Resolution")
+        self.trigger_mode = ad_rw(TetrammTrigger, prefix + "TriggerMode")
+        self.bias = ad_rw(bool, prefix + "BiasState")
+        self.bias_volts = ad_rw(float, prefix + "BiasVoltage")
+        self.geometry = ad_rw(TetrammGeometry, prefix + "Geometry")
+        self.nd_attributes_file = epics_signal_rw(str, prefix + "NDAttributesFile")
+
+        super().__init__(name=name)
+
+
+class TetrammController(DetectorControl):
+    """Controller for a TetrAMM current monitor
+
+    Attributes:
+        base_sample_rate (int): Fixed in hardware
+
+    Args:
+        drv (TetrammDriver): A configured driver for the device
+        maximum_readings_per_frame (int): Maximum number of readings per frame: actual readings may be lower if higher frame rate is required
+        minimum_values_per_reading (int): Lower bound on the values that will be averaged to create a single reading
+        readings_per_frame (int): Actual number of readings per frame.
+
+    """
+
+    base_sample_rate: int = 100_000
+
+    def __init__(
+        self,
+        drv: TetrammDriver,
+        minimum_values_per_reading: int = 5,
+        maximum_readings_per_frame: int = 1_000,
+        readings_per_frame: int = 1_000,
+    ):
+        # TODO: Are any of these also fixed by hardware constraints?
+        self._drv = drv
+        self.maximum_readings_per_frame = maximum_readings_per_frame
+        self.minimum_values_per_reading = minimum_values_per_reading
+        self.readings_per_frame = readings_per_frame
+
+    def get_deadtime(self, exposure: float) -> float:
+        # 2 internal clock cycles. Best effort approximation
+        return 2 / self.base_sample_rate
+
+    async def arm(
+        self,
+        num: int,
+        trigger: DetectorTrigger,
+        exposure: float,
+    ) -> AsyncStatus:
+        if trigger not in {DetectorTrigger.edge_trigger, DetectorTrigger.constant_gate}:
+            raise ValueError("Only edge triggers are supported")
+
+        # trigger mode must be set first and on its own!
+        await self._drv.trigger_mode.set(TetrammTrigger.ExtTrigger)
+
+        await asyncio.gather(
+            self._drv.averaging_time.set(exposure), self.set_frame_time(exposure)
+        )
+
+        status = await set_and_wait_for_value(self._drv.acquire, 1)
+
+        return status
+
+    async def disarm(self):
+        await stop_busy_record(self._drv.acquire, 0, timeout=1)
+
+    async def set_frame_time(self, frame_time: float):
+        """Tries to set the exposure time of a single frame.
+
+        As during the  exposure time, the device must collect an integer number
+        of readings, in the case where the frame_time is not a multiple of the base
+        sample rate, it will be lowered to the prior multiple ot ensure triggers
+        are not missed.
+
+        Args:
+            frame_time (float): The time for a single frame in seconds
+
+        Raises:
+            ValueError: If frame_time is too low to collect the required number
+            of readings per frame.
+        """
+
+        values_per_reading: int = int(
+            frame_time * self.base_sample_rate / self.readings_per_frame
+        )
+
+        if values_per_reading < self.minimum_values_per_reading:
+            raise ValueError(
+                f"frame_time {frame_time} is too low to collect at least "
+                f"{self.minimum_values_per_reading} values per reading, at "
+                f"{self.readings_per_frame} readings per frame."
+            )
+        await self._drv.values_per_reading.set(values_per_reading)
+
+    @property
+    def max_frame_rate(self) -> float:
+        """Max frame rate in Hz for the current configuration"""
+        return 1 / self.minimum_frame_time
+
+    @max_frame_rate.setter
+    def max_frame_rate(self, mfr: float):
+        self.minimum_frame_time = 1 / mfr
+
+    @property
+    def minimum_frame_time(self) -> float:
+        time_per_reading = self.minimum_values_per_reading / self.base_sample_rate
+        return self.readings_per_frame * time_per_reading
+
+    @minimum_frame_time.setter
+    def minimum_frame_time(self, frame: float):
+        time_per_reading = self.minimum_values_per_reading / self.base_sample_rate
+        self.readings_per_frame = int(
+            min(self.maximum_readings_per_frame, frame / time_per_reading)
+        )
+
+
+IDLE_TETRAMM = {
+    "drv.acquire": 0,
+}
+
+COMMON_TETRAMM = {
+    "drv.range": TetrammRange.uA,
+    "drv.num_channels": "4",
+    "drv.resolution": TetrammResolution.TwentyFourBits,
+    "drv.geometry": TetrammGeometry.Square,
+}
+
+TRIGGERED_TETRAMM = {
+    **COMMON_TETRAMM,
+    "drv.trigger_mode": TetrammTrigger.ExtTrigger,
+}
+
+FREE_TETRAMM = {
+    **COMMON_TETRAMM,
+    "drv.values_per_reading": 10,
+    "drv.averaging_time": 0.1,
+    "drv.trigger_mode": TetrammTrigger.FreeRun,
+}
+
+
+def triggered_tetramm(dev: TetrammDriver) -> Generator[Msg, None, None]:
+    sigs = walk_rw_signals(dev)
+    yield from set_signal_values(
+        sigs,
+        [
+            IDLE_TETRAMM,
+            TRIGGERED_TETRAMM,
+        ],
+    )
+
+
+def free_tetramm(dev: TetrammDriver) -> Generator[Msg, None, None]:
+    """Freerun the tetramm, setting it to acquire so diodes update."""
+    sigs = walk_rw_signals(dev)
+    yield from set_signal_values(sigs, [IDLE_TETRAMM, FREE_TETRAMM])
+    yield from bps.abs_set(dev.drv.acquire, 1)
+
+
+class TetrammShapeProvider(ShapeProvider):
+    max_channels = 11
+
+    def __init__(self, controller: TetrammController) -> None:
+        self.controller = controller
+
+    async def __call__(self) -> Sequence[int]:
+        return [self.max_channels, self.controller.readings_per_frame]
+
+
+# TODO: Support MeanValue signals https://github.com/DiamondLightSource/dodal/issues/337
+class TetrammDetector(StandardDetector):
+    def __init__(
+        self,
+        prefix: str,
+        directory_provider: DirectoryProvider,
+        name: str,
+        **scalar_sigs: str,
+    ) -> None:
+        self.drv = TetrammDriver(prefix + "DRV:")
+        self.hdf = NDFileHDF(prefix + "HDF5:")
+        controller = TetrammController(self.drv)
+        super().__init__(
+            controller,
+            HDFWriter(
+                self.hdf,
+                directory_provider,
+                lambda: self.name,
+                TetrammShapeProvider(controller),
+                **scalar_sigs,
+            ),
+            [
+                self.drv.values_per_reading,
+                self.drv.averaging_time,
+                self.drv.sample_time,
+            ],
+            name,
+        )
+
+    @property
+    def hints(self) -> Hints:
+        return {"fields": [self.name]}

--- a/tests/beamlines/unit_tests/test_device_instantiation.py
+++ b/tests/beamlines/unit_tests/test_device_instantiation.py
@@ -5,7 +5,7 @@ import pytest
 from dodal.beamlines import beamline_utils
 from dodal.utils import BLUESKY_PROTOCOLS, make_all_devices
 
-ALL_BEAMLINES = {"i03", "i04", "i04_1", "i23", "i24", "p38", "p45"}
+ALL_BEAMLINES = {"i03", "i04", "i04_1", "i23", "i24", "p38", "i22", "p45"}
 
 
 def follows_bluesky_protocols(obj: Any) -> bool:

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -1,0 +1,87 @@
+from unittest.mock import Mock
+
+import pytest
+from ophyd_async.core import DetectorTrigger, DeviceCollector
+
+from dodal.devices.tetramm import TetrammController, TetrammDriver
+
+
+@pytest.fixture
+async def tetramm_controller(RE) -> TetrammController:
+    async with DeviceCollector(sim=True):
+        drv = TetrammDriver("DRIVER:")
+        controller = TetrammController(drv)
+
+    return controller
+
+
+def test_max_frame_rate():
+    drv = Mock()
+    drv.minimum_frame_time = 0.1
+    assert TetrammController.max_frame_rate.__get__(drv) == 10
+    TetrammController.max_frame_rate.__set__(drv, 20)
+    # max_frame_rate**-1 = minimum_frame_times
+    assert drv.minimum_frame_time == pytest.approx(1 / 20)
+
+
+def test_min_frame_time():
+    drv = Mock()
+    # Using coprimes to ensure the solution has a unique relation to the values.
+    drv.base_sample_rate = 100_000
+    drv.readings_per_frame = 999
+    drv.maximum_readings_per_frame = 1_001
+    drv.minimum_values_per_reading = 17
+
+    # min_frame_time (s/f) = max_readings_per_frame * values_per_reading / sample_rate (v/s)
+    minimum_frame_time = (
+        drv.readings_per_frame
+        * drv.minimum_values_per_reading
+        / float(drv.base_sample_rate)
+    )
+
+    assert TetrammController.minimum_frame_time.__get__(drv) == pytest.approx(
+        minimum_frame_time
+    )
+
+    # From rearranging the above
+    # readings_per_frame = frame_time * sample_rate / values_per_reading
+
+    readings_per_time = drv.base_sample_rate / drv.minimum_values_per_reading
+
+    # 100_000 / 17 ~ 5800; 5800 * 0.01 = 58; 58 << drv.maximum_readings_per_frame
+    TetrammController.minimum_frame_time.__set__(drv, 0.01)
+    assert drv.readings_per_frame == int(readings_per_time * 0.01)
+
+    # 100_000 / 17 ~ 5800; 5800 * 0.2 = 1160; 1160 > drv.maximum_readings_per_frame
+    TetrammController.minimum_frame_time.__set__(drv, 0.2)
+    assert drv.readings_per_frame == drv.maximum_readings_per_frame
+
+    # 100_000 / 17 ~ 5800; 5800 * 0.2 = 1160; 1160 < 1200
+    drv.maximum_readings_per_frame = 1200
+    TetrammController.minimum_frame_time.__set__(drv, 0.1)
+    assert drv.readings_per_frame == int(readings_per_time * 0.1)
+
+
+async def test_excepts_for_invalid_triggers(tetramm_controller: TetrammController):
+    with pytest.raises(ValueError):
+        await tetramm_controller.arm(-1, DetectorTrigger.internal, 0.01)
+    # Function excepts early and does not do any sets
+
+
+async def test_set_frame_time(tetramm_controller: TetrammController):
+    """
+    frame_time >= readings_per_frame * values_per_reading / sample_rate
+    With the default values:
+    base_sample_rate = 100_000
+    minimum_values_per_reading = 5
+    readings_per_frame = 1_000
+    frame_time >= 1_000 * 5 / 100_000 = 1/20
+    """
+
+    await tetramm_controller.set_frame_time(1 / 19)
+
+    with pytest.raises(
+        ValueError,
+        match="frame_time 0.02 is too low to collect at least 5 values per reading, at 1000 readings per frame.",
+    ):
+        await tetramm_controller.set_frame_time(1 / 50)


### PR DESCRIPTION
Fixes #401 

Add a Tetramm Device based on the I22 user experiment in November, including tests. Add beam current monitors for i22 and mockup beam current monitor for p38.

### Instructions to reviewer on how to test:
1. Run unit tests
2. Confirm they pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)