### PR TITLE
Update fast grid scan so that PVs connect

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -208,7 +208,7 @@ def zebra_fast_grid_scan(
     return device_instantiation(
         device_factory=ZebraFastGridScan,
         name="zebra_fast_grid_scan",
-        prefix="-MO-SGON-01:FGS:",
+        prefix="-MO-SGON-01:",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
     )
@@ -224,7 +224,7 @@ def panda_fast_grid_scan(
     return device_instantiation(
         device_factory=PandAFastGridScan,
         name="panda_fast_grid_scan",
-        prefix="-MO-SGON-01:PGS:",
+        prefix="-MO-SGON-01:",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
     )


### PR DESCRIPTION
Fixes #612

Additionally:
* Moved the `super` call as this needs to be called after all the signals are created.
* Changed the `run_cmd` to be an `x` signal, this more fits what it is actually doing

### Instructions to reviewer on how to test:
1. Confirm unit tests still pass
2. Confirm FGS devices are happy on `dodal connect i03` and `dodal connect i04` (Note that the `PROG_NUM` is not on i04 but we will get it on https://jira.diamond.ac.uk/browse/I04-930)

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
