### PR TITLE
Move Diamond implementation of DirectoryProvider into dodal

### DIFF
--- a/src/dodal/beamlines/beamline_utils.py
+++ b/src/dodal/beamlines/beamline_utils.py
@@ -1,12 +1,10 @@
 import inspect
-import tempfile
 from typing import Callable, Dict, Final, List, Optional, TypeVar, cast
 
 from bluesky.run_engine import call_in_bluesky_event_loop
 from ophyd import Device as OphydV1Device
 from ophyd.sim import make_fake_device
 from ophyd_async.core import Device as OphydV2Device
-from ophyd_async.core import DirectoryProvider, StaticDirectoryProvider
 from ophyd_async.core import wait_for_connection as v2_device_wait_for_connection
 
 from dodal.utils import AnyDevice, BeamlinePrefix, skip_device
@@ -15,7 +13,6 @@ DEFAULT_CONNECTION_TIMEOUT: Final[float] = 5.0
 
 ACTIVE_DEVICES: Dict[str, AnyDevice] = {}
 BL = ""
-DIRECTORY_PROVIDER: DirectoryProvider | None = None
 
 
 def set_beamline(beamline: str):
@@ -124,17 +121,3 @@ def device_instantiation(
     if post_create:
         post_create(device_instance)
     return device_instance
-
-
-def set_directory_provider(provider: DirectoryProvider):
-    global DIRECTORY_PROVIDER
-
-    DIRECTORY_PROVIDER = provider
-
-
-def get_directory_provider() -> DirectoryProvider:
-    if DIRECTORY_PROVIDER is None:
-        set_directory_provider(
-            StaticDirectoryProvider(tempfile.NamedTemporaryFile().name, "")
-        )
-    return DIRECTORY_PROVIDER

--- a/src/dodal/beamlines/beamline_utils.py
+++ b/src/dodal/beamlines/beamline_utils.py
@@ -7,12 +7,14 @@ from ophyd.sim import make_fake_device
 from ophyd_async.core import Device as OphydV2Device
 from ophyd_async.core import wait_for_connection as v2_device_wait_for_connection
 
+from dodal.common.types import UpdatingDirectoryProvider
 from dodal.utils import AnyDevice, BeamlinePrefix, skip_device
 
 DEFAULT_CONNECTION_TIMEOUT: Final[float] = 5.0
 
 ACTIVE_DEVICES: Dict[str, AnyDevice] = {}
 BL = ""
+DIRECTORY_PROVIDER: UpdatingDirectoryProvider | None = None
 
 
 def set_beamline(beamline: str):
@@ -121,3 +123,17 @@ def device_instantiation(
     if post_create:
         post_create(device_instance)
     return device_instance
+
+
+def set_directory_provider(provider: UpdatingDirectoryProvider):
+    global DIRECTORY_PROVIDER
+
+    DIRECTORY_PROVIDER = provider
+
+
+def get_directory_provider() -> UpdatingDirectoryProvider:
+    if DIRECTORY_PROVIDER is None:
+        raise ValueError(
+            "DirectoryProvider has not been set! Ophyd-async StandardDetectors will not be able to write!"
+        )
+    return DIRECTORY_PROVIDER

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,8 +1,8 @@
-from functools import lru_cache
-
-from ophyd_async.core import DirectoryProvider
-
-from dodal.beamlines.beamline_utils import device_instantiation
+from dodal.beamlines.beamline_utils import (
+    device_instantiation,
+    get_directory_provider,
+    set_directory_provider,
+)
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.visit import StaticVisitDirectoryProvider
 from dodal.devices.tetramm import TetrammDetector
@@ -12,17 +12,15 @@ from dodal.utils import get_beamline_name
 BL = get_beamline_name("i22")
 set_log_beamline(BL)
 set_utils_beamline(BL)
-
-
-@lru_cache
-def get_directory_provider() -> DirectoryProvider:
-    """VISIT is a placeholder value for reference.
+"""VISIT is a placeholder value for reference.
     Requires that all StandardDetector IOCs are running with /data mapping to /dls/i22/data
     """
-    return StaticVisitDirectoryProvider(
+set_directory_provider(
+    StaticVisitDirectoryProvider(
         BL,
         "/data/i22/2024/VISIT",
     )
+)
 
 
 def i0(

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,5 +1,10 @@
-from dodal.beamlines.beamline_utils import device_instantiation, get_directory_provider
+from functools import lru_cache
+
+from ophyd_async.core import DirectoryProvider
+
+from dodal.beamlines.beamline_utils import device_instantiation
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.visit import StaticVisitDirectoryProvider
 from dodal.devices.tetramm import TetrammDetector
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import get_beamline_name
@@ -7,6 +12,17 @@ from dodal.utils import get_beamline_name
 BL = get_beamline_name("i22")
 set_log_beamline(BL)
 set_utils_beamline(BL)
+
+
+@lru_cache
+def get_directory_provider() -> DirectoryProvider:
+    """VISIT is a placeholder value for reference.
+    Requires that all StandardDetector IOCs are running with /data mapping to /dls/i22/data
+    """
+    return StaticVisitDirectoryProvider(
+        BL,
+        "/data/i22/2024/VISIT",
+    )
 
 
 def i0(

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -1,8 +1,8 @@
-from functools import lru_cache
-
-from ophyd_async.core import DirectoryProvider
-
-from dodal.beamlines.beamline_utils import device_instantiation
+from dodal.beamlines.beamline_utils import (
+    device_instantiation,
+    get_directory_provider,
+    set_directory_provider,
+)
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.visit import StaticVisitDirectoryProvider
 from dodal.devices.areadetector import AdAravisDetector
@@ -13,14 +13,12 @@ from dodal.utils import get_beamline_name
 BL = get_beamline_name("p38")
 set_log_beamline(BL)
 set_utils_beamline(BL)
-
-
-@lru_cache
-def get_directory_provider() -> DirectoryProvider:
-    return StaticVisitDirectoryProvider(
+set_directory_provider(
+    StaticVisitDirectoryProvider(
         BL,
         "/data/2024/cm37282-2/",  # latest commissioning visit
     )
+)
 
 
 def d11(

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -1,5 +1,10 @@
-from dodal.beamlines.beamline_utils import device_instantiation, get_directory_provider
+from functools import lru_cache
+
+from ophyd_async.core import DirectoryProvider
+
+from dodal.beamlines.beamline_utils import device_instantiation
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.visit import StaticVisitDirectoryProvider
 from dodal.devices.areadetector import AdAravisDetector
 from dodal.devices.tetramm import TetrammDetector
 from dodal.log import set_beamline as set_log_beamline
@@ -8,6 +13,14 @@ from dodal.utils import get_beamline_name
 BL = get_beamline_name("p38")
 set_log_beamline(BL)
 set_utils_beamline(BL)
+
+
+@lru_cache
+def get_directory_provider() -> DirectoryProvider:
+    return StaticVisitDirectoryProvider(
+        BL,
+        "/data/2024/cm37282-2/",  # latest commissioning visit
+    )
 
 
 def d11(

--- a/src/dodal/beamlines/p45.py
+++ b/src/dodal/beamlines/p45.py
@@ -1,5 +1,10 @@
+from functools import lru_cache
+
+from ophyd_async.core import DirectoryProvider
+
 from dodal.beamlines.beamline_utils import device_instantiation
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.visit import StaticVisitDirectoryProvider
 from dodal.devices.areadetector import AdAravisDetector
 from dodal.devices.p45 import Choppers, TomoStageWithStretchAndSkew
 from dodal.log import set_beamline as set_log_beamline
@@ -8,6 +13,14 @@ from dodal.utils import get_beamline_name
 BL = get_beamline_name("p45")
 set_log_beamline(BL)
 set_utils_beamline(BL)
+
+
+@lru_cache
+def get_directory_provider() -> DirectoryProvider:
+    return StaticVisitDirectoryProvider(
+        BL,
+        "/data/2024/cm37283-2/",  # latest commissioning visit
+    )
 
 
 def sample(

--- a/src/dodal/beamlines/p45.py
+++ b/src/dodal/beamlines/p45.py
@@ -1,8 +1,4 @@
-from functools import lru_cache
-
-from ophyd_async.core import DirectoryProvider
-
-from dodal.beamlines.beamline_utils import device_instantiation
+from dodal.beamlines.beamline_utils import device_instantiation, set_directory_provider
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.visit import StaticVisitDirectoryProvider
 from dodal.devices.areadetector import AdAravisDetector
@@ -13,14 +9,12 @@ from dodal.utils import get_beamline_name
 BL = get_beamline_name("p45")
 set_log_beamline(BL)
 set_utils_beamline(BL)
-
-
-@lru_cache
-def get_directory_provider() -> DirectoryProvider:
-    return StaticVisitDirectoryProvider(
+set_directory_provider(
+    StaticVisitDirectoryProvider(
         BL,
         "/data/2024/cm37283-2/",  # latest commissioning visit
     )
+)
 
 
 def sample(

--- a/src/dodal/common/types.py
+++ b/src/dodal/common/types.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import (
     Any,
     Callable,
@@ -5,6 +6,7 @@ from typing import (
 )
 
 from bluesky.utils import Msg
+from ophyd_async.core import DirectoryProvider
 
 # String identifier used by 'wait' or stubs that await
 Group = str
@@ -12,3 +14,9 @@ Group = str
 MsgGenerator = Generator[Msg, Any, None]
 # A function that generates a plan
 PlanGenerator = Callable[..., MsgGenerator]
+
+
+class UpdatingDirectoryProvider(DirectoryProvider, ABC):
+    @abstractmethod
+    def update(self) -> None:
+        ...

--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -1,0 +1,157 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from aiohttp import ClientSession
+from ophyd_async.core import DirectoryInfo, DirectoryProvider
+from pydantic import BaseModel
+
+from dodal.log import LOGGER
+
+"""
+Functionality required for/from the API of a DirectoryService which exposes the specifics of the Diamond filesystem.
+"""
+
+
+class DataCollectionIdentifier(BaseModel):
+    """
+    Equivalent to a `Scan Number` or `scan_id`, non-globally unique scan identifier.
+    Should be always incrementing, unique per-visit, co-ordinated with any other scan engines.
+    """
+
+    collectionNumber: int
+
+
+class DirectoryServiceClientBase(ABC):
+    """
+    Object responsible for I/O in determining collection number
+    """
+
+    @abstractmethod
+    async def create_new_collection(self) -> DataCollectionIdentifier:
+        """Create new collection"""
+
+    @abstractmethod
+    async def get_current_collection(self) -> DataCollectionIdentifier:
+        """Get current collection"""
+
+
+class DirectoryServiceClient(DirectoryServiceClientBase):
+    """Client for the VisitService REST API
+    Currently exposed by the GDA Server to co-ordinate unique filenames.
+    While VisitService is embedded in GDA, url is likely to be `ixx-control:8088/api`
+    """
+
+    _url: str
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    async def create_new_collection(self) -> DataCollectionIdentifier:
+        async with ClientSession() as session:
+            async with session.post(f"{self._url}/numtracker") as response:
+                if response.status == 200:
+                    json = await response.json()
+                    new_collection = DataCollectionIdentifier.parse_obj(json)
+                    LOGGER.debug("New DataCollection: %s", new_collection)
+                    return new_collection
+                else:
+                    raise Exception(response.status)
+
+    async def get_current_collection(self) -> DataCollectionIdentifier:
+        async with ClientSession() as session:
+            async with session.get(f"{self._url}/numtracker") as response:
+                if response.status == 200:
+                    json = await response.json()
+                    current_collection = DataCollectionIdentifier.parse_obj(json)
+                    LOGGER.debug("Current DataCollection: %s", current_collection)
+                    return current_collection
+                else:
+                    raise Exception(response.status)
+
+
+class LocalDirectoryServiceClient(DirectoryServiceClientBase):
+    """Local or dummy impl of VisitService client to co-ordinate unique filenames."""
+
+    _count: int
+
+    def __init__(self) -> None:
+        self._count = 0
+
+    async def create_new_collection(self) -> DataCollectionIdentifier:
+        self._count += 1
+        LOGGER.debug("New DataCollection: %s", self._count)
+        return DataCollectionIdentifier(collectionNumber=self._count)
+
+    async def get_current_collection(self) -> DataCollectionIdentifier:
+        LOGGER.debug("Current DataCollection: %s", self._count)
+        return DataCollectionIdentifier(collectionNumber=self._count)
+
+
+class StaticVisitDirectoryProvider(DirectoryProvider):
+    """
+    Static (single visit) implementation of DirectoryProvider whilst awaiting auth infrastructure to generate necessary information per-scan.
+    Allows setting a singular visit into which all run files will be saved.
+    update() queries a visit service to get the next DataCollectionIdentifier to increment the suffix of all file writers' next files.
+    Requires that all detectors are running with a mutual view on the filesystem.
+    Supports a single Visit which should be passed as a Path relative to the root of the Detector IOC mounting.
+    i.e. to write to visit /dls/ixx/data/YYYY/cm12345-1, assuming all detectors are mounted with /data -> /dls/ixx/data, root=/data/YYYY/cm12345-1/
+    """
+
+    _beamline: str
+    _root: Path
+    _client: DirectoryServiceClientBase
+    _current_collection: DirectoryInfo | None
+    _session: ClientSession | None
+
+    def __init__(
+        self,
+        beamline: str,
+        root: Path,
+        client: Optional[DirectoryServiceClientBase] = None,
+    ):
+        self._beamline = beamline
+        self._client = client or DirectoryServiceClient(f"{beamline}-control:8088/api")
+        self._root = root
+        self._current_collection = None
+        self._session = None
+
+    async def update(self) -> None:
+        """
+        Creates a new data collection in the current visit.
+        """
+        # https://github.com/DiamondLightSource/dodal/issues/452
+        # TODO: Allow selecting visit as part of a request
+        # TODO: DAQ-4827: Pass AuthN information as part of request
+
+        try:
+            collection_id_info = await self._client.create_new_collection()
+            self._current_collection = self._generate_directory_info(collection_id_info)
+        except Exception:
+            LOGGER.error(
+                "Exception while updating data collection, preventing overwriting data by setting current_collection to None"
+            )
+            self._current_collection = None
+            raise
+
+    def _generate_directory_info(
+        self,
+        collection_id_info: DataCollectionIdentifier,
+    ) -> DirectoryInfo:
+        return DirectoryInfo(
+            # See DocString of DirectoryInfo. At DLS, root = visit directory, resource_dir is relative to it.
+            root=self._root,
+            # https://github.com/DiamondLightSource/dodal/issues/452
+            # Currently all h5 files written to visit/ directory, as no guarantee that visit/dataCollection/ directory will have been produced. If it is as part of #452, append the resource_dir
+            resource_dir=Path("."),
+            # Diamond standard file naming
+            prefix=f"{self._beamline}-{collection_id_info.collectionNumber}",
+        )
+
+    def __call__(self) -> DirectoryInfo:
+        if self._current_collection is not None:
+            return self._current_collection
+        else:
+            raise ValueError(
+                "No current collection, update() needs to be called at least once"
+            )

--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -50,24 +50,20 @@ class DirectoryServiceClient(DirectoryServiceClientBase):
     async def create_new_collection(self) -> DataCollectionIdentifier:
         async with ClientSession() as session:
             async with session.post(f"{self._url}/numtracker") as response:
-                if response.status == 200:
-                    json = await response.json()
-                    new_collection = DataCollectionIdentifier.parse_obj(json)
-                    LOGGER.debug("New DataCollection: %s", new_collection)
-                    return new_collection
-                else:
-                    raise Exception(response.status)
+                response.raise_for_status()
+                json = await response.json()
+                new_collection = DataCollectionIdentifier.parse_obj(json)
+                LOGGER.debug("New DataCollection: %s", new_collection)
+                return new_collection
 
     async def get_current_collection(self) -> DataCollectionIdentifier:
         async with ClientSession() as session:
             async with session.get(f"{self._url}/numtracker") as response:
-                if response.status == 200:
-                    json = await response.json()
-                    current_collection = DataCollectionIdentifier.parse_obj(json)
-                    LOGGER.debug("Current DataCollection: %s", current_collection)
-                    return current_collection
-                else:
-                    raise Exception(response.status)
+                response.raise_for_status()
+                json = await response.json()
+                current_collection = DataCollectionIdentifier.parse_obj(json)
+                LOGGER.debug("Current DataCollection: %s", current_collection)
+                return current_collection
 
 
 class LocalDirectoryServiceClient(DirectoryServiceClientBase):

--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -146,7 +146,7 @@ class StaticVisitDirectoryProvider(UpdatingDirectoryProvider):
             # Currently all h5 files written to visit/ directory, as no guarantee that visit/dataCollection/ directory will have been produced. If it is as part of #452, append the resource_dir
             resource_dir=Path("."),
             # Diamond standard file naming
-            prefix=f"{self._beamline}-{collection_id_info.collectionNumber}",
+            prefix=f"{self._beamline}-{collection_id_info.collectionNumber}-",
         )
 
     def __call__(self) -> DirectoryInfo:

--- a/tests/beamlines/unit_tests/test_beamline_utils.py
+++ b/tests/beamlines/unit_tests/test_beamline_utils.py
@@ -119,23 +119,3 @@ def test_wait_for_v2_device_connection_passes_through_timeout(
         sim=ANY,
         timeout=expected_timeout,
     )
-
-
-def test_default_directory_provider_is_singleton():
-    provider1 = beamline_utils.get_directory_provider()
-    provider2 = beamline_utils.get_directory_provider()
-    assert provider1 is provider2
-
-
-def test_set_directory_provider_is_singleton():
-    beamline_utils.set_directory_provider(lambda: "")
-    provider1 = beamline_utils.get_directory_provider()
-    provider2 = beamline_utils.get_directory_provider()
-    assert provider1 is provider2
-
-
-def test_set_overrides_singleton():
-    provider1 = beamline_utils.get_directory_provider()
-    beamline_utils.set_directory_provider(lambda: "")
-    provider2 = beamline_utils.get_directory_provider()
-    assert provider1 is not provider2


### PR DESCRIPTION
Refactor to remove use of globals, make per-beamline, rename to make explicit that current impl is partial one-visit-static implementation. 

As the naming scheme is Diamond specific, and is used in instantiating devices, belongs in dodal
Closes #305 

### Instructions to reviewer on how to test:
1. Run up a (sim) ophyd_async StandardDetector
2. Ensure tries to write data to correct location

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)