### PR TITLE
Update default Graylog address and port, and allow passing in port

### DIFF
--- a/docs/user/tutorials/get_started.rst
+++ b/docs/user/tutorials/get_started.rst
@@ -49,4 +49,4 @@ If you would like to only log to graylog/file exlusively there are helper functi
 
 .. _ophyd: https://nsls-ii.github.io/ophyd/
 .. _bluesky: https://blueskyproject.io/bluesky/
-.. _graylog: https://graylog2.diamond.ac.uk/search
+.. _graylog: https://graylog-log-target.diamond.ac.uk/search

--- a/src/dodal/log.py
+++ b/src/dodal/log.py
@@ -173,6 +173,8 @@ def set_up_all_logging_handlers(
                                 production. Defaults to False.
         error_log_buffer_lines: Number of lines for the CircularMemoryHandler to keep in
                                 buffer and write to file when encountering an error message.
+        graylog_port:           The port to send graylog messages to, if None uses the
+                                default dodal port
     Returns:
         A DodaLogHandlers TypedDict with the created handlers.
     """

--- a/tests/unit_tests/test_log.py
+++ b/tests/unit_tests/test_log.py
@@ -68,7 +68,9 @@ def test_prod_mode_sets_correct_graypy_handler(
 ):
     mock_GELFTCPHandler.return_value.level = logging.INFO
     set_up_all_logging_handlers(mock_logger, Path("tmp/dev"), "dodal.log", False, 10000)
-    mock_GELFTCPHandler.assert_called_once_with("graylog2.diamond.ac.uk", 12218)
+    mock_GELFTCPHandler.assert_called_once_with(
+        "graylog-log-target.diamond.ac.uk", 12231
+    )
 
 
 @patch("dodal.log.GELFTCPHandler", autospec=True)
@@ -119,7 +121,9 @@ def test_messages_logged_from_dodal_get_sent_to_graylog_and_file(
     LOGGER.info("test")
     mock_GELFTCPHandler = handlers["graylog_handler"]
     assert mock_GELFTCPHandler is not None
-    mock_graylog_handler_class.assert_called_once_with("graylog2.diamond.ac.uk", 12218)
+    mock_graylog_handler_class.assert_called_once_with(
+        "graylog-log-target.diamond.ac.uk", 12231
+    )
     mock_GELFTCPHandler.handle.assert_called()
     mock_filehandler_emit.assert_called()
 


### PR DESCRIPTION
For Hyperion #801

### Instructions to reviewer on how to test:
Run:
```python
from dodal.log import LOGGER, do_default_logging_setup
do_default_logging_setup()
LOGGER.info("hello world")
```
and see the message appears in the dodal graylog stream: https://graylog.diamond.ac.uk/streams/662655e6b17cec581f3cf46d/search

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes