### PR TITLE
increase time out further

### DIFF
--- a/tests/devices/unit_tests/test_xspress3.py
+++ b/tests/devices/unit_tests/test_xspress3.py
@@ -34,7 +34,7 @@ async def mock_xspress3mini(prefix: str = "BLXX-EA-DET-007:") -> Xspress3:
     )
     assert mock_xspress3mini.roi_mca[1].name == "Xspress3Mini-roi_mca-1"
     assert mock_xspress3mini.roi_mca[2].name == "Xspress3Mini-roi_mca-2"
-    mock_xspress3mini.timeout = 1.0
+    mock_xspress3mini.timeout = 5.0
     return mock_xspress3mini
 
 


### PR DESCRIPTION
Fixes #638 

### Instructions to reviewer on how to test:
1. Make sure unit test run correctly without timing out. 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
