### PR TITLE
(#554) bump ophyd async requirement to 0.3a5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 description = "Ophyd devices and other utils that could be used across DLS beamlines"
 dependencies = [
     "ophyd",
-    "ophyd-async>=0.3a4",
+    "ophyd-async>=0.3a5",
     "bluesky",
     "pyepics",
     "dataclasses-json",


### PR DESCRIPTION
Fixes #554 

### Instructions to reviewer on how to test:
1. See tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly