### PR TITLE
Import new HDFPanda from ophyd-async 

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,3 +1,5 @@
+from ophyd_async.panda import HDFPanda
+
 from dodal.beamlines.beamline_utils import (
     device_instantiation,
     get_directory_provider,
@@ -9,7 +11,7 @@ from dodal.devices.i22.fswitch import FSwitch
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name
+from dodal.utils import get_beamline_name, skip_device
 
 from ._device_helpers import numbered_slits
 from .beamline_utils import device_instantiation, get_directory_provider
@@ -131,6 +133,65 @@ def fswitch(
         FSwitch,
         "fswitch",
         "-MO-FSWT-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+    )
+
+
+# Must find which PandA IOC(s) are compatible
+# Must document what PandAs are physically connected to
+# See: https://github.com/bluesky/ophyd-async/issues/284
+@skip_device
+def panda1(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda1",
+        "-MO-PANDA-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+    )
+
+
+@skip_device
+def panda2(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda2",
+        "-MO-PANDA-02:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+    )
+
+
+@skip_device
+def panda3(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda3",
+        "-MO-PANDA-03:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+    )
+
+
+@skip_device
+def panda4(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda4",
+        "-MO-PANDA-04:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -1,3 +1,5 @@
+from ophyd_async.panda import HDFPanda
+
 from dodal.beamlines.beamline_utils import (
     device_instantiation,
     get_directory_provider,
@@ -9,7 +11,7 @@ from dodal.devices.areadetector import AdAravisDetector
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name
+from dodal.utils import get_beamline_name, skip_device
 
 from ._device_helpers import numbered_slits
 from .beamline_utils import device_instantiation, get_directory_provider
@@ -136,4 +138,52 @@ def slits_6(
         6,
         wait_for_connection,
         fake_with_ophyd_sim,
+    )
+
+
+# Must find which PandA IOC(s) are compatible
+# Must document what PandAs are physically connected to
+# See: https://github.com/bluesky/ophyd-async/issues/284
+@skip_device
+def panda1(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda1",
+        "-MO-PANDA-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
+    )
+
+
+@skip_device
+def panda2(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda2",
+        "-MO-PANDA-02:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
+    )
+
+
+@skip_device
+def panda3(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda3",
+        "-MO-PANDA-03:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
     )

--- a/src/dodal/beamlines/p45.py
+++ b/src/dodal/beamlines/p45.py
@@ -1,10 +1,16 @@
-from dodal.beamlines.beamline_utils import device_instantiation, set_directory_provider
+from ophyd_async.panda import HDFPanda
+
+from dodal.beamlines.beamline_utils import (
+    device_instantiation,
+    get_directory_provider,
+    set_directory_provider,
+)
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.visit import StaticVisitDirectoryProvider
 from dodal.devices.areadetector import AdAravisDetector
 from dodal.devices.p45 import Choppers, TomoStageWithStretchAndSkew
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name
+from dodal.utils import get_beamline_name, skip_device
 
 BL = get_beamline_name("p45")
 set_log_beamline(BL)
@@ -62,4 +68,37 @@ def diff(
         "-EA-DIFF-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+    )
+
+
+# Must find which PandA IOC(s) are compatible
+# Must document what PandAs are physically connected to
+# See: https://github.com/bluesky/ophyd-async/issues/284
+@skip_device
+def panda1(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda1",
+        "-MO-PANDA-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
+    )
+
+
+@skip_device
+def panda2(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> HDFPanda:
+    return device_instantiation(
+        HDFPanda,
+        "panda2",
+        "-MO-PANDA-02:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
     )


### PR DESCRIPTION
Fixes #464 

With the new addition of the Standard Detector Panda and aravis in ophyd-async, these now need to be added to the relevant beamline modules. Included are: p45, p38, i22.

i03's existing PandA has been converted already

### Instructions to reviewer on how to test:
1. Mount new versions on p45
2. Confirm a simple collect-plan will work.