### PR TITLE
Add lower gonio to i03 and update XYZPositioner to ophyd_async

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -17,6 +17,7 @@ from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import PandAFastGridScan, ZebraFastGridScan
 from dodal.devices.flux import Flux
 from dodal.devices.focusing_mirror import FocusingMirrorWithStripes, VFMMirrorVoltages
+from dodal.devices.motors import XYZPositioner
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.qbpm1 import QBPM1
@@ -492,6 +493,21 @@ def thawer(
         Thawer,
         "thawer",
         "-EA-THAW-01",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+    )
+
+
+def lower_gonio_positioner(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> XYZPositioner:
+    """Get the i03 lower gonio device, instantiate it if it hasn't already been.
+    If this is called when already instantiated in i03, it will return the existing object.
+    """
+    return device_instantiation(
+        XYZPositioner,
+        "lower_gonio_positioner",
+        "-MO-GONP-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )

--- a/src/dodal/devices/lower_gonio_stages.py
+++ b/src/dodal/devices/lower_gonio_stages.py
@@ -1,8 +1,0 @@
-from ophyd import Component as Cpt
-from ophyd import Device, EpicsMotor
-
-
-class GonioLowerStages(Device):
-    x = Cpt(EpicsMotor, "-MO-GONP-01:X")
-    y = Cpt(EpicsMotor, "-MO-GONP-01:Y")
-    z = Cpt(EpicsMotor, "-MO-GONP-01:Z")

--- a/src/dodal/devices/motors.py
+++ b/src/dodal/devices/motors.py
@@ -2,13 +2,17 @@ from dataclasses import dataclass
 from typing import List, Tuple
 
 import numpy as np
-from ophyd import Component, Device, EpicsMotor
+from ophyd import EpicsMotor
+from ophyd_async.core import Device
+from ophyd_async.epics.motion import Motor
 
 
 class XYZPositioner(Device):
-    x = Component(EpicsMotor, "X")
-    y = Component(EpicsMotor, "Y")
-    z = Component(EpicsMotor, "Z")
+    def __init__(self, prefix: str, name: str):
+        self.x = Motor(prefix + "X")
+        self.y = Motor(prefix + "Y")
+        self.z = Motor(prefix + "Z")
+        super().__init__(name)
 
 
 @dataclass


### PR DESCRIPTION
Fixes #613

### Instructions to reviewer on how to test:
1. Run `dodal connect i03` and `dodal connect i04`
2. Confirm that all XYZ positioners connect note some unrelated devices are still off from the power down and https://github.com/DiamondLightSource/dodal/issues/612 is a known issue 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
