### PR TITLE
Remove Staging of Slits in Tests

### DIFF
--- a/tests/devices/unit_tests/test_slits.py
+++ b/tests/devices/unit_tests/test_slits.py
@@ -51,8 +51,6 @@ async def assert_reading(
     device: StandardReadable,
     expected_reading: Mapping[str, Any],
 ) -> None:
-    await device.stage()
     reading = await device.read()
-    await device.unstage()
 
     assert reading == expected_reading


### PR DESCRIPTION
It is not necessary to stage a `StandardReadable` in order to test its
`read` method. Remove redundant staging.

### Instructions to reviewer on how to test:
1. Ensure tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)