### PR TITLE
Upin vulnerable dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "pytest-cov",
     "pytest-random-order",
     "ruff",
-    "sphinx-autobuild==2024.2.4", # Later versions have a clash with fastapi<0.99, remove pin when fastapi is unpinned in blueapi
+    "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinxcontrib-mermaid",
     "sphinx-design",


### PR DESCRIPTION
FastAPI pinning exposes vulnerabilities to blueapi. Decision has been made to unpin FastAPI and deal with consequences in SwaggerCodeGen for Java client.

### Instructions to reviewer on how to test:
1. Install latest version of depencies `pip install -e .[dev] --force-reinstall --no-cache-dir`
2. Ensure that Sphinx-autobuild is latest version
3. Ensure that docs build passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
