### PR TITLE
Add NeXus-friendly soft signals to Undulator

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -15,8 +15,9 @@ from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.i22.fswitch import FSwitch
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
+from dodal.devices.undulator import Undulator
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name, skip_device
+from dodal.utils import BeamlinePrefix, get_beamline_name, skip_device
 
 BL = get_beamline_name("i22")
 set_log_beamline(BL)
@@ -117,6 +118,22 @@ def hfm(
         "-OP-KBM-01:HFM:",
         wait_for_connection,
         fake_with_ophyd_sim,
+    )
+
+
+def undulator(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+) -> Undulator:
+    return device_instantiation(
+        Undulator,
+        "undulator",
+        f"{BeamlinePrefix(BL).insertion_prefix}-MO-SERVC-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        bl_prefix=False,
+        poles=80,
+        length=2.0,
     )
 
 

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -14,8 +14,9 @@ from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitDirectory
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
+from dodal.devices.undulator import Undulator
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name, skip_device
+from dodal.utils import BeamlinePrefix, get_beamline_name, skip_device
 
 BL = get_beamline_name("p38")
 set_log_beamline(BL)
@@ -192,6 +193,22 @@ def hfm(
         "-OP-KBM-01:HFM:",
         wait_for_connection,
         fake_with_ophyd_sim,
+    )
+
+
+def undulator(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = True,
+) -> Undulator:
+    return device_instantiation(
+        Undulator,
+        "undulator",
+        f"{BeamlinePrefix(BL).insertion_prefix}-MO-SERVC-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        bl_prefix=False,
+        poles=80,
+        length=2.0,
     )
 
 

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from ophyd_async.core import StandardReadable
+from ophyd_async.core import ConfigSignal, StandardReadable, soft_signal_r_and_backend
 from ophyd_async.epics.motion import Motor
 from ophyd_async.epics.signal import epics_signal_r
 
@@ -23,12 +23,28 @@ class Undulator(StandardReadable):
     def __init__(
         self,
         prefix: str,
+        poles: int,
+        length: float,
         name: str = "",
     ) -> None:
+        """Constructor
+
+        Args:
+            prefix: PV prefix
+            poles (int): Number of magnetic poles built into the undulator
+            length (float): Length of the undulator in meters
+            name (str, optional): Name for device. Defaults to "".
+        """
+
         with self.add_children_as_readables():
             self.gap_motor = Motor(prefix + "BLGAPMTR")
             self.current_gap = epics_signal_r(float, prefix + "CURRGAPD")
             self.gap_access = epics_signal_r(UndulatorGapAccess, prefix + "IDBLENA")
-        self.gap_discrepancy_tolerance_mm: float = UNDULATOR_DISCREPANCY_THRESHOLD_MM
+
+        with self.add_children_as_readables(ConfigSignal):
+            self.poles, _ = soft_signal_r_and_backend(int, poles)
+            self.length, _ = soft_signal_r_and_backend(float, length)
+
+        self.gap_discrepancy_tolerance_mm = UNDULATOR_DISCREPANCY_THRESHOLD_MM
 
         super().__init__(name)

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -42,6 +42,10 @@ class Undulator(StandardReadable):
             self.gap_access = epics_signal_r(UndulatorGapAccess, prefix + "IDBLENA")
 
         with self.add_children_as_readables(ConfigSignal):
+            self.gap_discrepancy_tolerance_mm, _ = soft_signal_r_and_backend(
+                float,
+                UNDULATOR_DISCREPANCY_THRESHOLD_MM,
+            )
             if poles is not None:
                 self.poles, _ = soft_signal_r_and_backend(int, poles)
             else:
@@ -51,7 +55,5 @@ class Undulator(StandardReadable):
                 self.length, _ = soft_signal_r_and_backend(float, length)
             else:
                 self.length = None
