### PR TITLE
Fix i22 slits

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -125,7 +125,7 @@ def hfm(
 
 def slits_1(
     wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = True,
+    fake_with_ophyd_sim: bool = False,
 ) -> Slits:
     return numbered_slits(
         1,
@@ -136,7 +136,7 @@ def slits_1(
 
 def slits_2(
     wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = True,
+    fake_with_ophyd_sim: bool = False,
 ) -> Slits:
     return numbered_slits(
         2,
@@ -147,7 +147,7 @@ def slits_2(
 
 def slits_3(
     wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = True,
+    fake_with_ophyd_sim: bool = False,
 ) -> Slits:
     return numbered_slits(
         3,
@@ -156,9 +156,10 @@ def slits_3(
     )
 
 
+@skip_device
 def slits_4(
     wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = True,
+    fake_with_ophyd_sim: bool = False,
 ) -> Slits:
     return numbered_slits(
         4,
@@ -169,7 +170,7 @@ def slits_4(
 
 def slits_5(
     wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = True,
+    fake_with_ophyd_sim: bool = False,
 ) -> Slits:
     return numbered_slits(
         5,
@@ -180,7 +181,7 @@ def slits_5(
 
 def slits_6(
     wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = True,
+    fake_with_ophyd_sim: bool = False,
 ) -> Slits:
     return numbered_slits(
         6,


### PR DESCRIPTION
* These were added as fake by mistake
* Skip S4 for now as it has a different Epics interface

Fixes #520.

### Instructions to reviewer on how to test:
1. Check all i22 devices can be instantiated and connect with no error (easiest to do with blueapi)

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly