### PR TITLE
Make arm status for zebra read-only

### DIFF
--- a/src/dodal/devices/zebra.py
+++ b/src/dodal/devices/zebra.py
@@ -12,7 +12,7 @@ from ophyd_async.core import (
     StandardReadable,
     observe_value,
 )
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 
 # Sources
 DISCONNECT = 0
@@ -96,7 +96,7 @@ class ArmingDevice(StandardReadable):
     def __init__(self, prefix: str, name: str = "") -> None:
         self.arm_set = epics_signal_rw(float, prefix + "PC_ARM")
         self.disarm_set = epics_signal_rw(float, prefix + "PC_DISARM")
-        self.armed = epics_signal_rw(float, prefix + "PC_ARM_OUT")
+        self.armed = epics_signal_r(float, prefix + "PC_ARM_OUT")
         super().__init__(name)
 
     async def _set_armed(self, demand: ArmDemand):

--- a/tests/devices/unit_tests/test_zebra.py
+++ b/tests/devices/unit_tests/test_zebra.py
@@ -34,9 +34,9 @@ async def test_position_compare_sets_signals():
     await fake_pc.connect(sim=True)
 
     async def mock_arm(demand):
+        await fake_pc.arm.armed._backend.put(demand)  # type: ignore
         fake_pc.arm.disarm_set._backend._set_value(not demand)  # type: ignore
         fake_pc.arm.arm_set._backend._set_value(demand)  # type: ignore
-        await fake_pc.arm.armed.set(demand)
 
     fake_pc.arm.arm_set.set = AsyncMock(side_effect=mock_arm)
     fake_pc.arm.disarm_set.set = AsyncMock(side_effect=mock_arm)


### PR DESCRIPTION
Part of #356 
The PV holding the arm status for the zebra (`-EA-ZEBRA-01:PC_ARM_OUT`) is read-only and te signal in the Zebra device should reflect this.

### Instructions to reviewer on how to test:
1. Test makes sense and passes