-
-        self.gap_discrepancy_tolerance_mm = UNDULATOR_DISCREPANCY_THRESHOLD_MM
 
         super().__init__(name)

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -23,9 +23,9 @@ class Undulator(StandardReadable):
     def __init__(
         self,
         prefix: str,
-        poles: int,
-        length: float,
         name: str = "",
+        poles: int | None = None,
+        length: float | None = None,
     ) -> None:
         """Constructor
 
@@ -42,8 +42,15 @@ class Undulator(StandardReadable):
             self.gap_access = epics_signal_r(UndulatorGapAccess, prefix + "IDBLENA")
 
         with self.add_children_as_readables(ConfigSignal):
-            self.poles, _ = soft_signal_r_and_backend(int, poles)
-            self.length, _ = soft_signal_r_and_backend(float, length)
+            if poles is not None:
+                self.poles, _ = soft_signal_r_and_backend(int, poles)
+            else:
+                self.poles = None
+
+            if length is not None:
+                self.length, _ = soft_signal_r_and_backend(float, length)
+            else:
+                self.length = None
 
         self.gap_discrepancy_tolerance_mm = UNDULATOR_DISCREPANCY_THRESHOLD_MM
 

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from ophyd_async.core import ConfigSignal, StandardReadable, soft_signal_r_and_backend
+from ophyd_async.core import ConfigSignal, StandardReadable, soft_signal_r_and_setter
 from ophyd_async.epics.motion import Motor
 from ophyd_async.epics.signal import epics_signal_r
 
@@ -42,17 +42,23 @@ class Undulator(StandardReadable):
             self.gap_access = epics_signal_r(UndulatorGapAccess, prefix + "IDBLENA")
 
         with self.add_children_as_readables(ConfigSignal):
-            self.gap_discrepancy_tolerance_mm, _ = soft_signal_r_and_backend(
+            self.gap_discrepancy_tolerance_mm, _ = soft_signal_r_and_setter(
                 float,
-                UNDULATOR_DISCREPANCY_THRESHOLD_MM,
+                initial_value=UNDULATOR_DISCREPANCY_THRESHOLD_MM,
             )
             if poles is not None:
-                self.poles, _ = soft_signal_r_and_backend(int, poles)
+                self.poles, _ = soft_signal_r_and_setter(
+                    int,
+                    initial_value=poles,
+                )
             else:
                 self.poles = None
 
             if length is not None:
-                self.length, _ = soft_signal_r_and_backend(float, length)
+                self.length, _ = soft_signal_r_and_setter(
+                    float,
+                    initial_value=length,
+                )
             else:
                 self.length = None
 

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -99,10 +99,8 @@ class UndulatorDCM(StandardReadable, Movable):
 
         # Check if undulator gap is close enough to the value from the DCM
         current_gap = await self.undulator.current_gap.get_value()
-        if (
-            abs(gap_to_match_dcm_energy - current_gap)
-            > self.undulator.gap_discrepancy_tolerance_mm
-        ):
+        tolerance = await self.undulator.gap_discrepancy_tolerance_mm.get_value()
+        if abs(gap_to_match_dcm_energy - current_gap) > tolerance:
             LOGGER.info(
                 f"Undulator gap mismatch. {abs(gap_to_match_dcm_energy-current_gap):.3f}mm is outside tolerance.\
                 Moving gap to nominal value, {gap_to_match_dcm_energy:.3f}mm"

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -79,7 +79,7 @@ async def test_configuration_includes_configuration_fields(undulator: Undulator)
 
 
 async def test_poles_not_propagated_if_not_supplied():
-    async with DeviceCollector(sim=True):
+    async with DeviceCollector(mock=True):
         undulator = Undulator(
             "UND-01",
             name="undulator",
@@ -90,7 +90,7 @@ async def test_poles_not_propagated_if_not_supplied():
 
 
 async def test_length_not_propagated_if_not_supplied():
-    async with DeviceCollector(sim=True):
+    async with DeviceCollector(mock=True):
         undulator = Undulator(
             "UND-01",
             name="undulator",

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -60,17 +60,17 @@ async def test_configuration_includes_configuration_fields(undulator: Undulator)
                 "alarm_severity": ANY,
             },
             "undulator-length": {
-                "value": 0.0,
+                "value": 2.0,
                 "timestamp": ANY,
                 "alarm_severity": ANY,
             },
             "undulator-poles": {
-                "value": 0,
+                "value": 80,
                 "timestamp": ANY,
                 "alarm_severity": ANY,
             },
             "undulator-gap_discrepancy_tolerance_mm": {
-                "value": 0.0,
+                "value": 0.002,
                 "timestamp": ANY,
                 "alarm_severity": ANY,
             },

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -69,6 +69,11 @@ async def test_configuration_includes_configuration_fields(undulator: Undulator)
                 "timestamp": ANY,
                 "alarm_severity": ANY,
             },
+            "undulator-gap_discrepancy_tolerance_mm": {
+                "value": 0.0,
+                "timestamp": ANY,
+                "alarm_severity": ANY,
+            },
         },
     )
 

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -9,7 +9,7 @@ from dodal.devices.undulator import Undulator
 @pytest.fixture
 async def undulator() -> Undulator:
     async with DeviceCollector(mock=True):
-        undulator = Undulator("UND-01", name="undulator")
+        undulator = Undulator("UND-01", 80, 2.0, name="undulator")
     return undulator
 
 
@@ -27,6 +27,24 @@ async def test_read_and_describe_includes(
 ):
     description = await undulator.describe()
     reading = await undulator.read()
+
+    assert key in description
+    assert key in reading
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "undulator-poles",
+        "undulator-length",
+    ],
+)
+async def test_read_and_describe_configuration_includes(
+    undulator: Undulator,
+    key: str,
+):
+    description = await undulator.describe_configuration()
+    reading = await undulator.read_configuration()
 
     assert key in description
     assert key in reading

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -27,7 +27,7 @@ ID_GAP_LOOKUP_TABLE_PATH: str = (
 @pytest.fixture
 async def fake_undulator_dcm() -> UndulatorDCM:
     async with DeviceCollector(mock=True):
-        undulator = Undulator("UND-01", name="undulator")
+        undulator = Undulator("UND-01", 80, 2.0, name="undulator")
         dcm = DCM("DCM-01", name="dcm")
         undulator_dcm = UndulatorDCM(
             undulator,

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -27,7 +27,12 @@ ID_GAP_LOOKUP_TABLE_PATH: str = (
 @pytest.fixture
 async def fake_undulator_dcm() -> UndulatorDCM:
     async with DeviceCollector(mock=True):
-        undulator = Undulator("UND-01", 80, 2.0, name="undulator")
+        undulator = Undulator(
+            "UND-01",
+            name="undulator",
+            poles=80,
+            length=2.0,
+        )
         dcm = DCM("DCM-01", name="dcm")
         undulator_dcm = UndulatorDCM(
             undulator,


### PR DESCRIPTION
Add soft signals to Undulator that provide static information needed for the NXInsertionDevice class in the NeXus standard: poles and length.

Fixes #389

### Instructions to reviewer on how to test:
1. Run unit tests
2. Run system tests against i22, i03, i04 and i04-1

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly