### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/devices/system_tests/test_gridscan_system.py
+++ b/tests/devices/system_tests/test_gridscan_system.py
@@ -29,9 +29,8 @@ def fast_grid_scan():
 
 @pytest.mark.s03
 def test_when_program_data_set_and_staged_then_expected_images_correct(
-    fast_grid_scan: FastGridScan,
+    fast_grid_scan: FastGridScan, RE
 ):
-    RE = RunEngine()
     RE(
         set_fast_grid_scan_params(
             fast_grid_scan,
@@ -45,7 +44,7 @@ def test_when_program_data_set_and_staged_then_expected_images_correct(
 
 @pytest.mark.s03
 def test_given_valid_params_when_kickoff_then_completion_status_increases_and_finishes(
-    fast_grid_scan: FastGridScan,
+    fast_grid_scan: FastGridScan, RE: RunEngine
 ):
     def set_and_wait_plan(fast_grid_scan: FastGridScan):
         yield from set_fast_grid_scan_params(
@@ -68,7 +67,6 @@ def test_given_valid_params_when_kickoff_then_completion_status_increases_and_fi
                 assert 0 < fraction < 1
                 assert 0 < prev_fraction < 1
 
-    RE = RunEngine()
     RE(set_and_wait_plan(fast_grid_scan))
     assert fast_grid_scan.position_counter.get() == 0
 

--- a/tests/devices/system_tests/test_gridscan_system.py
+++ b/tests/devices/system_tests/test_gridscan_system.py
@@ -29,7 +29,7 @@ def fast_grid_scan():
 
 @pytest.mark.s03
 def test_when_program_data_set_and_staged_then_expected_images_correct(
-    fast_grid_scan: FastGridScan, RE
+    fast_grid_scan: FastGridScan, RE: RunEngine
 ):
     RE(
         set_fast_grid_scan_params(

--- a/tests/devices/system_tests/test_oav_system.py
+++ b/tests/devices/system_tests/test_oav_system.py
@@ -24,12 +24,11 @@ def take_snapshot_with_grid(oav: OAV, snapshot_filename, snapshot_directory):
 
 
 @pytest.mark.skip(reason="Don't want to actually take snapshots during testing.")
-def test_grid_overlay():
+def test_grid_overlay(RE: RunEngine):
     beamline = "BL03I"
     oav = OAV(name="oav", prefix=f"{beamline}-DI-OAV-01")
     snapshot_filename = "snapshot"
     snapshot_directory = "."
-    RE = RunEngine()
     RE(take_snapshot_with_grid(oav, snapshot_filename, snapshot_directory))
 
 

--- a/tests/devices/system_tests/test_zocalo_results.py
+++ b/tests/devices/system_tests/test_zocalo_results.py
@@ -34,7 +34,9 @@ async def zocalo_device():
 
 
 @pytest.mark.s03
-async def test_read_results_from_fake_zocalo(zocalo_device: ZocaloResults):
+async def test_read_results_from_fake_zocalo(
+    zocalo_device: ZocaloResults, RE: RunEngine
+):
     zocalo_device._subscribe_to_results()
     zc = ZocaloTrigger("dev_artemis")
     zc.run_start(0, 0, 100)
@@ -46,7 +48,6 @@ async def test_read_results_from_fake_zocalo(zocalo_device: ZocaloResults):
         yield from bps.trigger_and_read([zocalo_device])
         yield from bps.close_run()
 
-    RE = RunEngine()
     RE(plan())
 
     results = await zocalo_device.read()
@@ -55,7 +56,7 @@ async def test_read_results_from_fake_zocalo(zocalo_device: ZocaloResults):
 
 @pytest.mark.s03
 async def test_stage_unstage_controls_read_results_from_fake_zocalo(
-    zocalo_device: ZocaloResults,
+    zocalo_device: ZocaloResults, RE: RunEngine
 ):
     dodal.devices.zocalo.zocalo_results.CLEAR_QUEUE_WAIT_S = 0.05
     zc = ZocaloTrigger("dev_artemis")
@@ -74,7 +75,6 @@ async def test_stage_unstage_controls_read_results_from_fake_zocalo(
         yield from plan()
 
     # With stage, the plan should run normally
-    RE = RunEngine()
     RE(plan_with_stage())
     assert not zocalo_device.subscription
     # Without stage, the plan should run fail because we didn't connect to Zocalo
@@ -102,7 +102,7 @@ async def test_stage_unstage_controls_read_results_from_fake_zocalo(
 
 @pytest.mark.s03
 async def test_stale_connections_closed_after_unstage(
-    zocalo_device: ZocaloResults,
+    zocalo_device: ZocaloResults, RE: RunEngine
 ):
     this_process = psutil.Process(os.getpid())
 
@@ -112,7 +112,6 @@ async def test_stale_connections_closed_after_unstage(
         yield from bps.stage(zocalo_device)
         yield from bps.unstage(zocalo_device)
 
-    RE = RunEngine()
     RE(stage_unstage())
 
     connections_after = len(this_process.connections())

--- a/tests/devices/unit_tests/i24/test_dual_backlight.py
+++ b/tests/devices/unit_tests/i24/test_dual_backlight.py
@@ -23,21 +23,20 @@ def test_backlight_position(fake_backlight: DualBacklight):
     assert fake_backlight.pos1.pos_level.get() == "In"
 
 
-def test_when_led1_out_it_switches_off(fake_backlight: DualBacklight):
-    RE = RunEngine()
+def test_when_led1_out_it_switches_off(fake_backlight: DualBacklight, RE: RunEngine):
     RE(bps.mv(fake_backlight, fake_backlight.OUT))
     assert fake_backlight.led1.get() == "OFF"
 
 
-def test_when_led1_not_out_it_switches_on(fake_backlight: DualBacklight):
-    RE = RunEngine()
+def test_when_led1_not_out_it_switches_on(fake_backlight: DualBacklight, RE: RunEngine):
     RE(bps.mv(fake_backlight, "OAV2"))
     assert fake_backlight.led1.get() == "ON"
 
 
-def test_led2_independent_from_led1_position(fake_backlight: DualBacklight):
+def test_led2_independent_from_led1_position(
+    fake_backlight: DualBacklight, RE: RunEngine
+):
     fake_backlight.led2.sim_put("OFF")  # type: ignore
-    RE = RunEngine()
     RE(bps.abs_set(fake_backlight, fake_backlight.IN, wait=True))
     assert fake_backlight.led1.get() == "ON"
     assert fake_backlight.led2.get() == "OFF"

--- a/tests/devices/unit_tests/test_attenuator.py
+++ b/tests/devices/unit_tests/test_attenuator.py
@@ -35,6 +35,5 @@ def test_set_transmission_success(fake_attenuator: Attenuator):
     fake_attenuator.set(1.0).wait(1)
 
 
-def test_set_transmission_in_run_engine(fake_attenuator: Attenuator):
-    RE = RunEngine()
+def test_set_transmission_in_run_engine(fake_attenuator: Attenuator, RE: RunEngine):
     RE(bps.abs_set(fake_attenuator, 1, wait=True))

--- a/tests/devices/unit_tests/test_backlight.py
+++ b/tests/devices/unit_tests/test_backlight.py
@@ -18,13 +18,11 @@ def test_backlight_can_be_written_and_read_from(fake_backlight: Backlight):
     assert fake_backlight.pos.get() == fake_backlight.IN
 
 
-def test_when_backlight_out_it_switches_off(fake_backlight: Backlight):
-    RE = RunEngine()
+def test_when_backlight_out_it_switches_off(fake_backlight: Backlight, RE: RunEngine):
     RE(bps.mv(fake_backlight, fake_backlight.OUT))
     assert fake_backlight.toggle.get() == "Off"
 
 
-def test_when_backlight_in_it_switches_on(fake_backlight: Backlight):
-    RE = RunEngine()
+def test_when_backlight_in_it_switches_on(fake_backlight: Backlight, RE: RunEngine):
     RE(bps.mv(fake_backlight, fake_backlight.IN))
     assert fake_backlight.toggle.get() == "On"

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -76,9 +76,8 @@ def test_waits_for_running_motion(
 
 
 def run_test_on_complete_watcher(
-    fast_grid_scan: FastGridScan, num_pos_1d, put_value, expected_frac
+    RE: RunEngine, fast_grid_scan: FastGridScan, num_pos_1d, put_value, expected_frac
 ):
-    RE = RunEngine()
     RE(
         set_fast_grid_scan_params(
             fast_grid_scan,
@@ -105,15 +104,17 @@ def run_test_on_complete_watcher(
     return complete_status
 
 
-def test_when_new_image_then_complete_watcher_notified(fast_grid_scan: FastGridScan):
-    status = run_test_on_complete_watcher(fast_grid_scan, 2, 1, 3 / 4)
+def test_when_new_image_then_complete_watcher_notified(
+    fast_grid_scan: FastGridScan, RE: RunEngine
+):
+    status = run_test_on_complete_watcher(RE, fast_grid_scan, 2, 1, 3 / 4)
     discard_status(status)
 
 
 def test_given_0_expected_images_then_complete_watcher_correct(
-    fast_grid_scan: FastGridScan,
+    fast_grid_scan: FastGridScan, RE: RunEngine
 ):
-    status = run_test_on_complete_watcher(fast_grid_scan, 0, 1, 0)
+    status = run_test_on_complete_watcher(RE, fast_grid_scan, 0, 1, 0)
     discard_status(status)
 
 
@@ -136,17 +137,16 @@ def test_given_different_step_numbers_then_expected_images_correct(
 
 
 def test_given_invalid_image_number_then_complete_watcher_correct(
-    fast_grid_scan: FastGridScan,
+    fast_grid_scan: FastGridScan, RE: RunEngine
 ):
-    complete_status = run_test_on_complete_watcher(fast_grid_scan, 1, "BAD", None)
+    complete_status = run_test_on_complete_watcher(RE, fast_grid_scan, 1, "BAD", None)
     assert complete_status.exception()
 
 
 def test_running_finished_with_all_images_done_then_complete_status_finishes_not_in_error(
-    fast_grid_scan: FastGridScan,
+    fast_grid_scan: FastGridScan, RE: RunEngine
 ):
     num_pos_1d = 2
-    RE = RunEngine()
     RE(
         set_fast_grid_scan_params(
             fast_grid_scan,
@@ -370,7 +370,7 @@ def test_given_various_x_y_z_when_get_motor_positions_then_expected_positions_re
     )
 
 
-def test_can_run_fast_grid_scan_in_run_engine(fast_grid_scan):
+def test_can_run_fast_grid_scan_in_run_engine(fast_grid_scan, RE: RunEngine):
     @bpp.run_decorator()
     def kickoff_and_complete(device):
         yield from bps.kickoff(device, group="kickoff")
@@ -381,7 +381,6 @@ def test_can_run_fast_grid_scan_in_run_engine(fast_grid_scan):
         device.status.sim_put(0)
         yield from bps.wait("complete")
 
-    RE = RunEngine()
     RE(kickoff_and_complete(fast_grid_scan))
     assert RE.state == "idle"
 

--- a/tests/devices/unit_tests/test_oav.py
+++ b/tests/devices/unit_tests/test_oav.py
@@ -116,14 +116,12 @@ def test_bottom_right_from_top_left():
     assert bottom_right[0] == 198 and bottom_right[1] == 263
 
 
-def test_when_zoom_1_then_flat_field_applied(fake_oav: OAV):
-    RE = RunEngine()
+def test_when_zoom_1_then_flat_field_applied(fake_oav: OAV, RE: RunEngine):
     RE(bps.abs_set(fake_oav.zoom_controller, "1.0x"))
     assert fake_oav.snapshot.input_plugin.get() == "PROC"
 
 
-def test_when_zoom_not_1_then_flat_field_removed(fake_oav: OAV):
-    RE = RunEngine()
+def test_when_zoom_not_1_then_flat_field_removed(fake_oav: OAV, RE: RunEngine):
     RE(bps.abs_set(fake_oav.zoom_controller, "10.0x"))
     assert fake_oav.snapshot.input_plugin.get() == "CAM"
 

--- a/tests/devices/unit_tests/test_panda_gridscan.py
+++ b/tests/devices/unit_tests/test_panda_gridscan.py
@@ -61,10 +61,9 @@ def test_given_different_step_numbers_then_expected_images_correct(
 
 
 def test_running_finished_with_all_images_done_then_complete_status_finishes_not_in_error(
-    fast_grid_scan: PandAFastGridScan,
+    fast_grid_scan: PandAFastGridScan, RE: RunEngine
 ):
     num_pos_1d = 2
-    RE = RunEngine()
     RE(
         set_fast_grid_scan_params(
             fast_grid_scan,
@@ -103,12 +102,11 @@ def create_motor_bundle_with_limits(low_limit, high_limit) -> Smargon:
     return grid_scan_motor_bundle
 
 
-def test_can_run_fast_grid_scan_in_run_engine(fast_grid_scan):
+def test_can_run_fast_grid_scan_in_run_engine(fast_grid_scan, RE: RunEngine):
     @bpp.run_decorator()
     def kickoff_and_complete(device):
         yield from bps.kickoff(device)
         yield from bps.complete(device)
 
-    RE = RunEngine()
     RE(kickoff_and_complete(fast_grid_scan))
     assert RE.state == "idle"

--- a/tests/devices/unit_tests/test_xspress3mini.py
+++ b/tests/devices/unit_tests/test_xspress3mini.py
@@ -37,14 +37,12 @@ def test_arm_success_on_busy_state(fake_xspress3mini, status_finished: MagicMock
 
 
 @patch("dodal.devices.xspress3_mini.xspress3_mini.await_value")
-def test_stage_in_busy_state(mock_await_value, fake_xspress3mini):
+def test_stage_in_busy_state(mock_await_value, fake_xspress3mini, RE: RunEngine):
     fake_xspress3mini.detector_state.sim_put(DetectorState.ACQUIRE.value)  # type: ignore
     fake_xspress3mini.acquire.sim_put(0)  # type: ignore
-    RE = RunEngine()
     RE(bps.stage(fake_xspress3mini))
 
 
-def test_stage_fails_in_failed_acquire_state(fake_xspress3mini):
-    RE = RunEngine()
+def test_stage_fails_in_failed_acquire_state(fake_xspress3mini, RE: RunEngine):
     with pytest.raises(Exception):
         RE(bps.stage(fake_xspress3mini))

--- a/tests/devices/unit_tests/test_zebra.py
+++ b/tests/devices/unit_tests/test_zebra.py
@@ -18,8 +18,7 @@ from dodal.devices.zebra import (
 )
 
 
-async def test_arming_device():
-    RunEngine()
+async def test_arming_device(RE: RunEngine):
     arming_device = ArmingDevice("", name="fake arming device")
     await arming_device.connect(sim=True)
     status = arming_device.set(ArmDemand.DISARM)
@@ -28,8 +27,7 @@ async def test_arming_device():
     assert await arming_device.disarm_set.get_value() == 1
 
 
-async def test_position_compare_sets_signals():
-    RunEngine()
+async def test_position_compare_sets_signals(RE: RunEngine):
     fake_pc = PositionCompare("", name="fake position compare")
     await fake_pc.connect(sim=True)
 
@@ -95,12 +93,8 @@ def test_logic_gate_configuration_62_and_34_inv_and_15_inv():
 
 
 async def run_configurer_test(
-    gate_type: GateType,
-    gate_num,
-    config,
-    expected_pv_values,
+    gate_type: GateType, gate_num, config, expected_pv_values
 ):
-    RunEngine()
     configurer = LogicGateConfigurer(prefix="", name="test fake logicconfigurer")
     await configurer.connect(sim=True)
 

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -176,10 +176,8 @@ async def test_extraction_plan(mocked_zocalo_device, RE) -> None:
 )
 @patch("dodal.devices.zocalo.zocalo_results._get_zocalo_connection", autospec=True)
 async def test_subscribe_only_on_called_stage(
-    mock_connection: MagicMock,
-    mock_wrap_subscribe: MagicMock,
+    mock_connection: MagicMock, mock_wrap_subscribe: MagicMock, RE: RunEngine
 ):
-    RE = RunEngine()
     zocalo_results = ZocaloResults(
         name="zocalo", zocalo_environment="dev_artemis", timeout_s=2
     )
@@ -198,9 +196,8 @@ async def test_subscribe_only_on_called_stage(
 
 @patch("dodal.devices.zocalo.zocalo_results._get_zocalo_connection", autospec=True)
 async def test_when_exception_caused_by_zocalo_message_then_exception_propagated(
-    mock_connection,
+    mock_connection, RE: RunEngine
 ):
-    RE = RunEngine()
     zocalo_results = ZocaloResults(
         name="zocalo", zocalo_environment="dev_artemis", timeout_s=0.1
     )

--- a/tests/plans/test_topup_plan.py
+++ b/tests/plans/test_topup_plan.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import bluesky.plan_stubs as bps
 import pytest
+from bluesky.run_engine import RunEngine
 from ophyd_async.core import set_sim_value
 
 from dodal.beamlines import i03
@@ -20,7 +21,7 @@ def synchrotron() -> Synchrotron:
 @patch("dodal.plans.check_topup.wait_for_topup_complete")
 @patch("dodal.plans.check_topup.bps.sleep")
 def test_when_topup_before_end_of_collection_wait(
-    fake_sleep, fake_wait, synchrotron: Synchrotron, RE
+    fake_sleep: MagicMock, fake_wait: MagicMock, synchrotron: Synchrotron, RE: RunEngine
 ):
     set_sim_value(synchrotron.synchrotron_mode, SynchrotronMode.USER)
     set_sim_value(synchrotron.topup_start_countdown, 20.0)
@@ -38,7 +39,9 @@ def test_when_topup_before_end_of_collection_wait(
 
 @patch("dodal.plans.check_topup.bps.rd")
 @patch("dodal.plans.check_topup.bps.sleep")
-def test_wait_for_topup_complete(fake_sleep, fake_rd, synchrotron, RE):
+def test_wait_for_topup_complete(
+    fake_sleep: MagicMock, fake_rd: MagicMock, synchrotron: Synchrotron, RE: RunEngine
+):
     def fake_generator(value):
         yield from bps.null()
         return value
@@ -58,7 +61,9 @@ def test_wait_for_topup_complete(fake_sleep, fake_rd, synchrotron, RE):
 
 @patch("dodal.plans.check_topup.bps.sleep")
 @patch("dodal.plans.check_topup.bps.null")
-def test_no_waiting_if_decay_mode(fake_null, fake_sleep, synchrotron: Synchrotron, RE):
+def test_no_waiting_if_decay_mode(
+    fake_null: MagicMock, fake_sleep: MagicMock, synchrotron: Synchrotron, RE: RunEngine
+):
     set_sim_value(synchrotron.topup_start_countdown, -1)
 
     RE(
@@ -74,7 +79,7 @@ def test_no_waiting_if_decay_mode(fake_null, fake_sleep, synchrotron: Synchrotro
 
 @patch("dodal.plans.check_topup.bps.null")
 def test_no_waiting_when_mode_does_not_allow_gating(
-    fake_null, synchrotron: Synchrotron, RE
+    fake_null: MagicMock, synchrotron: Synchrotron, RE: RunEngine
 ):
     set_sim_value(synchrotron.topup_start_countdown, 1.0)
     set_sim_value(synchrotron.synchrotron_mode, SynchrotronMode.SHUTDOWN)

--- a/tests/plans/test_topup_plan.py
+++ b/tests/plans/test_topup_plan.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import bluesky.plan_stubs as bps
 import pytest
-from bluesky.run_engine import RunEngine
 from ophyd_async.core import set_sim_value
 
 from dodal.beamlines import i03
@@ -21,13 +20,12 @@ def synchrotron() -> Synchrotron:
 @patch("dodal.plans.check_topup.wait_for_topup_complete")
 @patch("dodal.plans.check_topup.bps.sleep")
 def test_when_topup_before_end_of_collection_wait(
-    fake_sleep, fake_wait, synchrotron: Synchrotron
+    fake_sleep, fake_wait, synchrotron: Synchrotron, RE
 ):
     set_sim_value(synchrotron.synchrotron_mode, SynchrotronMode.USER)
     set_sim_value(synchrotron.topup_start_countdown, 20.0)
     set_sim_value(synchrotron.top_up_end_countdown, 60.0)
 
-    RE = RunEngine()
     RE(
         check_topup_and_wait_if_necessary(
             synchrotron=synchrotron,
@@ -40,7 +38,7 @@ def test_when_topup_before_end_of_collection_wait(
 
 @patch("dodal.plans.check_topup.bps.rd")
 @patch("dodal.plans.check_topup.bps.sleep")
-def test_wait_for_topup_complete(fake_sleep, fake_rd, synchrotron):
+def test_wait_for_topup_complete(fake_sleep, fake_rd, synchrotron, RE):
     def fake_generator(value):
         yield from bps.null()
         return value
@@ -52,7 +50,6 @@ def test_wait_for_topup_complete(fake_sleep, fake_rd, synchrotron):
         fake_generator(10.0),
     ]
 
-    RE = RunEngine()
     RE(wait_for_topup_complete(synchrotron))
 
     assert fake_sleep.call_count == 3
@@ -61,10 +58,9 @@ def test_wait_for_topup_complete(fake_sleep, fake_rd, synchrotron):
 
 @patch("dodal.plans.check_topup.bps.sleep")
 @patch("dodal.plans.check_topup.bps.null")
-def test_no_waiting_if_decay_mode(fake_null, fake_sleep, synchrotron: Synchrotron):
+def test_no_waiting_if_decay_mode(fake_null, fake_sleep, synchrotron: Synchrotron, RE):
     set_sim_value(synchrotron.topup_start_countdown, -1)
 
-    RE = RunEngine()
     RE(
         check_topup_and_wait_if_necessary(
             synchrotron=synchrotron,
@@ -78,12 +74,11 @@ def test_no_waiting_if_decay_mode(fake_null, fake_sleep, synchrotron: Synchrotro
 
 @patch("dodal.plans.check_topup.bps.null")
 def test_no_waiting_when_mode_does_not_allow_gating(
-    fake_null, synchrotron: Synchrotron
+    fake_null, synchrotron: Synchrotron, RE
 ):
     set_sim_value(synchrotron.topup_start_countdown, 1.0)
     set_sim_value(synchrotron.synchrotron_mode, SynchrotronMode.SHUTDOWN)
 
-    RE = RunEngine()
     RE(
         check_topup_and_wait_if_necessary(
             synchrotron=synchrotron,


### PR DESCRIPTION
Fixes #414 
Ensures the RunEngine fixture is established before it can be used in tests, also replaces independently created REs in tests with this fixture

### Instructions to reviewer on how to test:
1. Run tests a bunch of times, I guess

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)