### PR TITLE
 Utilise Aravis implementation from ophyd-async 0.3a3

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,3 +1,5 @@
+from ophyd_async.epics.areadetector import AravisDetector
+
 from dodal.beamlines.beamline_utils import (
     device_instantiation,
     get_directory_provider,
@@ -133,4 +135,19 @@ def fswitch(
         "-MO-FSWT-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+    )
+
+
+def oav(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> AravisDetector:
+    return device_instantiation(
+        AravisDetector,
+        "oav",
+        "-DI-OAV-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        drv_suffix="DET:",
+        hdf_suffix="HDF5:",
+        directory_provider=get_directory_provider(),
     )

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -58,6 +58,7 @@ def d11(
         directory_provider=get_directory_provider(),
     )
 
+
 def d12(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> AravisDetector:

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -1,3 +1,5 @@
+from ophyd_async.epics.areadetector import AravisDetector
+
 from dodal.beamlines.beamline_utils import (
     device_instantiation,
     get_directory_provider,
@@ -5,11 +7,10 @@ from dodal.beamlines.beamline_utils import (
 )
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.visit import StaticVisitDirectoryProvider
-from dodal.devices.areadetector import AdAravisDetector
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name
+from dodal.utils import get_beamline_name, skip_device
 
 from ._device_helpers import numbered_slits
 from .beamline_utils import device_instantiation, get_directory_provider
@@ -26,29 +27,49 @@ set_directory_provider(
 )
 
 
-def d11(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> AdAravisDetector:
+def d3(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> AravisDetector:
     return device_instantiation(
-        AdAravisDetector,
-        "D11",
-        "-DI-DCAM-03:",
+        AravisDetector,
+        "d3",
+        "-DI-DCAM-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        drv_suffix="DET:",
+        hdf_suffix="HDF5:",
+        directory_provider=get_directory_provider(),
     )
 
 
-def d12(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> AdAravisDetector:
+# Disconnected
+@skip_device
+def d11(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> AravisDetector:
     return device_instantiation(
-        AdAravisDetector,
-        "D12",
+        AravisDetector,
+        "d11",
+        "-DI-DCAM-03:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        drv_suffix="DET:",
+        hdf_suffix="HDF5:",
+        directory_provider=get_directory_provider(),
+    )
+
+def d12(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> AravisDetector:
+    return device_instantiation(
+        AravisDetector,
+        "d12",
         "-DI-DCAM-04:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        drv_suffix="DET:",
+        hdf_suffix="HDF5:",
+        directory_provider=get_directory_provider(),
     )
 
 

--- a/src/dodal/beamlines/p45.py
+++ b/src/dodal/beamlines/p45.py
@@ -1,10 +1,15 @@
-from dodal.beamlines.beamline_utils import device_instantiation, set_directory_provider
+from ophyd_async.epics.areadetector import AravisDetector
+
+from dodal.beamlines.beamline_utils import (
+    device_instantiation,
+    get_directory_provider,
+    set_directory_provider,
+)
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.visit import StaticVisitDirectoryProvider
-from dodal.devices.areadetector import AdAravisDetector
 from dodal.devices.p45 import Choppers, TomoStageWithStretchAndSkew
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name
+from dodal.utils import get_beamline_name, skip_device
 
 BL = get_beamline_name("p45")
 set_log_beamline(BL)
@@ -41,25 +46,35 @@ def choppers(
     )
 
 
+# Disconnected
+@skip_device
 def det(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> AdAravisDetector:
+) -> AravisDetector:
     return device_instantiation(
-        AdAravisDetector,
+        AravisDetector,
         "det",
         "-EA-MAP-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        drv_suffix="DET:",
+        hdf_suffix="HDF5:",
+        directory_provider=get_directory_provider(),
     )
 
 
+# Disconnected
+@skip_device
 def diff(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> AdAravisDetector:
+) -> AravisDetector:
     return device_instantiation(
-        AdAravisDetector,
+        AravisDetector,
         "diff",
         "-EA-DIFF-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        drv_suffix="DET:",
+        hdf_suffix="HDF5:",
+        directory_provider=get_directory_provider(),
     )


### PR DESCRIPTION
Fixes #406

Adds an Aravis as the OAV for i22, for the p38/p45 test beamlines.

### Instructions to reviewer on how to test:
1. Test that Aravis detector can be instantiated in dummy mode and the signals look correct to connect to the actual instances

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)