### PR TITLE
(#551) Update ApertureScatterguard tests to use new ophyd-async mock signals

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -49,6 +49,45 @@ set_utils_beamline(BL)
 set_directory_provider(PandASubdirectoryProvider())
 
 
+def aperture_scatterguard(
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+    aperture_positions: AperturePositions | None = None,
+) -> ApertureScatterguard:
+    """Get the i03 aperture and scatterguard device, instantiate it if it hasn't already
+    been. If this is called when already instantiated in i03, it will return the existing
+    object. If aperture_positions is specified, it will update them.
+    """
+
+    def load_positions(a_s: ApertureScatterguard):
+        if aperture_positions is not None:
+            a_s.load_aperture_positions(aperture_positions)
+
+    return device_instantiation(
+        device_factory=ApertureScatterguard,
+        name="aperture_scatterguard",
+        prefix="",
+        wait=wait_for_connection,
+        fake=fake_with_ophyd_sim,
+        post_create=load_positions,
+    )
+
+
+def attenuator(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> Attenuator:
+    """Get the i03 attenuator device, instantiate it if it hasn't already been.
+    If this is called when already instantiated in i03, it will return the existing object.
+    """
+    return device_instantiation(
+        Attenuator,
+        "attenuator",
+        "-EA-ATTN-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+    )
+
+
 def dcm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> DCM:
     """Get the i03 DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -101,30 +140,6 @@ def vfm_mirror_voltages(
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
         daq_configuration_path=DAQ_CONFIGURATION_PATH,
-    )
-
-
-def aperture_scatterguard(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-    aperture_positions: AperturePositions | None = None,
-) -> ApertureScatterguard:
-    """Get the i03 aperture and scatterguard device, instantiate it if it hasn't already
-    been. If this is called when already instantiated in i03, it will return the existing
-    object. If aperture_positions is specified, it will update them.
-    """
-
-    def load_positions(a_s: ApertureScatterguard):
-        if aperture_positions is not None:
-            a_s.load_aperture_positions(aperture_positions)
-
-    return device_instantiation(
-        device_factory=ApertureScatterguard,
-        name="aperture_scatterguard",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        post_create=load_positions,
     )
 
 
@@ -355,21 +370,6 @@ def xspress3mini(
         Xspress3Mini,
         "xspress3mini",
         "-EA-XSP3-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
-
-
-def attenuator(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Attenuator:
-    """Get the i03 attenuator device, instantiate it if it hasn't already been.
-    If this is called when already instantiated in i03, it will return the existing object.
-    """
-    return device_instantiation(
-        Attenuator,
-        "attenuator",
-        "-EA-ATTN-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -147,6 +147,7 @@ class ApertureScatterguard(StandardReadable, Movable):
             self.scatterguard.y,
         ]
 
+    @AsyncStatus.wrap
     async def _set_raw_unsafe(self, positions: ApertureFiveDimensionalLocation):
         """Accept the risks and move in an unsafe way. Collisions possible."""
 
@@ -154,11 +155,11 @@ class ApertureScatterguard(StandardReadable, Movable):
         aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = positions
 
         await asyncio.gather(
-            self.aperture.x._move(aperture_x),
-            self.aperture.y._move(aperture_y),
-            self.aperture.z._move(aperture_z),
-            self.scatterguard.x._move(scatterguard_x),
-            self.scatterguard.y._move(scatterguard_y),
+            self.aperture.x.set(aperture_x),
+            self.aperture.y.set(aperture_y),
+            self.aperture.z.set(aperture_z),
+            self.scatterguard.x.set(scatterguard_x),
+            self.scatterguard.y.set(scatterguard_y),
         )
 
     async def _get_current_aperture_position(self) -> SingleAperturePosition:
@@ -216,22 +217,22 @@ class ApertureScatterguard(StandardReadable, Movable):
 
         if aperture_y > current_ap_y:
             await asyncio.gather(
-                self.scatterguard.x._move(scatterguard_x),
-                self.scatterguard.y._move(scatterguard_y),
+                self.scatterguard.x.set(scatterguard_x),
+                self.scatterguard.y.set(scatterguard_y),
             )
             await asyncio.gather(
-                self.aperture.x._move(aperture_x),
-                self.aperture.y._move(aperture_y),
-                self.aperture.z._move(aperture_z),
+                self.aperture.x.set(aperture_x),
+                self.aperture.y.set(aperture_y),
+                self.aperture.z.set(aperture_z),
             )
             return
         await asyncio.gather(
-            self.aperture.x._move(aperture_x),
-            self.aperture.y._move(aperture_y),
-            self.aperture.z._move(aperture_z),
+            self.aperture.x.set(aperture_x),
+            self.aperture.y.set(aperture_y),
+            self.aperture.z.set(aperture_z),
         )
 
         await asyncio.gather(
-            self.scatterguard.x._move(scatterguard_x),
-            self.scatterguard.y._move(scatterguard_y),
+            self.scatterguard.x.set(scatterguard_x),
+            self.scatterguard.y.set(scatterguard_y),
         )

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -1,9 +1,13 @@
-from unittest.mock import AsyncMock, call
+from typing import Sequence
+from unittest.mock import MagicMock, call
 
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import set_mock_value
+from ophyd_async.core import (
+    assert_mock_put_called_with,
+    set_mock_value,
+)
 
 from dodal.devices.aperturescatterguard import (
     ApertureFiveDimensionalLocation,
@@ -15,35 +19,47 @@ from dodal.devices.aperturescatterguard import (
 
 from .conftest import patch_motor
 
+ApSgAndLog = tuple[ApertureScatterguard, MagicMock]
+
 
 @pytest.fixture
-async def ap_sg(aperture_positions: AperturePositions):
+async def ap_sg_and_call_log(aperture_positions: AperturePositions):
+    call_log = MagicMock()
     ap_sg = ApertureScatterguard(name="test_ap_sg")
     await ap_sg.connect(mock=True)
     ap_sg.load_aperture_positions(aperture_positions)
     with (
-        patch_motor(ap_sg.aperture.x),
-        patch_motor(ap_sg.aperture.y),
-        patch_motor(ap_sg.aperture.z),
-        patch_motor(ap_sg.scatterguard.x),
-        patch_motor(ap_sg.scatterguard.y),
+        patch_motor(ap_sg.aperture.x, call_log=call_log),
+        patch_motor(ap_sg.aperture.y, call_log=call_log),
+        patch_motor(ap_sg.aperture.z, call_log=call_log),
+        patch_motor(ap_sg.scatterguard.x, call_log=call_log),
+        patch_motor(ap_sg.scatterguard.y, call_log=call_log),
     ):
-        yield ap_sg
+        yield ap_sg, call_log
 
 
 @pytest.fixture
-async def aperture_in_medium_pos(
-    ap_sg: ApertureScatterguard,
+async def ap_sg(ap_sg_and_call_log: ApSgAndLog):
+    ap_sg, _ = ap_sg_and_call_log
+    return ap_sg
+
+
+@pytest.fixture
+async def aperture_in_medium_pos_w_call_log(
+    ap_sg_and_call_log: ApSgAndLog,
     aperture_positions: AperturePositions,
 ):
-    medium = aperture_positions.MEDIUM.location
-    await ap_sg.aperture.x.set(medium.aperture_x)
-    await ap_sg.aperture.y.set(medium.aperture_y)
-    await ap_sg.aperture.z.set(medium.aperture_z)
-    await ap_sg.scatterguard.x.set(medium.scatterguard_x)
-    await ap_sg.scatterguard.y.set(medium.scatterguard_y)
+    ap_sg, call_log = ap_sg_and_call_log
+    await ap_sg._set_raw_unsafe(aperture_positions.MEDIUM.location)
+
     set_mock_value(ap_sg.aperture.medium, 1)
-    yield ap_sg
+    yield ap_sg, call_log
+
+
+@pytest.fixture
+async def aperture_in_medium_pos(aperture_in_medium_pos_w_call_log: ApSgAndLog):
+    ap_sg, _ = aperture_in_medium_pos_w_call_log
+    return ap_sg
 
 
 @pytest.fixture
@@ -75,19 +91,22 @@ def aperture_positions():
     return aperture_positions
 
 
-def install_logger_for_aperture_and_scatterguard(aperture_scatterguard):
-    parent_mock = AsyncMock()
-    mock_ap_x = aperture_scatterguard.aperture.x._move
-    mock_ap_y = aperture_scatterguard.aperture.y._move
-    mock_ap_z = aperture_scatterguard.aperture.z._move
-    mock_sg_x = aperture_scatterguard.scatterguard.x._move
-    mock_sg_y = aperture_scatterguard.scatterguard.y._move
-    parent_mock.attach_mock(mock_ap_x, "_mock_ap_x")
-    parent_mock.attach_mock(mock_ap_y, "_mock_ap_y")
-    parent_mock.attach_mock(mock_ap_z, "_mock_ap_z")
-    parent_mock.attach_mock(mock_sg_x, "_mock_sg_x")
-    parent_mock.attach_mock(mock_sg_y, "_mock_sg_y")
-    return parent_mock
+def _assert_patched_ap_sg_has_call(
+    ap_sg: ApertureScatterguard,
+    position: ApertureFiveDimensionalLocation
+    | tuple[float, float, float, float, float],
+):
+    for motor, pos in zip(
+        (
+            ap_sg.aperture.x,
+            ap_sg.aperture.y,
+            ap_sg.aperture.z,
+            ap_sg.scatterguard.x,
+            ap_sg.scatterguard.y,
+        ),
+        position,
+    ):
+        assert_mock_put_called_with(motor.user_setpoint, pos)
 
 
 def test_aperture_scatterguard_rejects_unknown_position(aperture_in_medium_pos):
@@ -99,64 +118,38 @@ def test_aperture_scatterguard_rejects_unknown_position(aperture_in_medium_pos):
         )
 
 
+def _call_list(calls: Sequence[float]):
+    return [call(v, wait=True, timeout=10.0) for v in calls]
+
+
 async def test_aperture_scatterguard_select_bottom_moves_sg_down_then_assembly_up(
     aperture_positions: AperturePositions,
-    aperture_in_medium_pos: ApertureScatterguard,
+    aperture_in_medium_pos_w_call_log: ApSgAndLog,
 ):
-    call_logger = install_logger_for_aperture_and_scatterguard(aperture_in_medium_pos)
-    aperture_scatterguard = aperture_in_medium_pos
+    ap_sg, call_log = aperture_in_medium_pos_w_call_log
 
-    await aperture_scatterguard.set(aperture_positions.SMALL)
+    await ap_sg.set(aperture_positions.SMALL)
 
-    call_logger.assert_has_calls(
-        calls=[
-            call._mock_sg_x(5.3375),
-            call._mock_sg_y(-3.55),
-            call._mock_ap_x(2.43),
-            call._mock_ap_y(48.974),
-            call._mock_ap_z(15.8),
-        ],
-    )
+    call_log.assert_has_calls(_call_list((5.3375, -3.55, 2.43, 48.974, 15.8)))
 
 
 async def test_aperture_unsafe_move(
-    aperture_positions: AperturePositions,
     aperture_in_medium_pos: ApertureScatterguard,
 ):
     (a, b, c, d, e) = (0.2, 3.4, 5.6, 7.8, 9.0)
-    aperture_scatterguard = aperture_in_medium_pos
-    call_logger = install_logger_for_aperture_and_scatterguard(aperture_scatterguard)
-    await aperture_scatterguard._set_raw_unsafe((a, b, c, d, e))  # type: ignore
-
-    call_logger.assert_has_calls(
-        [
-            call._mock_ap_x(a),
-            call._mock_ap_y(b),
-            call._mock_ap_z(c),
-            call._mock_sg_x(d),
-            call._mock_sg_y(e),
-        ]
-    )
+    ap_sg = aperture_in_medium_pos
+    await ap_sg._set_raw_unsafe((a, b, c, d, e))  # type: ignore
+    _assert_patched_ap_sg_has_call(ap_sg, (a, b, c, d, e))
 
 
 async def test_aperture_scatterguard_select_top_moves_assembly_down_then_sg_up(
     aperture_positions: AperturePositions, aperture_in_medium_pos: ApertureScatterguard
 ):
-    aperture_scatterguard = aperture_in_medium_pos
-    call_logger = install_logger_for_aperture_and_scatterguard(aperture_scatterguard)
+    ap_sg = aperture_in_medium_pos
 
-    await aperture_scatterguard.set(aperture_positions.LARGE)
+    await ap_sg.set(aperture_positions.LARGE)
 
-    call_logger.assert_has_calls(
-        [
-            call._mock_ap_x(2.389),
-            call._mock_ap_y(40.986),
-            call._mock_ap_z(15.8),
-            call._mock_sg_x(5.25),
-            call._mock_sg_y(4.43),
-        ],
-        any_order=False,
-    )
+    _assert_patched_ap_sg_has_call(ap_sg, (2.389, 40.986, 15.8, 5.25, 4.43))
 
 
 async def test_aperture_scatterguard_throws_error_if_outside_tolerance(


### PR DESCRIPTION
And fix them in the process

Fixes #551 

### Instructions to reviewer on how to test:
1. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly