### PR TITLE
Disable visit service connection on I22 and P38

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ophyd_async.epics.areadetector import AravisDetector, PilatusDetector
 from ophyd_async.panda import HDFPanda
 
@@ -7,7 +9,7 @@ from dodal.beamlines.beamline_utils import (
     set_directory_provider,
 )
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.visit import StaticVisitDirectoryProvider
+from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitDirectoryProvider
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.i22.fswitch import FSwitch
 from dodal.devices.slits import Slits
@@ -22,13 +24,17 @@ from .beamline_utils import set_beamline as set_utils_beamline
 BL = get_beamline_name("i22")
 set_log_beamline(BL)
 set_utils_beamline(BL)
-"""VISIT is a placeholder value for reference.
-    Requires that all StandardDetector IOCs are running with /data mapping to /dls/i22/data
-    """
+
+# Currently we must hard-code the visit, determining the visit at runtime requires
+# infrastructure that is still WIP.
+# Communication with GDA is also WIP so for now we determine an arbitrary scan number
+# locally and write the commissioning directory. The scan number is not guaranteed to
+# be unique and the data is at risk - this configuration is for testing only.
 set_directory_provider(
     StaticVisitDirectoryProvider(
         BL,
-        "/data/i22/2024/VISIT",
+        Path("/dls/i22/data/2024/cm37271-2/bluesky"),
+        client=LocalDirectoryServiceClient(),
     )
 )
 

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ophyd_async.epics.areadetector import AravisDetector
 from ophyd_async.panda import HDFPanda
 
@@ -7,7 +9,7 @@ from dodal.beamlines.beamline_utils import (
     set_directory_provider,
 )
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.visit import StaticVisitDirectoryProvider
+from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitDirectoryProvider
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
@@ -21,10 +23,17 @@ from .beamline_utils import set_beamline as set_utils_beamline
 BL = get_beamline_name("p38")
 set_log_beamline(BL)
 set_utils_beamline(BL)
+
+# Currently we must hard-code the visit, determining the visit at runtime requires
+# infrastructure that is still WIP.
+# Communication with GDA is also WIP so for now we determine an arbitrary scan number
+# locally and write the commissioning directory. The scan number is not guaranteed to
+# be unique and the data is at risk - this configuration is for testing only.
 set_directory_provider(
     StaticVisitDirectoryProvider(
         BL,
-        "/data/2024/cm37282-2/",  # latest commissioning visit
+        Path("/dls/p38/data/2024/cm37282-2/bluesky"),
+        client=LocalDirectoryServiceClient(),
     )
 )
 


### PR DESCRIPTION
Temporary measure to facilitate beamline testing: Don't require a connection with the GDA visit service to write data on I22 and P38.

### Instructions to reviewer on how to test:
1. Confirm unit tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly