### PR TITLE
Replace black with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,23 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
       - id: check-merge-conflict
 
-  # Automatic source code formatting
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        args: [--safe, --quiet]
-        files: \.pyi?
-        types: [file]
-
   - repo: local
     hooks:
       - id: ruff
-        name: Run ruff
-        stages: [commit]
+        name: lint with ruff
         language: system
-        entry: ruff
+        entry: ruff check --force-exclude
         types: [python]
+        require_serial: true
 
-  # Re-enable after https://github.com/DiamondLightSource/dodal/issues/311
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.7.1
-  #   hooks:
-  #     - id: mypy
-  #       files: 'src/.*\.py$'
-  #       additional_dependencies: [types-requests, pydantic]
-  #       args: ["--ignore-missing-imports", "--show-traceback", "--no-strict-optional"]
+      - id: ruff-format
+        name: format with ruff
+        language: system
+        entry: ruff format --force-exclude
+        types: [python]
+        require_serial: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,6 @@ inheritance_graph_attrs = {"rankdir": "TB"}
 # Common links that should be available on every page
 rst_epilog = """
 .. _Diamond Light Source: http://www.diamond.ac.uk
-.. _black: https://github.com/psf/black
 .. _ruff: https://beta.ruff.rs/docs/
 .. _mypy: http://mypy-lang.org/
 .. _pre-commit: https://pre-commit.com/

--- a/docs/developer/how-to/lint.rst
+++ b/docs/developer/how-to/lint.rst
@@ -1,7 +1,7 @@
 Run linting using pre-commit
 ============================
 
-Code linting is handled by black_ and ruff_ run under pre-commit_.
+Code linting is handled by ruff_ run under pre-commit_.
 
 Running pre-commit
 ------------------
@@ -21,19 +21,14 @@ This will result in pre-commits being enabled on every repo your user clones fro
 Fixing issues
 -------------
 
-If black reports an issue you can tell it to reformat all the files in the
+If ruff reports an issue you can tell it to reformat all the files in the
 repository::
 
-    $ black .
-
-Likewise with ruff::
-
-    $ ruff --fix .
+    $ ruff check --fix .
 
 Ruff may not be able to automatically fix all issues; in this case, you will have to fix those manually.
 
 VSCode support
 --------------
 
-The ``.vscode/settings.json`` will run black formatting as well as
-ruff checking on save. Issues will be highlighted in the editor window.
+The ``.vscode/settings.json`` will run formatting as well as ruff checking on save. Issues will be highlighted in the editor window.

--- a/docs/developer/reference/standards.rst
+++ b/docs/developer/reference/standards.rst
@@ -9,8 +9,7 @@ Code Standards
 
 The code in this repository conforms to standards set by the following tools:
 
-- black_ for code formatting
-- ruff_ for style checks
+- ruff_ for style checks and code formatting
 - mypy_ for static type checking
 
 .. seealso::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [
-    "black",
     "mypy",
     "mockito",
     "pipdeptree",

--- a/src/dodal/common/types.py
+++ b/src/dodal/common/types.py
@@ -18,5 +18,4 @@ PlanGenerator = Callable[..., MsgGenerator]
 
 class UpdatingDirectoryProvider(DirectoryProvider, ABC):
     @abstractmethod
-    def update(self) -> None:
-        ...
+    def update(self) -> None: ...

--- a/tests/devices/unit_tests/test_focusing_mirror.py
+++ b/tests/devices/unit_tests/test_focusing_mirror.py
@@ -63,9 +63,7 @@ def vfm_mirror_voltages_with_set_timing_out(vfm_mirror_voltages) -> VFMMirrorVol
 def test_mirror_set_voltage_sets_and_waits_happy_path(
     vfm_mirror_voltages_with_set: VFMMirrorVoltages,
 ):
-    vfm_mirror_voltages_with_set._channel14_voltage_device._setpoint_v.set.return_value = (
-        NullStatus()
-    )
+    vfm_mirror_voltages_with_set._channel14_voltage_device._setpoint_v.set.return_value = NullStatus()
     vfm_mirror_voltages_with_set._channel14_voltage_device._demand_accepted.sim_put(
         MirrorVoltageDemand.OK
     )
@@ -103,9 +101,7 @@ def test_mirror_set_voltage_sets_and_waits_set_fail(
 def test_mirror_set_voltage_sets_and_waits_settle_timeout_expires(
     vfm_mirror_voltages_with_set_timing_out: VFMMirrorVoltages,
 ):
-    vfm_mirror_voltages_with_set_timing_out._channel14_voltage_device._setpoint_v.set.return_value = (
-        NullStatus()
-    )
+    vfm_mirror_voltages_with_set_timing_out._channel14_voltage_device._setpoint_v.set.return_value = NullStatus()
 
     status: StatusBase = vfm_mirror_voltages_with_set_timing_out.voltage_channels[
         0


### PR DESCRIPTION
Closes #311 

CI was starting to fail due to minor disagreements between black and ruff. This PR switches to the ruff formatter as standard like the copier template: https://github.com/DiamondLightSource/python-copier-template/blob/main/.pre-commit-config.yaml

### Instructions to reviewer on how to test:
1. Ensure CI passes
2. Optional: rebase into #461 and see if it fixes CI

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)