### PR TITLE
Fix slit naming

### DIFF
--- a/src/dodal/beamlines/_device_helpers.py
+++ b/src/dodal/beamlines/_device_helpers.py
@@ -26,7 +26,7 @@ def numbered_slits(
 
     return device_instantiation(
         Slits,
-        f"s{slit_number}_slit_gaps",
+        f"slits_{slit_number}",
         f"-AL-SLITS-{slit_number:02}:",
         wait_for_connection,
         fake_with_ophyd_sim,

--- a/tests/beamlines/unit_tests/test_device_helpers.py
+++ b/tests/beamlines/unit_tests/test_device_helpers.py
@@ -1,15 +1,15 @@
-from random import randint
+import pytest
 
 from dodal.beamlines._device_helpers import numbered_slits
 
 
-def test_slit_field_naming():
-    num = randint(1, 20)
+@pytest.mark.parametrize("num", [5, 17])
+def test_slit_field_naming(num):
     prefix = f"-AL-SLITS-{num:02}:"
     slits = numbered_slits(
-        num,
-        False,
-        True,
+        slit_number=num,
+        wait_for_connection=False,
+        fake_with_ophyd_sim=True,
     )
 
     assert slits.name == f"slits_{num}"

--- a/tests/beamlines/unit_tests/test_device_helpers.py
+++ b/tests/beamlines/unit_tests/test_device_helpers.py
@@ -1,0 +1,24 @@
+from random import randint
+from dodal.beamlines._device_helpers import numbered_slits
+
+
+def test_slit_field_naming():
+
+    num = randint(1, 20)
+    prefix = f"-AL-SLITS-{num:02}:"
+    slits = numbered_slits(
+        num,
+        False,
+        True,
+    )
+
+    assert slits.name == f"slits_{num}"
+    assert slits.x_centre.name == f"slits_{num}-x_centre"
+    assert slits.x_gap.name == f"slits_{num}-x_gap"
+    assert slits.y_centre.name == f"slits_{num}-y_centre"
+    assert slits.y_gap.name == f"slits_{num}-y_gap"
+    assert f"{prefix}X:CENTRE.VAL" in slits.x_centre.user_setpoint.source
+    assert f"{prefix}X:SIZE.VAL" in slits.x_gap.user_setpoint.source
+    assert f"{prefix}Y:CENTRE.VAL" in slits.y_centre.user_setpoint.source
+    assert f"{prefix}Y:SIZE.VAL" in slits.y_gap.user_setpoint.source
+

--- a/tests/beamlines/unit_tests/test_device_helpers.py
+++ b/tests/beamlines/unit_tests/test_device_helpers.py
@@ -1,9 +1,9 @@
 from random import randint
+
 from dodal.beamlines._device_helpers import numbered_slits
 
 
 def test_slit_field_naming():
-
     num = randint(1, 20)
     prefix = f"-AL-SLITS-{num:02}:"
     slits = numbered_slits(
@@ -21,4 +21,3 @@ def test_slit_field_naming():
     assert f"{prefix}X:SIZE.VAL" in slits.x_gap.user_setpoint.source
     assert f"{prefix}Y:CENTRE.VAL" in slits.y_centre.user_setpoint.source
     assert f"{prefix}Y:SIZE.VAL" in slits.y_gap.user_setpoint.source
-


### PR DESCRIPTION
Fixes #529

### Instructions to reviewer on how to test:
Run unit tests which replicate the declaration as used in dodal/beamlines/i22.py but with a simulated ophyd device

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly