### PR TITLE
(#466) Add udc_directory_provider.py to configure pandas with HDF file directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
     "ophyd",
-    "ophyd-async>=0.3a1",
+    "ophyd-async>=0.3a2",
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -1,7 +1,8 @@
-from ophyd_async.panda import PandA
+from ophyd_async.panda import HDFPanda
 
 from dodal.beamlines.beamline_utils import device_instantiation
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.udc_directory_provider import get_udc_directory_provider
 from dodal.devices.aperturescatterguard import AperturePositions, ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
@@ -366,16 +367,19 @@ def attenuator(
     )
 
 
-def panda(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> PandA:
+def panda(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> HDFPanda:
     """Get the i03 panda device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
     return device_instantiation(
-        PandA,
+        HDFPanda,
         "panda",
         "-EA-PANDA-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        directory_provider=get_udc_directory_provider(),
     )
 
 

--- a/src/dodal/common/udc_directory_provider.py
+++ b/src/dodal/common/udc_directory_provider.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from ophyd_async.core import DirectoryInfo
+
+_directory_info: DirectoryInfo
+
+
+def set_directory(directory: Path):
+    """
+    Set the current base directory of the UDC DirectoryProvider.
+    Files will be stored in the 'panda' subdirectory.
+    """
+    global _directory_info
+    _directory_info = DirectoryInfo(
+        root=directory, resource_dir=Path("panda"), prefix="", suffix=""
+    )
+
+
+def get_udc_directory_provider():
+    """Get the singleton instance of the UDC DirectoryProvider"""
+    return _get_directory
+
+
+def _get_directory() -> DirectoryInfo:
+    return _directory_info

--- a/tests/common/test_udc_directory_provider.py
+++ b/tests/common/test_udc_directory_provider.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from dodal.common.udc_directory_provider import (
+    get_udc_directory_provider,
+    set_directory,
+)
+
+
+@pytest.mark.parametrize(
+    "root, expected",
+    [
+        ["/foo", "/foo/panda"],
+        [
+            "/tmp/dls/i03/data/2024/cm31105-4/xraycentring/123456/",
+            "/tmp/dls/i03/data/2024/cm31105-4/xraycentring/123456/panda",
+        ],
+    ],
+)
+def test_udc_directory_provider_get_and_set(root, expected):
+    path = Path(root)
+    set_directory(path)
+    directory_info = get_udc_directory_provider()()
+    assert directory_info.root == path
+    assert str(directory_info.root.joinpath(directory_info.resource_dir)) == expected


### PR DESCRIPTION
* Update minimum ophyd-async version to 0.3a1
* Change references to ophyd_async.panda.PandA to HDFPanda

Fixes #466 

See also accompanying hyperion change: DiamondLightSource/hyperion#1337

### Instructions to reviewer on how to test:
1. All tests pass
2. hyperion saves panda HDF files in the folder denoted by the `storage_directory` request parameter

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)