### PR TITLE
Add System tests for I22

### DIFF
--- a/tests/system_tests/test_i22_system.py
+++ b/tests/system_tests/test_i22_system.py
@@ -1,0 +1,20 @@
+import os
+
+from bluesky import RunEngine
+
+from dodal.utils import make_all_devices
+
+if __name__ == "__main__":
+    """This test runs against the real beamline and confirms that all the devices connect
+    i.e. that we match the beamline PVs.
+    This must be run on the DLS network,
+    behavior will be flaky when parts of the beamline are down for maintenance.
+    """
+
+    os.environ["BEAMLINE"] = "i22"
+    from dodal.beamlines import i22
+
+    print("Making all i22 devices")
+    RE = RunEngine()
+    make_all_devices(i22)
+    print("Successfully connected")

--- a/tests/system_tests/test_p38_system.py
+++ b/tests/system_tests/test_p38_system.py
@@ -1,0 +1,17 @@
+import os
+
+from dodal.utils import make_all_devices
+
+if __name__ == "__main__":
+    """This test runs against the real beamline and confirms that all the devices connect
+    i.e. that we match the beamline PVs.
+    This must be run on the DLS network,
+    behavior will be flaky when parts of the beamline are down for maintenance.
+    """
+
+    os.environ["BEAMLINE"] = "p38"
+    from dodal.beamlines import p38
+
+    print("Making all p38 devices")
+    make_all_devices(p38)
+    print("Successfully connected")


### PR DESCRIPTION
Add system tests files for I22 and fix P38 files

### Instructions to reviewer on how to test:
1. Run system tests on a DLS machine that can see I22 and P38 pvs

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)