### PR TITLE
Pin sphinx-autobuild to play nice with blueapi's fastapi version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "pytest-cov",
     "pytest-random-order",
     "ruff",
-    "sphinx-autobuild",
+    "sphinx-autobuild==2024.2.4", # Later versions have a clash with fastapi<0.99, remove pin when fastapi is unpinned in blueapi
     "sphinx-copybutton",
     "sphinx-design",
     "tox-direct",


### PR DESCRIPTION
See https://github.com/DiamondLightSource/hyperion/issues/1346 and https://github.com/DiamondLightSource/blueapi/pull/456

I feel like this shouldn't be necessary as the pin is already in `blueapi` itself and this should just use that version but `hyperion` doesn't and it doesn't seem worth going down the rabbithole.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly