### PR TITLE
Fix I22 panda prefixes

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -249,6 +249,7 @@ def panda2(
         "-EA-PANDA-02:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
     )
 
 
@@ -263,6 +264,7 @@ def panda3(
         "-EA-PANDA-03:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
     )
 
 
@@ -277,6 +279,7 @@ def panda4(
         "-EA-PANDA-04:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
     )
 
 

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from ophyd_async.epics.areadetector import AravisDetector, PilatusDetector
 from ophyd_async.panda import HDFPanda
-from ophyd_async.core import StaticDirectoryProvider
 
 from dodal.common.beamlines.beamline_utils import (
     device_instantiation,

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from ophyd_async.epics.areadetector import AravisDetector, PilatusDetector
 from ophyd_async.panda import HDFPanda
+from ophyd_async.core import StaticDirectoryProvider
 
 from dodal.common.beamlines.beamline_utils import (
     device_instantiation,
@@ -223,7 +224,6 @@ def fswitch(
 # Must find which PandA IOC(s) are compatible
 # Must document what PandAs are physically connected to
 # See: https://github.com/bluesky/ophyd-async/issues/284
-@skip_device
 def panda1(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
@@ -231,9 +231,10 @@ def panda1(
     return device_instantiation(
         HDFPanda,
         "panda1",
-        "-MO-PANDA-01:",
+        "-EA-PANDA-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+        directory_provider=get_directory_provider(),
     )
 
 
@@ -245,7 +246,7 @@ def panda2(
     return device_instantiation(
         HDFPanda,
         "panda2",
-        "-MO-PANDA-02:",
+        "-EA-PANDA-02:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )
@@ -259,7 +260,7 @@ def panda3(
     return device_instantiation(
         HDFPanda,
         "panda3",
-        "-MO-PANDA-03:",
+        "-EA-PANDA-03:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )
@@ -273,7 +274,7 @@ def panda4(
     return device_instantiation(
         HDFPanda,
         "panda4",
-        "-MO-PANDA-04:",
+        "-EA-PANDA-04:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )


### PR DESCRIPTION
Fixes #582 

### Instructions to reviewer on how to test:
1. Run unit tests
2. Run system tests (`dodal connect i22`)

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
