### PR TITLE
Update the location off the OAV xml file for I24

### DIFF
--- a/src/dodal/beamlines/i24.py
+++ b/src/dodal/beamlines/i24.py
@@ -11,7 +11,7 @@ from dodal.devices.zebra import Zebra
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import get_beamline_name, skip_device
 
-ZOOM_PARAMS_FILE = "/dls_sw/i24/software/gda/config/xml/jCameraManZoomLevels.xml"
+ZOOM_PARAMS_FILE = "/dls_sw/i24/software/gda_versions/gda_9_34/config/xml/jCameraManZoomLevels.xml"
 DISPLAY_CONFIG = "/dls_sw/i24/software/gda_versions/var/display.configuration"
 
 BL = get_beamline_name("s24")


### PR DESCRIPTION
Following the update to GDA 9.34, the location of the xml files for I24 has changed.
