### PR TITLE
Implement describe for fswitch

### DIFF
--- a/tests/devices/i22/test_fswitch.py
+++ b/tests/devices/i22/test_fswitch.py
@@ -1,6 +1,9 @@
 from unittest import mock
 
 import pytest
+from bluesky.plans import count
+from bluesky.protocols import DataKey
+from bluesky.run_engine import RunEngine
 from ophyd_async.core import DeviceCollector, set_mock_value
 
 from dodal.devices.i22.fswitch import FilterState, FSwitch
@@ -26,3 +29,25 @@ async def test_reading_fswitch(fswitch: FSwitch):
             "value": 125,  # three filters out
         }
     }
+
+
+def test_fswitch_count_plan(RE: RunEngine, fswitch: FSwitch):
+    names = []
+    docs = []
+
+    def subscription(name, doc):
+        names.append(name)
+        docs.append(doc)
+
+    RE(count([fswitch]), subscription)
+
+    descriptor_doc = docs[names.index("descriptor")]
+    event_doc = docs[names.index("event")]
+
+    expected_data_key = DataKey(
+        dtype="integer", shape=[], source="fswitch", object_name="fswitch"
+    )
+    assert descriptor_doc["data_keys"] == {"number_of_lenses": expected_data_key}
+
+    expected_data = {"number_of_lenses": 128}
+    assert event_doc["data"] == expected_data


### PR DESCRIPTION
This must be implemented to allow the device to be used in plans.

Add a simple test to ensure the count plan runs successfully.

Fixes #536.

### Instructions to reviewer on how to test:
1. Run blueapi with i22 devices loaded
2. Run count plan with fswitch and verify that the plan completes without error.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly