### PR TITLE
Make tetramm scale averaging rate with frame time

### DIFF
--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -168,17 +168,13 @@ class TetrammController(DetectorControl):
             of readings per frame.
         """
 
+        # Set up the number of readings across the exposure period to scale with
+        # the exposure time
         self._set_minimum_frame_time(frame_time)
         values_per_reading: int = int(
             frame_time * self.base_sample_rate / self.readings_per_frame
         )
 
-        if values_per_reading < self.minimum_values_per_reading:
-            raise ValueError(
-                f"frame_time {frame_time} is too low to collect at least "
-                f"{self.minimum_values_per_reading} values per reading, at "
-                f"{self.readings_per_frame} readings per frame."
-            )
         await self._drv.values_per_reading.set(values_per_reading)
 
     @property

--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -129,7 +129,7 @@ class TetrammController(DetectorControl):
         await self._drv.trigger_mode.set(TetrammTrigger.ExtTrigger)
 
         await asyncio.gather(
-            self._drv.averaging_time.set(exposure), self.set_frame_time(exposure)
+            self._drv.averaging_time.set(exposure), self.set_exposure(exposure)
         )
 
         status = await set_and_wait_for_value(self._drv.acquire, 1)
@@ -152,27 +152,27 @@ class TetrammController(DetectorControl):
     async def disarm(self):
         await stop_busy_record(self._drv.acquire, 0, timeout=1)
 
-    async def set_frame_time(self, frame_time: float):
+    async def set_exposure(self, exposure: float):
         """Tries to set the exposure time of a single frame.
 
         As during the  exposure time, the device must collect an integer number
-        of readings, in the case where the frame_time is not a multiple of the base
+        of readings, in the case where the exposure is not a multiple of the base
         sample rate, it will be lowered to the prior multiple ot ensure triggers
         are not missed.
 
         Args:
-            frame_time (float): The time for a single frame in seconds
+            exposure (float): The time for a single frame in seconds
 
         Raises:
-            ValueError: If frame_time is too low to collect the required number
+            ValueError: If exposure is too low to collect the required number
             of readings per frame.
         """
 
         # Set up the number of readings across the exposure period to scale with
         # the exposure time
-        self._set_minimum_frame_time(frame_time)
+        self._set_minimum_exposure(exposure)
         values_per_reading: int = int(
-            frame_time * self.base_sample_rate / self.readings_per_frame
+            exposure * self.base_sample_rate / self.readings_per_frame
         )
 
         await self._drv.values_per_reading.set(values_per_reading)
@@ -180,27 +180,27 @@ class TetrammController(DetectorControl):
     @property
     def max_frame_rate(self) -> float:
         """Max frame rate in Hz for the current configuration"""
-        return 1 / self.minimum_frame_time
+        return 1 / self.minimum_exposure
 
     @max_frame_rate.setter
     def max_frame_rate(self, mfr: float):
-        self._set_minimum_frame_time(1 / mfr)
+        self._set_minimum_exposure(1 / mfr)
 
     @property
-    def minimum_frame_time(self) -> float:
+    def minimum_exposure(self) -> float:
         """Smallest amount of time needed to take a frame"""
         time_per_reading = self.minimum_values_per_reading / self.base_sample_rate
         return self.readings_per_frame * time_per_reading
 
-    def _set_minimum_frame_time(self, frame: float):
+    def _set_minimum_exposure(self, exposure: float):
         time_per_reading = self.minimum_values_per_reading / self.base_sample_rate
-        if frame < time_per_reading:
+        if exposure < time_per_reading:
             raise ValueError(
                 "Tetramm exposure time must be at least "
-                f"{time_per_reading}s, asked to set it to {frame}s"
+                f"{time_per_reading}s, asked to set it to {exposure}s"
             )
         self.readings_per_frame = int(
-            min(self.maximum_readings_per_frame, frame / time_per_reading)
+            min(self.maximum_readings_per_frame, exposure / time_per_reading)
         )
 
 

--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -168,6 +168,7 @@ class TetrammController(DetectorControl):
             of readings per frame.
         """
 
+        self._set_minimum_frame_time(frame_time)
         values_per_reading: int = int(
             frame_time * self.base_sample_rate / self.readings_per_frame
         )
@@ -187,7 +188,7 @@ class TetrammController(DetectorControl):
 
     @max_frame_rate.setter
     def max_frame_rate(self, mfr: float):
-        self.minimum_frame_time = 1 / mfr
+        self._set_minimum_frame_time(1 / mfr)
 
     @property
     def minimum_frame_time(self) -> float:
