### PR TITLE
Create directory provider that can use the RunEngine's scan number hook

### DIFF
--- a/src/dodal/beamlines/beamline_utils.py
+++ b/src/dodal/beamlines/beamline_utils.py
@@ -130,9 +130,5 @@ def set_directory_provider(provider: UpdatingDirectoryProvider):
     DIRECTORY_PROVIDER = provider
 
 
-def get_directory_provider() -> UpdatingDirectoryProvider:
-    if DIRECTORY_PROVIDER is None:
-        raise ValueError(
-            "DirectoryProvider has not been set! Ophyd-async StandardDetectors will not be able to write!"
-        )
+def get_directory_provider() -> UpdatingDirectoryProvider | None:
     return DIRECTORY_PROVIDER

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -9,7 +9,11 @@ from dodal.beamlines.beamline_utils import (
     set_directory_provider,
 )
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitDirectoryProvider
+from dodal.common.visit import (
+    InMemoryScanNumberProvider,
+    ScanNumberDirectoryProvider,
+    VisitDirectory,
+)
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.i22.fswitch import FSwitch
 from dodal.devices.slits import Slits
@@ -31,10 +35,11 @@ set_utils_beamline(BL)
 # locally and write the commissioning directory. The scan number is not guaranteed to
 # be unique and the data is at risk - this configuration is for testing only.
 set_directory_provider(
-    StaticVisitDirectoryProvider(
-        BL,
-        Path("/dls/i22/data/2024/cm37271-2/bluesky"),
-        client=LocalDirectoryServiceClient(),
+    ScanNumberDirectoryProvider(
+        VisitDirectory(
+            beamline=BL,
+            root=Path("/dls/i22/data/2024/cm37271-2/bluesky"),
+        )
     )
 )
 

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -9,7 +9,11 @@ from dodal.beamlines.beamline_utils import (
     set_directory_provider,
 )
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitDirectoryProvider
+from dodal.common.visit import (
+    InMemoryScanNumberProvider,
+    ScanNumberDirectoryProvider,
+    VisitDirectory,
+)
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
@@ -30,10 +34,11 @@ set_utils_beamline(BL)
 # locally and write the commissioning directory. The scan number is not guaranteed to
 # be unique and the data is at risk - this configuration is for testing only.
 set_directory_provider(
-    StaticVisitDirectoryProvider(
-        BL,
-        Path("/dls/p38/data/2024/cm37282-2/bluesky"),
-        client=LocalDirectoryServiceClient(),
+    ScanNumberDirectoryProvider(
+        VisitDirectory(
+            beamline=BL,
+            root=Path("/dls/p38/data/2024/cm37282-2/bluesky"),
+        )
     )
 )
 

--- a/src/dodal/beamlines/p45.py
+++ b/src/dodal/beamlines/p45.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ophyd_async.epics.areadetector import AravisDetector
 from ophyd_async.panda import HDFPanda
 
@@ -7,7 +9,7 @@ from dodal.beamlines.beamline_utils import (
     set_directory_provider,
 )
 from dodal.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.visit import StaticVisitDirectoryProvider
+from dodal.common.visit import ScanNumberDirectoryProvider, VisitDirectory
 from dodal.devices.p45 import Choppers, TomoStageWithStretchAndSkew
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import get_beamline_name, skip_device
@@ -16,9 +18,11 @@ BL = get_beamline_name("p45")
 set_log_beamline(BL)
 set_utils_beamline(BL)
 set_directory_provider(
-    StaticVisitDirectoryProvider(
-        BL,
-        "/data/2024/cm37283-2/",  # latest commissioning visit
+    ScanNumberDirectoryProvider(
+        VisitDirectory(
+            beamline=BL,
+            root=Path("/data/2024/cm37283-2/"),
+        )
     )
 )
 

--- a/src/dodal/common/types.py
+++ b/src/dodal/common/types.py
@@ -5,6 +5,7 @@ from typing import (
     Generator,
 )
 
+from bluesky import RunEngine
 from bluesky.utils import Msg
 from ophyd_async.core import DirectoryProvider
 
@@ -16,6 +17,11 @@ MsgGenerator = Generator[Msg, Any, None]
 PlanGenerator = Callable[..., MsgGenerator]
 
 
+class RunEngineAwareDirectoryProvider(DirectoryProvider, ABC):
+    @abstractmethod
+    def connect_to_run_engine(self, run_engine: RunEngine) -> None: ...
+
+
 class UpdatingDirectoryProvider(DirectoryProvider, ABC):
     @abstractmethod
-    def update(self, **kwargs) -> None: ...
+    async def update(self, **kwargs) -> None: ...

--- a/src/dodal/common/udc_directory_provider.py
+++ b/src/dodal/common/udc_directory_provider.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from bluesky import RunEngine
 from ophyd_async.core import DirectoryInfo
 
 from dodal.common.types import UpdatingDirectoryProvider
@@ -22,6 +23,8 @@ class PandASubdirectoryProvider(UpdatingDirectoryProvider):
             if directory
             else None
         )
+
+    def connect_to_run_engine(self, run_engine: RunEngine) -> None: ...
 
     def update(self, directory: Path):
         self._directory_info = DirectoryInfo(

--- a/tests/preprocessors/test_filesystem_metadata.py
+++ b/tests/preprocessors/test_filesystem_metadata.py
@@ -31,10 +31,9 @@ from dodal.common.types import MsgGenerator, UpdatingDirectoryProvider
 from dodal.common.visit import (
     DATA_SESSION,
     DataCollectionIdentifier,
-    DirectoryServiceClientBase,
-    LocalDirectoryServiceClient,
-    StaticVisitDirectoryProvider,
-    attach_metadata,
+    InMemoryScanNumberProvider,
+    ScanNumberDirectoryProvider,
+    ScanNumberProvider,
 )
 
 
@@ -87,7 +86,7 @@ class FakeDetector(Readable, HasName, Triggerable):
         return None
 
 
-class MockDirectoryServiceClient(LocalDirectoryServiceClient):
+class MockDirectoryServiceClient(InMemoryScanNumberProvider):
     def __init__(self):
         self.fail = False
         super().__init__()
@@ -111,15 +110,13 @@ class DataEvent(BaseModel):
 
 
 @pytest.fixture
-def client() -> DirectoryServiceClientBase:
+def client() -> ScanNumberProvider:
     return MockDirectoryServiceClient()
 
 
 @pytest.fixture
-def provider(
-    client: DirectoryServiceClientBase, tmp_path: Path
-) -> UpdatingDirectoryProvider:
-    return StaticVisitDirectoryProvider("example", tmp_path, client=client)
+def provider(client: ScanNumberProvider, tmp_path: Path) -> UpdatingDirectoryProvider:
+    return ScanNumberDirectoryProvider("example", tmp_path, client=client)
 
 
 @pytest.fixture(params=[1, 2])


### PR DESCRIPTION
### This is a proposal/RFC

Replace `attach_metadata` wrapper with a `DirectoryProvider` that can be hooked into the `RunEngine`'s `scan_number_source`. Meaning:
- We control the `scan_number` in each start document, and can potentially get it from GDA
- The directory provider also shares the `scan_number`, so each run should match the detector file names
- The logic for getting the scan number into the metadata already exists inside bluesky so we don't need to duplicate it

Still need to figure out if this can be made compatible with the UDC/panda directory providers or if `RunEngineCompatibleDirectoryProvider` and `UpdatingDirectoryProvider` would need to coexist. 

Corresponding changes to blueapi: https://github.com/DiamondLightSource/blueapi/pull/476

### Instructions to reviewer on how to test:
1. Confirm unit tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly