### PR TITLE
Increase timeout to fix test

### DIFF
--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -132,7 +132,7 @@ async def test_if_gap_is_already_correct_then_dont_move_gap(
     set_mock_value(fake_undulator_dcm.undulator.current_gap, 5.4605)
 
     status = fake_undulator_dcm.set(5.8)
-    await asyncio.wait_for(status, timeout=0.01)
+    await asyncio.wait_for(status, timeout=0.05)
 
     # Verify undulator has not been asked to move
     assert (


### PR DESCRIPTION
Due to https://github.com/DiamondLightSource/dodal/issues/533 this test is now regularly timing out. This fixes that for now but I have also added a note to the speed up issue to revert this

### Instructions to reviewer on how to test:
1. Confirm this test is flaky in main
2. Confirm it is not so here

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly