### PR TITLE
Fix for latest ophyd async

### DIFF
--- a/tests/devices/unit_tests/conftest.py
+++ b/tests/devices/unit_tests/conftest.py
@@ -31,6 +31,7 @@ def patch_motor(motor: Motor, initial_position=0, call_log: MagicMock | None = N
     set_mock_value(motor.user_readback, initial_position)
     set_mock_value(motor.deadband, 0.001)
     set_mock_value(motor.motor_done_move, 1)
+    set_mock_value(motor.velocity, 3)
     return callback_on_mock_put(motor.user_setpoint, pass_on_mock(motor, call_log))
 
 

--- a/tests/devices/unit_tests/conftest.py
+++ b/tests/devices/unit_tests/conftest.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from ophyd_async.core import (
@@ -17,22 +16,16 @@ DIRECTORY_INFO_FOR_TESTING: DirectoryInfo = DirectoryInfo(
 )
 
 
-def pass_on_mock(motor, call_log: MagicMock | None = None):
-    def _pass_on_mock(value, **kwargs):
-        set_mock_value(motor.user_readback, value)
-        if call_log is not None:
-            call_log(value, **kwargs)
-
-    return _pass_on_mock
-
-
-def patch_motor(motor: Motor, initial_position=0, call_log: MagicMock | None = None):
+def patch_motor(motor: Motor, initial_position=0):
     set_mock_value(motor.user_setpoint, initial_position)
     set_mock_value(motor.user_readback, initial_position)
     set_mock_value(motor.deadband, 0.001)
     set_mock_value(motor.motor_done_move, 1)
     set_mock_value(motor.velocity, 3)
-    return callback_on_mock_put(motor.user_setpoint, pass_on_mock(motor, call_log))
+    return callback_on_mock_put(
+        motor.user_setpoint,
+        lambda pos, *args, **kwargs: set_mock_value(motor.user_readback, pos),
+    )
 
 
 @pytest.fixture

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -1,3 +1,4 @@
+from contextlib import ExitStack
 from dataclasses import asdict
 from typing import Sequence
 from unittest.mock import ANY, MagicMock, call
@@ -23,19 +24,26 @@ from .conftest import patch_motor
 ApSgAndLog = tuple[ApertureScatterguard, MagicMock]
 
 
+def get_all_motors(ap_sg: ApertureScatterguard):
+    return [
+        ap_sg.aperture.x,
+        ap_sg.aperture.y,
+        ap_sg.aperture.z,
+        ap_sg.scatterguard.x,
+        ap_sg.scatterguard.y,
+    ]
+
+
 @pytest.fixture
 async def ap_sg_and_call_log(aperture_positions: AperturePositions):
     call_log = MagicMock()
     ap_sg = ApertureScatterguard(name="test_ap_sg")
     await ap_sg.connect(mock=True)
     ap_sg.load_aperture_positions(aperture_positions)
-    with (
-        patch_motor(ap_sg.aperture.x, call_log=call_log),
-        patch_motor(ap_sg.aperture.y, call_log=call_log),
-        patch_motor(ap_sg.aperture.z, call_log=call_log),
-        patch_motor(ap_sg.scatterguard.x, call_log=call_log),
-        patch_motor(ap_sg.scatterguard.y, call_log=call_log),
-    ):
+    with ExitStack() as motor_patch_stack:
+        for motor in get_all_motors(ap_sg):
+            motor_patch_stack.enter_context(patch_motor(motor))
+            call_log.attach_mock(get_mock_put(motor.user_setpoint), "setpoint")
         yield ap_sg, call_log
 
 
@@ -104,13 +112,7 @@ def _assert_patched_ap_sg_has_call(
     ),
 ):
     for motor, pos in zip(
-        (
-            ap_sg.aperture.x,
-            ap_sg.aperture.y,
-            ap_sg.aperture.z,
-            ap_sg.scatterguard.x,
-            ap_sg.scatterguard.y,
-        ),
+        get_all_motors(ap_sg),
         position,
     ):
         get_mock_put(motor.user_setpoint).assert_called_with(
@@ -128,7 +130,7 @@ def test_aperture_scatterguard_rejects_unknown_position(aperture_in_medium_pos):
 
 
 def _call_list(calls: Sequence[float]):
-    return [call(v, wait=True, timeout=ANY) for v in calls]
+    return [call.setpoint(v, wait=True, timeout=ANY) for v in calls]
 
 
 async def test_aperture_scatterguard_select_bottom_moves_sg_down_then_assembly_up(
@@ -187,11 +189,11 @@ async def test_aperture_scatterguard_returns_status_if_within_tolerance(
 def set_underlying_motors(
     ap_sg: ApertureScatterguard, position: ApertureFiveDimensionalLocation
 ):
-    ap_sg.aperture.x.set(position.aperture_x)
-    ap_sg.aperture.y.set(position.aperture_y)
-    ap_sg.aperture.z.set(position.aperture_z)
-    ap_sg.scatterguard.x.set(position.scatterguard_x)
-    ap_sg.scatterguard.y.set(position.scatterguard_y)
+    for motor, pos in zip(
+        get_all_motors(ap_sg),
+        position,
+    ):
+        motor.set(pos)
 
 
 async def test_aperture_positions_large(

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -168,4 +168,4 @@ async def test_energy_set_only_complete_when_all_statuses_are_finished(
     release_dcm.set()
     assert not status.done
     release_undulator.set()
-    await asyncio.wait_for(status, timeout=0.01)
+    await asyncio.wait_for(status, timeout=0.02)


### PR DESCRIPTION
Fixes #580 

### Instructions to reviewer on how to test:
1. Confirm tests now pass and are tidier

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
