### PR TITLE
[Temporarily] add required/desired NeXus metadata for i22 detectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async>=0.3a5",
+    "ophyd-async>=0.3.1",
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -14,6 +14,7 @@ from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitDirectory
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.i22.dcm import CrystalMetadata, DoubleCrystalMonochromator
 from dodal.devices.i22.fswitch import FSwitch
+from dodal.devices.i22.nxsas import NXSasMetadataHolder, NXSasOAV, NXSasPilatus
 from dodal.devices.linkam3 import Linkam3
 from dodal.devices.slits import Slits
 from dodal.devices.synchrotron import Synchrotron
@@ -44,13 +45,23 @@ def saxs(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> PilatusDetector:
     return device_instantiation(
-        PilatusDetector,
+        NXSasPilatus,
         "saxs",
         "-EA-PILAT-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
         drv_suffix="CAM:",
         hdf_suffix="HDF5:",
+        metadata_holder=NXSasMetadataHolder(
+            x_pixel_size=(1.72e-1, "mm"),
+            y_pixel_size=(1.72e-1, "mm"),
+            description="Dectris Pilatus3 2M",
+            type="Photon Counting Hybrid Pixel",
+            sensor_material="silicon",
+            distance=(0, "m"),  # To get from configuration data after visit begins
+            sensor_thickness=(0, "mm"),
+            threshold_energy=(0, "keV"),
+        ),
         directory_provider=get_directory_provider(),
     )
 
@@ -71,13 +82,23 @@ def waxs(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> PilatusDetector:
     return device_instantiation(
-        PilatusDetector,
+        NXSasPilatus,
         "waxs",
         "-EA-PILAT-03:",
         wait_for_connection,
         fake_with_ophyd_sim,
         drv_suffix="CAM:",
         hdf_suffix="HDF5:",
+        metadata_holder=NXSasMetadataHolder(
+            x_pixel_size=(1.72e-1, "mm"),
+            y_pixel_size=(1.72e-1, "mm"),
+            description="Dectris Pilatus3 2M",
+            type="Photon Counting Hybrid Pixel",
+            sensor_material="silicon",
+            distance=(0, "m"),  # To get from configuration data after visit begins
+            sensor_thickness=(0, "mm"),
+            threshold_energy=(0, "keV"),
+        ),
         directory_provider=get_directory_provider(),
     )
 
@@ -330,13 +351,19 @@ def oav(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> AravisDetector:
     return device_instantiation(
-        AravisDetector,
+        NXSasOAV,
         "oav",
         "-DI-OAV-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
         drv_suffix="DET:",
         hdf_suffix="HDF5:",
+        metadata_holder=NXSasMetadataHolder(
+            x_pixel_size=(3.45e-3, "mm"),  # Double check this figure
+            y_pixel_size=(3.45e-3, "mm"),
+            description="AVT Mako G-507B",
+            distance=(0, "m"),  # To get from configuration data after visit begins
+        ),
         directory_provider=get_directory_provider(),
     )
 

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -1,0 +1,167 @@
+from typing import Dict, Tuple
+
+from event_model.documents.event_descriptor import DataKey
+from ophyd_async.core import (
+    ConfigSignal,
+    DirectoryProvider,
+    StandardReadable,
+    soft_signal_r_and_setter,
+)
+from ophyd_async.epics.areadetector import AravisDetector, PilatusDetector
+from ophyd_async.epics.areadetector.aravis import AravisController
+
+
+class NXSasMetadataHolder(StandardReadable):
+    ValueAndUnits = Tuple[float, str]
+    """
+    Required fields for NXDetectors that are used in an NXsas application definition
+    """
+
+    def __init__(
+        self,
+        distance: ValueAndUnits,
+        x_pixel_size: ValueAndUnits,
+        y_pixel_size: ValueAndUnits,
+        beam_center_x: ValueAndUnits | None = None,
+        beam_center_y: ValueAndUnits | None = None,
+        aequetorial_angle: ValueAndUnits | None = None,
+        azimuthal_angle: ValueAndUnits | None = None,
+        polar_angle: ValueAndUnits | None = None,
+        rotation_angle: ValueAndUnits | None = None,
+        threshold_energy: ValueAndUnits | None = None,
+        serial_number: str | None = None,
+        sensor_material: str | None = None,
+        sensor_thickness: ValueAndUnits | None = None,
+        description: str | None = None,
+        type: str | None = None,
+        prefix: str = "",
+        name: str = "",
+    ):
+        with self.add_children_as_readables(ConfigSignal):
+            self.distance, _ = soft_signal_r_and_setter(
+                float, distance[0], units=distance[1]
+            )
+            self.x_pixel_size, _ = soft_signal_r_and_setter(
+                float, x_pixel_size[0], units=x_pixel_size[1]
+            )
+            self.y_pixel_size, _ = soft_signal_r_and_setter(
+                float, y_pixel_size[0], units=y_pixel_size[1]
+            )
+            if polar_angle is not None:
+                self.polar_angle, _ = soft_signal_r_and_setter(
+                    float, polar_angle[0], units=polar_angle[1]
+                )
+            else:
+                self.polar_angle = None
+            if azimuthal_angle is not None:
+                self.azimuthal_angle, _ = soft_signal_r_and_setter(
+                    float, azimuthal_angle[0], units=azimuthal_angle[1]
+                )
+            else:
+                self.azimuthal_angle = None
+            if rotation_angle is not None:
+                self.rotation_angle, _ = soft_signal_r_and_setter(
+                    float, rotation_angle[0], units=rotation_angle[1]
+                )
+            else:
+                self.rotation_angle = None
+            if aequetorial_angle is not None:
+                self.aequetorial_angle, _ = soft_signal_r_and_setter(
+                    float, aequetorial_angle[0], aequetorial_angle[1]
+                )
+            else:
+                self.aequetorial_angle = None
+            if beam_center_x is not None:
+                self.beam_center_x, _ = soft_signal_r_and_setter(
+                    float, beam_center_x[0], units=beam_center_x[1]
+                )
+            else:
+                self.beam_center_x = None
+            if beam_center_y is not None:
+                self.beam_center_y, _ = soft_signal_r_and_setter(
+                    float, beam_center_y[0], units=beam_center_y[1]
+                )
+            else:
+                self.beam_center_y = None
+            if sensor_material is not None:
+                self.sensor_material, _ = soft_signal_r_and_setter(str, sensor_material)
+            else:
+                self.sensor_material = None
+            if description is not None:
+                self.description, _ = soft_signal_r_and_setter(str, description)
+            else:
+                self.description = None
+            if type is not None:
+                self.type, _ = soft_signal_r_and_setter(str, type)
+            else:
+                self.type = None
+            if serial_number is not None:
+                self.serial_number, _ = soft_signal_r_and_setter(str, serial_number)
+            else:
+                self.serial_number = None
+            if sensor_thickness is not None:
+                self.sensor_thickness, _ = soft_signal_r_and_setter(
+                    float, sensor_thickness[0], units=sensor_thickness[1]
+                )
+            else:
+                self.sensor_thickness = None
+            if threshold_energy is not None:
+                self.threshold_energy, _ = soft_signal_r_and_setter(
+                    float, threshold_energy[0], threshold_energy[1]
+                )
+            else:
+                self.threshold_energy = None
+
+
+class NXSasPilatus(PilatusDetector):
+    def __init__(
+        self,
+        prefix: str,
+        directory_provider: DirectoryProvider,
+        drv_suffix,
+        hdf_suffix,
+        metadata_holder: NXSasMetadataHolder,
+        name: str = "",
+    ):
+        super().__init__(
+            prefix,
+            directory_provider,
+            drv_suffix=drv_suffix,
+            hdf_suffix=hdf_suffix,
+            name=name,
+        )
+        self._metadata_holder = metadata_holder
+
+    async def describe_configuration(self) -> Dict[str, DataKey]:
+        return {
+            **await super().describe_configuration(),
+            **await self._metadata_holder.describe_configuration(),
+        }
+
+
+class NXSasOAV(AravisDetector):
+    def __init__(
+        self,
+        prefix: str,
+        directory_provider: DirectoryProvider,
+        drv_suffix,
+        hdf_suffix,
+        metadata_holder: NXSasMetadataHolder,
+        name: str = "",
+        gpio_number: AravisController.GPIO_NUMBER = 1,
+    ):
+        super().__init__(
+            prefix,
+            directory_provider,
+            drv_suffix=drv_suffix,
+            hdf_suffix=hdf_suffix,
+            name=name,
+            gpio_number=gpio_number,
+        )
+        self._metadata_holder = metadata_holder
+
+    async def describe_configuration(self) -> Dict[str, DataKey]:
+        return {
+            **await super().describe_configuration(),
+            **await self._metadata_holder.describe_configuration(),
+        }

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -108,7 +108,7 @@ class NXSasMetadataHolder(StandardReadable):
                 self.sensor_thickness = None
             if threshold_energy is not None:
                 self.threshold_energy, _ = soft_signal_r_and_setter(
-                    float, threshold_energy[0], threshold_energy[1]
+                    float, threshold_energy[0], units=threshold_energy[1]
                 )
             else:
                 self.threshold_energy = None

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -15,7 +15,8 @@ from ophyd_async.epics.areadetector.aravis import AravisController
 class NXSasMetadataHolder(StandardReadable):
     ValueAndUnits = Tuple[float, str]
     """
-    Required fields for NXDetectors that are used in an NXsas application definition
+    Required fields for NXDetectors that are used in an NXsas application definition.
+    All fields are Configuration and read once per run only.
     """
 
     def __init__(
@@ -119,11 +120,16 @@ class NXSasPilatus(PilatusDetector):
         self,
         prefix: str,
         directory_provider: DirectoryProvider,
-        drv_suffix,
-        hdf_suffix,
+        drv_suffix: str,
+        hdf_suffix: str,
         metadata_holder: NXSasMetadataHolder,
         name: str = "",
     ):
+        """Extends detector with configuration metadata required or desired
+        to comply with the NXsas application definition.
+        Adds all values in the NXSasMetadataHolder's configuration fields
+        to the configuration of the parent device.
+        Writes hdf5 files."""
         super().__init__(
             prefix,
             directory_provider,
@@ -151,12 +157,17 @@ class NXSasOAV(AravisDetector):
         self,
         prefix: str,
         directory_provider: DirectoryProvider,
-        drv_suffix,
-        hdf_suffix,
+        drv_suffix: str,
+        hdf_suffix: str,
         metadata_holder: NXSasMetadataHolder,
         name: str = "",
         gpio_number: AravisController.GPIO_NUMBER = 1,
     ):
+        """Extends detector with configuration metadata required or desired
+        to comply with the NXsas application definition.
+        Adds all values in the NXSasMetadataHolder's configuration fields
+        to the configuration of the parent device.
+        Writes hdf5 files."""
         super().__init__(
             prefix,
             directory_provider,

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -1,5 +1,6 @@
 from typing import Dict, Tuple
 
+from bluesky.protocols import Reading
 from event_model.documents.event_descriptor import DataKey
 from ophyd_async.core import (
     ConfigSignal,
@@ -138,6 +139,12 @@ class NXSasPilatus(PilatusDetector):
             **await self._metadata_holder.describe_configuration(),
         }
 
+    async def read_configuration(self) -> Dict[str, Reading]:
+        return {
+            **await super().read_configuration(),
+            **await self._metadata_holder.read_configuration(),
+        }
+
 
 class NXSasOAV(AravisDetector):
     def __init__(
@@ -164,4 +171,10 @@ class NXSasOAV(AravisDetector):
         return {
             **await super().describe_configuration(),
             **await self._metadata_holder.describe_configuration(),
+        }
+
+    async def read_configuration(self) -> Dict[str, Reading]:
+        return {
+            **await super().read_configuration(),
+            **await self._metadata_holder.read_configuration(),
         }

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -68,7 +68,7 @@ class NXSasMetadataHolder(StandardReadable):
                 self.rotation_angle = None
             if aequetorial_angle is not None:
                 self.aequetorial_angle, _ = soft_signal_r_and_setter(
-                    float, aequetorial_angle[0], aequetorial_angle[1]
+                    float, aequetorial_angle[0], units=aequetorial_angle[1]
                 )
             else:
                 self.aequetorial_angle = None


### PR DESCRIPTION
Required for i22 June experiment

### Instructions to reviewer on how to test:
1. check that i22 saxs/waxs/oav have expected field in describe_configuration(), describe()

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
