### PR TITLE
Fix Mypy Errors Caused by Pillow

### DIFF
--- a/src/dodal/devices/oav/grid_overlay.py
+++ b/src/dodal/devices/oav/grid_overlay.py
@@ -15,7 +15,7 @@ class Orientation(Enum):
 
 
 def _add_parallel_lines_to_image(
-    image: Image,
+    image: Image.Image,
     start_x: int,
     start_y: int,
     line_length: int,

--- a/tests/devices/unit_tests/test_oav.py
+++ b/tests/devices/unit_tests/test_oav.py
@@ -67,18 +67,16 @@ def test_snapshot_trigger_saves_to_correct_file(
     mock_open: MagicMock, mock_get, fake_oav
 ):
     image = PIL.Image.open("test")
-    mock_save = MagicMock()
-    # mypy doesn't like method assignments
-    image.save = mock_save  # type: ignore
     mock_open.return_value.__enter__.return_value = image
-    st = fake_oav.snapshot.trigger()
-    st.wait()
-    expected_calls_to_save = [
-        call(f"test directory/test filename{addition}.png")
-        for addition in ["", "_outer_overlay", "_grid_overlay"]
-    ]
-    calls_to_save = mock_save.mock_calls
-    assert calls_to_save == expected_calls_to_save
+    with patch.object(image, "save") as mock_save:
+        st = fake_oav.snapshot.trigger()
+        st.wait()
+        expected_calls_to_save = [
+            call(f"test directory/test filename{addition}.png")
+            for addition in ["", "_outer_overlay", "_grid_overlay"]
+        ]
+        calls_to_save = mock_save.mock_calls
+        assert calls_to_save == expected_calls_to_save
 
 
 @patch("requests.get")

--- a/tests/devices/unit_tests/test_oav.py
+++ b/tests/devices/unit_tests/test_oav.py
@@ -68,7 +68,8 @@ def test_snapshot_trigger_saves_to_correct_file(
 ):
     image = PIL.Image.open("test")
     mock_save = MagicMock()
-    image.save = mock_save
+    # mypy doesn't like method assignments
+    image.save = mock_save  # type: ignore
     mock_open.return_value.__enter__.return_value = image
     st = fake_oav.snapshot.trigger()
     st.wait()


### PR DESCRIPTION
The new version of pillow  (10.3.0) includes type hints, which seems to have
caused mypy to pay more attention to it and thrown up a couple of
issues. Nothing significant but blocks CI on other PRs.

Pillow PR that added type hints: https://github.com/python-pillow/Pillow/commit/b6c755df3204f625cb9761edea98a59d604aa153

### Instructions to reviewer on how to test:
1. Ensure CI passes
2. Can also run mypy locally

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)