### PR TITLE
Prevent Type checking issues with injecting default device arguments

### DIFF
--- a/src/dodal/common/coordination.py
+++ b/src/dodal/common/coordination.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from dodal.common.types import Group
 
@@ -16,19 +17,19 @@ def group_uuid(name: str) -> Group:
     return f"{name}-{str(uuid.uuid4())[:6]}"
 
 
-def inject(name: str):  # type: ignore
+def inject(name: str) -> Any:  # type: ignore
     """
-    Function to mark a default argument of a plan method as a reference to a device
-    that is stored in the Blueapi context, as devices are constructed on startup of the
-    service, and are not available to be used when writing plans.
-    Bypasses mypy linting, returning x as Any and therefore valid as a default
-    argument.
-    e.g. For a 1-dimensional scan, that is usually performed on a consistent Movable
-    axis with name "stage_x"
+    Function to mark a defaulted argument of a plan as a reference to a device stored
+    in another context and are not available to be used when writing plans.
+    Bypasses type checking, returning x as Any and therefore valid as a default
+    argument, leaving handling to the context from which the plan is called.
+    e.g. For a 1-dimensional scan, that is usually performed on a Movable with
+    name "stage_x"
+
     def scan(x: Movable = inject("stage_x"), start: float = 0.0 ...)
 
     Args:
-        name (str): Name of a device to be fetched from the Blueapi context
+        name (str): Name of a Device to be fetched from an external context
 
     Returns:
         Any: name but without typing checking, valid as any default type

--- a/src/dodal/common/coordination.py
+++ b/src/dodal/common/coordination.py
@@ -20,9 +20,10 @@ def group_uuid(name: str) -> Group:
 def inject(name: str) -> Any:  # type: ignore
     """
     Function to mark a defaulted argument of a plan as a reference to a device stored
-    in another context and are not available to be used when writing plans.
+    in another context and not available to be referenced directly.
     Bypasses type checking, returning x as Any and therefore valid as a default
     argument, leaving handling to the context from which the plan is called.
+    Assumes that device.name is unique.
     e.g. For a 1-dimensional scan, that is usually performed on a Movable with
     name "stage_x"
 

--- a/tests/common/test_coordination.py
+++ b/tests/common/test_coordination.py
@@ -1,8 +1,11 @@
 import uuid
+from inspect import Parameter, signature
 
 import pytest
+from bluesky.protocols import Movable
 
-from dodal.common.coordination import group_uuid
+from dodal.common.coordination import group_uuid, inject
+from dodal.common.types import MsgGenerator
 
 
 @pytest.mark.parametrize("group", ["foo", "bar", "baz", str(uuid.uuid4())])
@@ -10,3 +13,14 @@ def test_group_uid(group: str):
     gid = group_uuid(group)
     assert gid.startswith(f"{group}-")
     assert not gid.endswith(f"{group}-")
+
+
+def test_type_checking_ignores_inject():
+    def example_function(x: Movable = inject("foo")) -> MsgGenerator:
+        yield from {}
+
+    # These asserts are sanity checks
+    # the real test is whether this test passes type checking
+    x: Parameter = signature(example_function).parameters["x"]
+    assert x.annotation == Movable
+    assert x.default == "foo"


### PR DESCRIPTION
### Instructions to reviewer on how to test:
1. Write a plan that takes a device of type D with a default of inject(<some string>)
2. Confirm that type checking (mypy, pylance, ruff...) do not flag the inject return as the wrong type.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
