### PR TITLE
Correct driver EPICS suffix for i22 Pilatus

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -42,7 +42,7 @@ def saxs(
         "-EA-PILAT-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
-        drv_suffix="DRV:",
+        drv_suffix="CAM:",
         hdf_suffix="HDF:",
         directory_provider=get_directory_provider(),
     )
@@ -57,7 +57,7 @@ def waxs(
         "-EA-PILAT-03:",
         wait_for_connection,
         fake_with_ophyd_sim,
-        drv_suffix="DRV:",
+        drv_suffix="CAM:",
         hdf_suffix="HDF:",
         directory_provider=get_directory_provider(),
     )


### PR DESCRIPTION
Fixes on i22 machine day testing, Pilatuses were unable to connect as drive suffix was incorrect.

### Instructions to reviewer on how to test:
1. Test if expected DRV signals can be found on the CAM suffix on i22.
e.g. `caget BL22I-EA-PILAT-01:CAM:TriggerMode`

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly