### PR TITLE
Add Pilatus implementation for i22 beamline module

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,3 +1,5 @@
+from ophyd_async.epics.areadetector import PilatusDetector
+
 from dodal.beamlines.beamline_utils import (
     device_instantiation,
     get_directory_provider,
@@ -27,6 +29,36 @@ set_directory_provider(
         "/data/i22/2024/VISIT",
     )
 )
+
+
+def saxs(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> PilatusDetector:
+    return device_instantiation(
+        PilatusDetector,
+        "saxs",
+        "-EA-PILAT-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        drv_suffix="DRV:",
+        hdf_suffix="HDF:",
+        directory_provider=get_directory_provider(),
+    )
+
+
+def waxs(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> PilatusDetector:
+    return device_instantiation(
+        PilatusDetector,
+        "waxs",
+        "-EA-PILAT-03:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        drv_suffix="DRV:",
+        hdf_suffix="HDF:",
+        directory_provider=get_directory_provider(),
+    )
 
 
 def i0(


### PR DESCRIPTION
Fixes #406

Adds a Pilatus without the Stats plugin as previously enabled for i22. Configuring the Stats plugin will be handled in ophyd-async more generally with https://github.com/bluesky/ophyd-async/issues/213 et al.

### Instructions to reviewer on how to test:
1. Test that Pilatus detector can be instantiated in dummy mode and the signals look correct to connect to the i22 instance

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)