### PR TITLE
(#494) Use ApertureScatterguard tolerances from parameter file

### DIFF
--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -1,5 +1,9 @@
 from dodal.beamlines import beamline_utils, i03
-from dodal.devices.aperturescatterguard import AperturePositions, ApertureScatterguard
+from dodal.devices.aperturescatterguard import (
+    AperturePositions,
+    ApertureScatterguard,
+    ApertureScatterguardTolerances,
+)
 
 
 def test_list():
@@ -17,7 +21,11 @@ def test_list():
 def test_getting_second_aperture_scatterguard_gives_valid_device(RE):
     beamline_utils.clear_devices()
     test_positions = AperturePositions(
-        (0, 1, 2, 3, 4), (5, 6, 7, 8, 9), (10, 11, 12, 13, 14), (15, 16, 17, 18, 19)
+        (0, 1, 2, 3, 4),
+        (5, 6, 7, 8, 9),
+        (10, 11, 12, 13, 14),
+        (15, 16, 17, 18, 19),
+        tolerances=ApertureScatterguardTolerances(0.1, 0.1, 0.1, 0.1, 0.1),
     )
     ap_sg: ApertureScatterguard = i03.aperture_scatterguard(
         fake_with_ophyd_sim=True, aperture_positions=test_positions

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -70,6 +70,11 @@ def aperture_positions():
             "miniap_z_ROBOT_LOAD": 15.8,
             "sg_x_ROBOT_LOAD": 5.25,
             "sg_y_ROBOT_LOAD": 4.43,
+            "miniap_x_tolerance": 0.004,
+            "miniap_y_tolerance": 0.1,
+            "miniap_z_tolerance": 0.1,
+            "sg_x_tolerance": 0.1,
+            "sg_y_tolerance": 0.1,
         }
     )
     return aperture_positions
@@ -227,7 +232,7 @@ async def test_aperture_positions_robot_load_within_tolerance(
     ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
 ):
     robot_load_ap_y = aperture_positions.ROBOT_LOAD.location.aperture_y
-    tolerance = ap_sg.TOLERANCE_STEPS * await ap_sg.aperture.y.deadband.get_value()
+    tolerance = aperture_positions.tolerances.ap_y
     set_mock_value(ap_sg.aperture.large, 0)
     set_mock_value(ap_sg.aperture.medium, 0)
     set_mock_value(ap_sg.aperture.small, 0)
@@ -239,9 +244,7 @@ async def test_aperture_positions_robot_load_outside_tolerance(
     ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
 ):
     robot_load_ap_y = aperture_positions.ROBOT_LOAD.location.aperture_y
-    tolerance = (
-        ap_sg.TOLERANCE_STEPS + 1
-    ) * await ap_sg.aperture.y.deadband.get_value()
+    tolerance = aperture_positions.tolerances.ap_y + 0.01
     set_mock_value(ap_sg.aperture.large, 0)
     set_mock_value(ap_sg.aperture.medium, 0)
     set_mock_value(ap_sg.aperture.small, 0)


### PR DESCRIPTION
Fixes #494
Loads tolerances for `ApertureScatterguard` movements from the beamline parameters file

### Instructions to reviewer on how to test:
1. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly