### PR TITLE
(#508) Implement ApertureScatterguard `describe()`

### DIFF
--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 from dataclasses import dataclass
 
 from bluesky.protocols import Movable
@@ -108,6 +108,22 @@ class ApertureScatterguard(StandardReadable, Movable):
             assert isinstance(self.parent, ApertureScatterguard)
             await self._backend.put(await self.parent._get_current_aperture_position())
             return {self.name: await self._backend.get_reading()}
+
+        async def describe(self):
+            return OrderedDict(
+                [
+                    (
+                        self._name,
+                        {
+                            "source": self._backend.source(self._name),  # type: ignore
+                            "dtype": "array",
+                            "shape": [
+                                -1,
+                            ],  # TODO describe properly - see https://github.com/DiamondLightSource/dodal/issues/253
+                        },
+                    ),
+                ],
+            )
 
     def load_aperture_positions(self, positions: AperturePositions):
         LOGGER.info(f"{self.name} loaded in {positions}")

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -299,3 +299,11 @@ async def test_ap_sg_in_runengine(
     assert await ap.z.user_readback.get_value() == test_loc.aperture_z
     assert await sg.x.user_readback.get_value() == test_loc.scatterguard_x
     assert await sg.y.user_readback.get_value() == test_loc.scatterguard_y
+
+
+async def test_ap_sg_descriptor(
+    aperture_in_medium_pos: ApertureScatterguard,
+    RE: RunEngine,
+):
+    description = await aperture_in_medium_pos.describe()
+    assert description


### PR DESCRIPTION
Fixes #508

### Instructions to reviewer on how to test:
1. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly