### PR TITLE
Correct MirrorType declaration

### DIFF
--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -19,7 +19,7 @@ VOLTAGE_POLLING_DELAY_S = 0.5
 DEFAULT_SETTLE_TIME_S = 60
 
 
-class MirrorType(Enum):
+class MirrorType(str, Enum):
     """See https://manual.nexusformat.org/classes/base_classes/NXmirror.html"""
 
     SINGLE = "single"


### PR DESCRIPTION
Fixes #537

### Instructions to reviewer on how to test:
1. Run Tests
2. Alternatively pull change into scratch area of either p38 or i22 and restart BlueAPI, then Run count plan via BlueAPI on vfm or hfm device. No serialization error should be generated

This source of bugs in class declaration will be address as part of https://github.com/bluesky/ophyd-async/issues/310

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly