### PR TITLE
Add sample ID to robot

### DIFF
--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -14,6 +14,7 @@ from dodal.devices.i04.transfocator import Transfocator
 from dodal.devices.ipin import IPin
 from dodal.devices.motors import XYZPositioner
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
+from dodal.devices.robot import BartRobot
 from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.smargon import Smargon
 from dodal.devices.synchrotron import Synchrotron
@@ -376,6 +377,21 @@ def thawer(
         Thawer,
         "thawer",
         "-EA-THAW-01",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+    )
+
+
+def robot(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> BartRobot:
+    """Get the i04 robot device, instantiate it if it hasn't already been.
+    If this is called when already instantiated in i03, it will return the existing object.
+    """
+    return device_instantiation(
+        BartRobot,
+        "robot",
+        "-MO-ROBOT-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -386,7 +386,7 @@ def robot(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> BartRobot:
     """Get the i04 robot device, instantiate it if it hasn't already been.
-    If this is called when already instantiated in i03, it will return the existing object.
+    If this is called when already instantiated in i04, it will return the existing object.
     """
     return device_instantiation(
         BartRobot,

--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -35,6 +35,8 @@ class BartRobot(StandardReadable, Movable):
         self.gonio_pin_sensor = epics_signal_r(PinMounted, prefix + "PIN_MOUNTED")
         self.next_pin = epics_signal_rw_rbv(float, prefix + "NEXT_PIN")
         self.next_puck = epics_signal_rw_rbv(float, prefix + "NEXT_PUCK")
+        self.next_sample_id = epics_signal_rw_rbv(float, prefix + "NEXT_ID")
+        self.sample_id = epics_signal_r(float, prefix + "CURRENT_ID_RBV")
         self.load = epics_signal_x(prefix + "LOAD.PROC")
         self.program_running = epics_signal_r(bool, prefix + "PROGRAM_RUNNING")
         self.program_name = epics_signal_r(str, prefix + "PROGRAM_NAME")


### PR DESCRIPTION
Fixes #499

### Instructions to reviewer on how to test:
1. Run `dodal connect i03` and `dodal connect i04` confirm that the robot connects happily for both

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
