### PR TITLE
Ensure metadata signals for NXsas detectors are connected & named

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "opencv-python-headless", # For pin-tip detection.
     "aioca",                  # Required for CA support with ophyd-async.
     "p4p",                    # Required for PVA support with ophyd-async.
-    "numpy",
+    "numpy<2.0",
     "aiofiles",
     "aiohttp",
 ]

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -114,6 +114,8 @@ class NXSasMetadataHolder(StandardReadable):
             else:
                 self.threshold_energy = None
 
+        super().__init__(name=name)
+
 
 class NXSasPilatus(PilatusDetector):
     def __init__(
@@ -130,6 +132,8 @@ class NXSasPilatus(PilatusDetector):
         Adds all values in the NXSasMetadataHolder's configuration fields
         to the configuration of the parent device.
         Writes hdf5 files."""
+
+        self._metadata_holder = metadata_holder
         super().__init__(
             prefix,
             directory_provider,
@@ -137,7 +141,7 @@ class NXSasPilatus(PilatusDetector):
             hdf_suffix=hdf_suffix,
             name=name,
         )
-        self._metadata_holder = metadata_holder
+
 
     async def describe_configuration(self) -> Dict[str, DataKey]:
         return {
@@ -168,6 +172,8 @@ class NXSasOAV(AravisDetector):
         Adds all values in the NXSasMetadataHolder's configuration fields
         to the configuration of the parent device.
         Writes hdf5 files."""
+
+        self._metadata_holder = metadata_holder
         super().__init__(
             prefix,
             directory_provider,
@@ -176,7 +182,7 @@ class NXSasOAV(AravisDetector):
             name=name,
             gpio_number=gpio_number,
         )
-        self._metadata_holder = metadata_holder
+
 
     async def describe_configuration(self) -> Dict[str, DataKey]:
         return {

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -142,7 +142,6 @@ class NXSasPilatus(PilatusDetector):
             name=name,
         )
 
-
     async def describe_configuration(self) -> Dict[str, DataKey]:
         return {
             **await super().describe_configuration(),
@@ -182,7 +181,6 @@ class NXSasOAV(AravisDetector):
             name=name,
             gpio_number=gpio_number,
         )
-
 
     async def describe_configuration(self) -> Dict[str, DataKey]:
         return {


### PR DESCRIPTION
In i22/NXsas.py

1. Moves setting of name for NXSasMetadataHolder to end of __init__ function
2. Moves metedata_holder declaration to before calls to super().__init__ in both NXSasPilatus and NXSasOAV

to correct BluAPI startup errors

### Instructions to reviewer on how to test:
1. Test on beamline and confirm that Blueapi starts up correctly


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
