### PR TITLE
Reinstate accidentally removed oav_snapshot hook that was causing system tests to fail

### DIFF
--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -89,6 +89,7 @@ class OAV(AreaDetector):
         self.snapshot.oav_params = params
         self.subscription_id = None
         self._snapshot_trigger_subscription_id = None
+        self.add_snapshot_trigger_hook()
 
     def wait_for_connection(self, all_signals=False, timeout=2):
         connected = super().wait_for_connection(all_signals, timeout)
@@ -102,3 +103,17 @@ class OAV(AreaDetector):
         self.subscription_id = self.zoom_controller.level.subscribe(cb)
 
         return connected
+
+    def add_snapshot_trigger_hook(self):
+        def apply_current_microns_per_pixel_to_snapshot(*args, **kwargs):
+            """Persist the current value of the mpp to the snapshot so that it is retained if zoom changes"""
+            microns_per_x_pixel = self.parameters.micronsPerXPixel
+            microns_per_y_pixel = self.parameters.micronsPerYPixel
+            self.grid_snapshot.microns_per_pixel_x.put(microns_per_x_pixel)
+            self.grid_snapshot.microns_per_pixel_y.put(microns_per_y_pixel)
+
+        self._snapshot_trigger_subscription_id = (
+            self.grid_snapshot.last_saved_path.subscribe(
+                apply_current_microns_per_pixel_to_snapshot
+            )
+        )


### PR DESCRIPTION
Fixes broken hyperion system tests

### Instructions to reviewer on how to test:
1. System tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly