### PR TITLE
Add test forgotten from #628

### DIFF
--- a/tests/devices/unit_tests/oav/test_oav_utils.py
+++ b/tests/devices/unit_tests/oav/test_oav_utils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from PIL.Image import Image
+
+from dodal.devices.oav.utils import save_thumbnail
+
+
+def test_given_full_sized_image_when_save_thumbnail_called_then_saves_with_expected_size_and_location():
+    mock_image: Image = MagicMock(spec=Image)
+    mock_image.size = (400, 200)
+    full_path = Path("/test/path.jpg")
+    save_thumbnail(full_path, mock_image, 10)
+    mock_image.thumbnail.assert_called_once_with((20, 10))
+    mock_image.save.assert_called_once_with("/test/patht.jpg")

--- a/tests/devices/unit_tests/oav/test_oav_utils.py
+++ b/tests/devices/unit_tests/oav/test_oav_utils.py
@@ -7,7 +7,7 @@ from dodal.devices.oav.utils import save_thumbnail
 
 
 def test_given_full_sized_image_when_save_thumbnail_called_then_saves_with_expected_size_and_location():
-    mock_image: Image = MagicMock(spec=Image)
+    mock_image = MagicMock(spec=Image)
     mock_image.size = (400, 200)
     full_path = Path("/test/path.jpg")
     save_thumbnail(full_path, mock_image, 10)


### PR DESCRIPTION
I wrote this at the time I wrote #628 but forgot to add it

### Instructions to reviewer on how to test:
1. Confirm new test passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
