### PR TITLE
Read aperture size in serialisable format

### DIFF
--- a/src/dodal/beamline_specific_utils/i03.py
+++ b/src/dodal/beamline_specific_utils/i03.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from dodal.devices.aperturescatterguard import SingleAperturePosition
 
-I03_BEAM_HEIGHT = 20
+I03_BEAM_HEIGHT_UM = 20
 
 
 @dataclass
@@ -13,4 +13,4 @@ class BeamSize:
 
 def beam_size_from_aperture(position: SingleAperturePosition):
     aperture_size = position.radius_microns
-    return BeamSize(aperture_size, I03_BEAM_HEIGHT if aperture_size else None)
+    return BeamSize(aperture_size, I03_BEAM_HEIGHT_UM if aperture_size else None)

--- a/src/dodal/beamline_specific_utils/i03.py
+++ b/src/dodal/beamline_specific_utils/i03.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from dodal.devices.aperturescatterguard import SingleAperturePosition
+
+I03_BEAM_HEIGHT = 20
+
+
+@dataclass
+class BeamSize:
+    x_um: float | None
+    y_um: float | None
+
+
+def beam_size_from_aperture(position: SingleAperturePosition):
+    aperture_size = position.radius_microns
+    return BeamSize(aperture_size, I03_BEAM_HEIGHT if aperture_size else None)

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections import OrderedDict, namedtuple
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from bluesky.protocols import Movable, Reading
 from ophyd_async.core import AsyncStatus, SignalR, StandardReadable
@@ -37,14 +37,6 @@ class SingleAperturePosition:
     location: ApertureFiveDimensionalLocation = ApertureFiveDimensionalLocation(
         0, 0, 0, 0, 0
     )
-
-    def dict(self):
-        return {
-            "name": self.name,
-            "GDA_name": self.GDA_name,
-            "radius_microns": self.radius_microns,
-            "location": tuple(self.location),
-        }
 
 
 def position_from_params(
@@ -106,7 +98,6 @@ class ApertureScatterguard(StandardReadable, Movable):
         )
         aperture_backend.converter = self.ApertureConverter()
         self.selected_aperture = self.SelectedAperture(backend=aperture_backend)
-        self.selected_aperture
         self.set_readable_signals(
             read=[
                 self.selected_aperture,
@@ -120,7 +111,7 @@ class ApertureScatterguard(StandardReadable, Movable):
             self, value: SingleAperturePosition, timestamp: float, severity: int
         ) -> Reading:
             return Reading(
-                value=value.dict(),
+                value=asdict(value),
                 timestamp=timestamp,
                 alarm_severity=-1 if severity > 2 else severity,
             )

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -268,7 +268,7 @@ async def test_given_aperture_not_set_through_device_but_motors_in_position_when
     assert isinstance(selected_aperture, dict)
     assert (
         selected_aperture["test_ap_sg-selected_aperture"]["value"]
-        == aperture_positions.MEDIUM
+        == aperture_positions.MEDIUM.dict()
     )
 
 
@@ -279,7 +279,7 @@ async def test_when_aperture_set_and_device_read_then_position_returned(
     selected_aperture = await aperture_in_medium_pos.read()
     assert (
         selected_aperture["test_ap_sg-selected_aperture"]["value"]
-        == aperture_positions.MEDIUM
+        == aperture_positions.MEDIUM.dict()
     )
 
 

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from unittest.mock import AsyncMock, call
 
 import bluesky.plan_stubs as bps
@@ -266,9 +267,8 @@ async def test_given_aperture_not_set_through_device_but_motors_in_position_when
 ):
     selected_aperture = await aperture_in_medium_pos.read()
     assert isinstance(selected_aperture, dict)
-    assert (
-        selected_aperture["test_ap_sg-selected_aperture"]["value"]
-        == aperture_positions.MEDIUM.dict()
+    assert selected_aperture["test_ap_sg-selected_aperture"]["value"] == asdict(
+        aperture_positions.MEDIUM
     )
 
 
@@ -277,9 +277,8 @@ async def test_when_aperture_set_and_device_read_then_position_returned(
 ):
     await aperture_in_medium_pos.set(aperture_positions.MEDIUM)
     selected_aperture = await aperture_in_medium_pos.read()
-    assert (
-        selected_aperture["test_ap_sg-selected_aperture"]["value"]
-        == aperture_positions.MEDIUM.dict()
+    assert selected_aperture["test_ap_sg-selected_aperture"]["value"] == asdict(
+        aperture_positions.MEDIUM
     )
 
 

--- a/tests/devices/unit_tests/util/test_beamline_specific_utils.py
+++ b/tests/devices/unit_tests/util/test_beamline_specific_utils.py
@@ -1,6 +1,9 @@
 import pytest
 
-from dodal.beamline_specific_utils.i03 import I03_BEAM_HEIGHT, beam_size_from_aperture
+from dodal.beamline_specific_utils.i03 import (
+    I03_BEAM_HEIGHT_UM,
+    beam_size_from_aperture,
+)
 from dodal.devices.aperturescatterguard import (
     ApertureFiveDimensionalLocation,
     SingleAperturePosition,
@@ -8,9 +11,9 @@ from dodal.devices.aperturescatterguard import (
 
 RADII_AND_SIZES = [
     (None, (None, None)),
-    (123, (123, I03_BEAM_HEIGHT)),
-    (23.45, (23.45, I03_BEAM_HEIGHT)),
-    (888, (888, I03_BEAM_HEIGHT)),
+    (123, (123, I03_BEAM_HEIGHT_UM)),
+    (23.45, (23.45, I03_BEAM_HEIGHT_UM)),
+    (888, (888, I03_BEAM_HEIGHT_UM)),
 ]
 
 

--- a/tests/devices/unit_tests/util/test_beamline_specific_utils.py
+++ b/tests/devices/unit_tests/util/test_beamline_specific_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from dodal.beamline_specific_utils.i03 import I03_BEAM_HEIGHT, beam_size_from_aperture
+from dodal.devices.aperturescatterguard import (
+    ApertureFiveDimensionalLocation,
+    SingleAperturePosition,
+)
+
+RADII_AND_SIZES = [
+    (None, (None, None)),
+    (123, (123, I03_BEAM_HEIGHT)),
+    (23.45, (23.45, I03_BEAM_HEIGHT)),
+    (888, (888, I03_BEAM_HEIGHT)),
+]
+
+
+def get_single_ap(radius):
+    return SingleAperturePosition(
+        "", "", radius, ApertureFiveDimensionalLocation(0, 0, 0, 0, 0)
+    )
+
+
+@pytest.mark.parametrize(["aperture_radius", "beam_size"], RADII_AND_SIZES)
+def test_beam_size_from_aperture(aperture_radius, beam_size):
+    beamsize = beam_size_from_aperture(get_single_ap(aperture_radius))
+    assert beamsize.x_um == beam_size[0]
+    assert beamsize.y_um == beam_size[1]


### PR DESCRIPTION
Needed for [Hyperion 1311](https://github.com/DiamondLightSource/hyperion/issues/1311)
- Add a Converter and method to convert SingleAperturePosition
- Add a util to get beam size x and y from the above

### Instructions to reviewer on how to test:
1. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly