### PR TITLE
Changes to support hyperion 1283 use pixels per micron from file not gda

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -208,7 +208,11 @@ def panda_fast_grid_scan(
 
 
 @skip_device(lambda: BL == "s03")
-def oav(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> OAV:
+def oav(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+    params=OAVConfigParams(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
+) -> OAV:
     """Get the i03 OAV device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
@@ -218,7 +222,7 @@ def oav(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> 
         "",
         wait_for_connection,
         fake_with_ophyd_sim,
-        params=OAVConfigParams(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
+        params=params,
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -211,7 +211,7 @@ def panda_fast_grid_scan(
 def oav(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
-    params=OAVConfigParams(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
+    params: OAVConfigParams | None = None,
 ) -> OAV:
     """Get the i03 OAV device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -222,7 +222,7 @@ def oav(
         "",
         wait_for_connection,
         fake_with_ophyd_sim,
-        params=params,
+        params=params or OAVConfigParams(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
     )
 
 

--- a/src/dodal/devices/oav/grid_overlay.py
+++ b/src/dodal/devices/oav/grid_overlay.py
@@ -133,6 +133,9 @@ class SnapshotWithGrid(MJPG):
     last_path_outer = Component(Signal)
     last_path_full_overlay = Component(Signal)
 
+    microns_per_pixel_x = Component(Signal)
+    microns_per_pixel_y = Component(Signal)
+
     def post_processing(self, image: Image.Image):
         top_left_x = self.top_left_x.get()
         top_left_y = self.top_left_y.get()

--- a/src/dodal/devices/oav/grid_overlay.py
+++ b/src/dodal/devices/oav/grid_overlay.py
@@ -133,6 +133,7 @@ class SnapshotWithGrid(MJPG):
     last_path_outer = Component(Signal)
     last_path_full_overlay = Component(Signal)
 
+    # scaling factors for the snapshot at the time it was triggered
     microns_per_pixel_x = Component(Signal)
     microns_per_pixel_y = Component(Signal)
 


### PR DESCRIPTION
Fixes (DiamondLightSource/hyperion#1283)

Add microns-per-pixel to the snapshot so that oav snapshot events can contain data needed for ispyb
A small change to OAV initialiser to allow parameters to be specified on construction for system tests 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)