### PR TITLE
Return empty string if barcode is an empty list

### DIFF
--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -35,10 +35,8 @@ class SingleIndexWaveformReadable(StandardReadable):
     async def read(self) -> Dict[str, Reading]:
         underlying_read = await self.bare_signal.read()
         pv_reading = underlying_read[self.bare_signal.name]
-        try:
-            pv_reading["value"] = str(pv_reading["value"][self.index])
-        except Exception:
-            pv_reading["value"] = ""
+        old_reading = pv_reading["value"]
+        pv_reading["value"] = str(old_reading[self.index]) if old_reading else ""
         return OrderedDict([(self._name, pv_reading)])
 
     async def describe(self) -> dict[str, Descriptor]:

--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -35,7 +35,10 @@ class SingleIndexWaveformReadable(StandardReadable):
     async def read(self) -> Dict[str, Reading]:
         underlying_read = await self.bare_signal.read()
         pv_reading = underlying_read[self.bare_signal.name]
-        pv_reading["value"] = str(pv_reading["value"][self.index])
+        try:
+            pv_reading["value"] = str(pv_reading["value"][self.index])
+        except Exception:
+            pv_reading["value"] = ""
         return OrderedDict([(self._name, pv_reading)])
 
     async def describe(self) -> dict[str, Descriptor]:

--- a/tests/devices/unit_tests/test_bart_robot.py
+++ b/tests/devices/unit_tests/test_bart_robot.py
@@ -26,6 +26,13 @@ async def test_when_barcode_updates_then_new_barcode_read():
     assert (await device.barcode.read())["robot-barcode"]["value"] == expected_barcode
 
 
+async def test_when_barcode_updates_with_empty_list_then_new_barcode_is_empty_string():
+    device = await _get_bart_robot()
+    expected_barcode = ""
+    set_sim_value(device.barcode.bare_signal, [])
+    assert (await device.barcode.read())["robot-barcode"]["value"] == expected_barcode
+
+
 @patch("dodal.devices.robot.LOGGER")
 async def test_given_program_running_when_load_pin_then_logs_the_program_name_and_times_out(
     patch_logger: MagicMock,


### PR DESCRIPTION
Fixes #425

### Instructions to reviewer on how to test:
1. Run the following on `main` and this branch:
```python
import os

os.environ["BEAMLINE"] = "i03"

import bluesky.plan_stubs as bps
from bluesky.run_engine import RunEngine
from dodal.beamlines.i03 import robot

RE = RunEngine()

my_bart = robot()


def my_plan():
    barcode = yield from bps.rd(my_bart.barcode)
    print(barcode)


RE(my_plan())
```
2. Confirm fails on main, passes here (this is based on the state of i03 when writing this so if there is a sample loaded when you test it will pass on both)
3. Confirm new unit test also passes

### Checks for reviewer
- [x] Would the PR title make sense to a scientist on a set of release notes
- [x] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)