### PR TITLE
Change backlight to ophyd_async

### DIFF
--- a/src/dodal/devices/backlight.py
+++ b/src/dodal/devices/backlight.py
@@ -1,20 +1,36 @@
-from ophyd import Component, Device, EpicsSignal, StatusBase
+from enum import Enum
+
+from ophyd_async.core import AsyncStatus, StandardReadable
+from ophyd_async.epics.signal import epics_signal_rw
 
 
-class Backlight(Device):
+class BacklightPower(str, Enum):
+    ON = "On"
+    OFF = "Off"
+
+
+class BacklightPosition(str, Enum):
+    IN = "In"
+    OUT = "Out"
+
+
+class Backlight(StandardReadable):
     """Simple device to trigger the pneumatic in/out."""
 
-    OUT = 0
-    IN = 1
+    def __init__(self, prefix: str, name: str = "") -> None:
+        with self.add_children_as_readables():
+            self.power = epics_signal_rw(BacklightPower, prefix + "-EA-BLIT-01:TOGGLE")
+            self.position = epics_signal_rw(
+                BacklightPosition, prefix + "-EA-BL-01:CTRL"
+            )
+        super().__init__(name)
 
-    pos = Component(EpicsSignal, "-EA-BL-01:CTRL")
-    # Toggle to switch it On or Off
-    toggle = Component(EpicsSignal, "-EA-BLIT-01:TOGGLE")
-
-    def set(self, position: int) -> StatusBase:
-        status = self.pos.set(position)
-        if position == self.OUT:
-            status &= self.toggle.set("Off")
+    @AsyncStatus.wrap
+    async def set(self, position: BacklightPosition):
+        """This setter will turn the backlight on when we move it in to the beam and off
+        when we move it out."""
+        await self.position.set(position)
+        if position == BacklightPosition.OUT:
+            await self.power.set(BacklightPower.OFF)
         else:
-            status &= self.toggle.set("On")
-        return status
+            await self.power.set(BacklightPower.ON)

--- a/tests/devices/unit_tests/test_backlight.py
+++ b/tests/devices/unit_tests/test_backlight.py
@@ -1,28 +1,51 @@
+from unittest.mock import ANY
+
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from ophyd.sim import make_fake_device
+from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
 
-from dodal.devices.backlight import Backlight
+from dodal.devices.backlight import Backlight, BacklightPosition, BacklightPower
 
 
 @pytest.fixture
-def fake_backlight() -> Backlight:
-    FakeBacklight = make_fake_device(Backlight)
-    fake_backlight: Backlight = FakeBacklight(name="backlight")
-    return fake_backlight
+def fake_backlight(RE: RunEngine):
+    with DeviceCollector(mock=True):
+        backlight = Backlight("", "backlight")
+    return backlight
 
 
-def test_backlight_can_be_written_and_read_from(fake_backlight: Backlight):
-    fake_backlight.pos.sim_put(fake_backlight.IN)  # type: ignore
-    assert fake_backlight.pos.get() == fake_backlight.IN
+async def test_backlight_can_be_written_and_read_from(fake_backlight: Backlight):
+    set_mock_value(fake_backlight.position, BacklightPosition.IN)
+    set_mock_value(fake_backlight.power, BacklightPower.ON)
+    await assert_reading(
+        fake_backlight,
+        {
+            "backlight-power": {
+                "value": BacklightPower.ON,
+                "alarm_severity": 0,
+                "timestamp": ANY,
+            },
+            "backlight-position": {
+                "value": BacklightPosition.IN,
+                "alarm_severity": 0,
+                "timestamp": ANY,
+            },
+        },
+    )
 
 
-def test_when_backlight_out_it_switches_off(fake_backlight: Backlight, RE: RunEngine):
-    RE(bps.mv(fake_backlight, fake_backlight.OUT))
-    assert fake_backlight.toggle.get() == "Off"
+async def test_when_backlight_moved_out_it_switches_off(
+    fake_backlight: Backlight, RE: RunEngine
+):
+    RE(bps.mv(fake_backlight, BacklightPosition.OUT))
+    assert await fake_backlight.position.get_value() == BacklightPosition.OUT
+    assert await fake_backlight.power.get_value() == BacklightPower.OFF
 
 
-def test_when_backlight_in_it_switches_on(fake_backlight: Backlight, RE: RunEngine):
-    RE(bps.mv(fake_backlight, fake_backlight.IN))
-    assert fake_backlight.toggle.get() == "On"
+async def test_when_backlight_moved_in_it_switches_on(
+    fake_backlight: Backlight, RE: RunEngine
+):
+    RE(bps.mv(fake_backlight, BacklightPosition.IN))
+    assert await fake_backlight.position.get_value() == BacklightPosition.IN
+    assert await fake_backlight.power.get_value() == BacklightPower.ON


### PR DESCRIPTION
Fixes #602

### Instructions to reviewer on how to test:
1. Confirm unit tests still pass
2. Confirm `dodal connect i03` still passes (once everything is back from power outage)

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