@@ -195,9 +196,13 @@ class TetrammController(DetectorControl):
         time_per_reading = self.minimum_values_per_reading / self.base_sample_rate
         return self.readings_per_frame * time_per_reading
 
-    @minimum_frame_time.setter
-    def minimum_frame_time(self, frame: float):
+    def _set_minimum_frame_time(self, frame: float):
         time_per_reading = self.minimum_values_per_reading / self.base_sample_rate
+        if frame < time_per_reading:
+            raise ValueError(
+                "Tetramm exposure time must be at least "
+                f"{time_per_reading}s, asked to set it to {frame}s"
+            )
         self.readings_per_frame = int(
             min(self.maximum_readings_per_frame, frame / time_per_reading)
         )

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -58,17 +58,17 @@ async def test_max_frame_rate_is_calculated_correctly(
     status = await tetramm_controller.arm(1, DetectorTrigger.edge_trigger, 2.0)
     await status
 
-    assert tetramm_controller.minimum_frame_time == 0.1
+    assert tetramm_controller.minimum_exposure == 0.1
     assert tetramm_controller.max_frame_rate == 10.0
 
     # Ensure that the minimum frame time is correctly calculated given a maximum
     # frame rate.
-    # max_frame_rate**-1 = minimum_frame_times
+    # max_frame_rate**-1 = minimum_exposures
     tetramm_controller.max_frame_rate = 20.0
-    assert tetramm_controller.minimum_frame_time == pytest.approx(1 / 20)
+    assert tetramm_controller.minimum_exposure == pytest.approx(1 / 20)
 
 
-async def test_min_frame_time_is_calculated_correctly(
+async def test_min_exposure_is_calculated_correctly(
     tetramm_controller: TetrammController,
 ):
     # Using coprimes to ensure the solution has a unique relation to the values.
@@ -77,17 +77,17 @@ async def test_min_frame_time_is_calculated_correctly(
     tetramm_controller.maximum_readings_per_frame = 1_001
     tetramm_controller.minimum_values_per_reading = 17
 
-    # min_frame_time (s/f) = max_readings_per_frame * values_per_reading / sample_rate (v/s)
-    minimum_frame_time = (
+    # min_exposure (s/f) = max_readings_per_frame * values_per_reading / sample_rate (v/s)
+    minimum_exposure = (
         tetramm_controller.readings_per_frame
         * tetramm_controller.minimum_values_per_reading
         / float(tetramm_controller.base_sample_rate)
     )
 
-    assert tetramm_controller.minimum_frame_time == pytest.approx(minimum_frame_time)
+    assert tetramm_controller.minimum_exposure == pytest.approx(minimum_exposure)
 
     # From rearranging the above
-    # readings_per_frame = frame_time * sample_rate / values_per_reading
+    # readings_per_frame = exposure * sample_rate / values_per_reading
 
     readings_per_time = (
         tetramm_controller.base_sample_rate
@@ -117,25 +117,25 @@ async def test_min_frame_time_is_calculated_correctly(
 VALID_TEST_EXPOSURE_TIME = 1 / 19
 
 
-async def test_set_frame_time_updates_values_per_reading(
+async def test_set_exposure_updates_values_per_reading(
     tetramm_controller: TetrammController,
     tetramm_driver: TetrammDriver,
 ):
-    await tetramm_controller.set_frame_time(VALID_TEST_EXPOSURE_TIME)
+    await tetramm_controller.set_exposure(VALID_TEST_EXPOSURE_TIME)
     values_per_reading = await tetramm_driver.values_per_reading.get_value()
     assert values_per_reading == 5
 
 
-async def test_set_invalid_frame_time_for_number_of_values_per_reading(
+async def test_set_invalid_exposure_for_number_of_values_per_reading(
     tetramm_controller: TetrammController,
 ):
     """
-    frame_time >= readings_per_frame * values_per_reading / sample_rate
+    exposure >= readings_per_frame * values_per_reading / sample_rate
     With the default values:
     base_sample_rate = 100_000
     minimum_values_per_reading = 5
     readings_per_frame = 1_000
-    frame_time >= 1_000 * 5 / 100_000 = 1/20
+    exposure >= 1_000 * 5 / 100_000 = 1/20
     """
 
     with pytest.raises(

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -55,7 +55,8 @@ async def tetramm(static_directory_provider: DirectoryProvider) -> TetrammDetect
 async def test_max_frame_rate_is_calculated_correctly(
     tetramm_controller: TetrammController,
 ):
-    tetramm_controller.minimum_frame_time = 2.0
+    status = await tetramm_controller.arm(1, DetectorTrigger.edge_trigger, 2.0)
+    await status
 
     assert tetramm_controller.minimum_frame_time == 0.1
     assert tetramm_controller.max_frame_rate == 10.0
@@ -67,10 +68,9 @@ async def test_max_frame_rate_is_calculated_correctly(
     assert tetramm_controller.minimum_frame_time == pytest.approx(1 / 20)
 
 
-def test_min_frame_time_is_calculated_correctly(
+async def test_min_frame_time_is_calculated_correctly(
     tetramm_controller: TetrammController,
 ):
-    tetramm_controller = tetramm_controller
     # Using coprimes to ensure the solution has a unique relation to the values.
     tetramm_controller.base_sample_rate = 100_000
     tetramm_controller.readings_per_frame = 999
@@ -95,11 +95,13 @@ def test_min_frame_time_is_calculated_correctly(
     )
 
     # 100_000 / 17 ~ 5800; 5800 * 0.01 = 58; 58 << tetramm_controller.maximum_readings_per_frame
-    tetramm_controller.minimum_frame_time = 0.01
+    status = await tetramm_controller.arm(1, DetectorTrigger.edge_trigger, 0.01)
+    await status
     assert tetramm_controller.readings_per_frame == int(readings_per_time * 0.01)
 
     # 100_000 / 17 ~ 5800; 5800 * 0.2 = 1160; 1160 > tetramm_controller.maximum_readings_per_frame
-    tetramm_controller.minimum_frame_time = 0.2
+    status = await tetramm_controller.arm(1, DetectorTrigger.edge_trigger, 0.2)
+    await status
     assert (
         tetramm_controller.readings_per_frame
         == tetramm_controller.maximum_readings_per_frame
@@ -107,7 +109,8 @@ def test_min_frame_time_is_calculated_correctly(
 
     # 100_000 / 17 ~ 5800; 5800 * 0.2 = 1160; 1160 < 1200
     tetramm_controller.maximum_readings_per_frame = 1200
-    tetramm_controller.minimum_frame_time = 0.1
+    status = await tetramm_controller.arm(1, DetectorTrigger.edge_trigger, 0.1)
+    await status
     assert tetramm_controller.readings_per_frame == int(readings_per_time * 0.1)
 
 
@@ -137,9 +140,40 @@ async def test_set_invalid_frame_time_for_number_of_values_per_reading(
 
     with pytest.raises(
         ValueError,
-        match="frame_time 0.02 is too low to collect at least 5 values per reading, at 1000 readings per frame.",
+        match="Tetramm exposure time must be at least 5e-05s, asked to set it to 4e-05s",
     ):
-        await (await tetramm_controller.arm(-1, DetectorTrigger.edge_trigger, 1 / 50))
+        await (await tetramm_controller.arm(-1, DetectorTrigger.edge_trigger, 4e-5))
+
+
+@pytest.mark.parametrize(
+    "exposure,expected_values_per_reading",
+    [
+        (20.0, 2000),
+        (10.0, 1000),
+        (1.0, 100),
+        (0.1, 10),
+        (0.05, 5),  # Smallest exposure time where we can still have 1000 readings per
+        # frame
+        (1 / 50.0, 5),
+        (1 / 1000.0, 5),
+        (5e-5, 5),  # Smallest possible exposure time
+    ],
+)
+async def test_sample_rate_scales_with_exposure_time(
+    tetramm: TetrammDetector,
+    exposure: float,
+    expected_values_per_reading: int,
+):
+    await tetramm.prepare(
+        TriggerInfo(
+            100,
+            DetectorTrigger.edge_trigger,
+            2e-5,
+            exposure,
+        )
+    )
+    values_per_reading = await tetramm.drv.values_per_reading.get_value()
+    assert values_per_reading == expected_values_per_reading
 
 
 @pytest.mark.parametrize(

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -134,8 +134,8 @@ async def test_set_invalid_exposure_for_number_of_values_per_reading(
     With the default values:
     base_sample_rate = 100_000
     minimum_values_per_reading = 5
-    readings_per_frame = 1_000
-    exposure >= 1_000 * 5 / 100_000 = 1/20
+    readings_per_frame = 5
+    exposure >= 5 * 5 / 100_000 = 1/4000
     """
 
     with pytest.raises(


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/i22-bluesky/issues/60

### Instructions to reviewer on how to test:
1. Confirm tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
