### PR TITLE
Improve error message if Tetramm arm called with no exposure time

### DIFF
--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -115,8 +115,13 @@ class TetrammController(DetectorControl):
         self,
         num: int,
         trigger: DetectorTrigger,
-        exposure: float,
+        exposure: float | None = None,
     ) -> AsyncStatus:
+        if exposure is None:
+            raise ValueError(
+                "Tetramm does not support arm without exposure time. "
+                "Is this a software scan? Tetramm only supports hardware scans."
+            )
         self._validate_trigger(trigger)
 
         # trigger mode must be set first and on its own!

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -272,6 +272,11 @@ async def test_stage_sets_up_accurate_describe_output(
     }
 
 
+async def test_error_if_armed_without_exposure(tetramm_controller: TetrammController):
+    with pytest.raises(ValueError):
+        await tetramm_controller.arm(10, DetectorTrigger.internal)
+
+
 async def assert_armed(driver: TetrammDriver) -> None:
     assert (await driver.trigger_mode.get_value()) is TetrammTrigger.ExtTrigger
     assert (await driver.averaging_time.get_value()) == VALID_TEST_EXPOSURE_TIME


### PR DESCRIPTION
Fixes #610

### Instructions to reviewer on how to test:
1. Run count plan with a tetramm
2. Confirm new exception is shown

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
