### PR TITLE
Change type of robot error code PV

### DIFF
--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -60,7 +60,8 @@ class BartRobot(StandardReadable, Movable):
         self.program_running = epics_signal_r(bool, prefix + "PROGRAM_RUNNING")
         self.program_name = epics_signal_r(str, prefix + "PROGRAM_NAME")
         self.error_str = epics_signal_r(str, prefix + "PRG_ERR_MSG")
-        self.error_code = epics_signal_r(int, prefix + "PRG_ERR_CODE")
+        # Change error_code to int type when https://github.com/bluesky/ophyd-async/issues/280 released
+        self.error_code = epics_signal_r(float, prefix + "PRG_ERR_CODE")
         super().__init__(name=name)
 
     async def pin_mounted_or_no_pin_found(self):


### PR DESCRIPTION
Part of https://github.com/DiamondLightSource/hyperion/issues/1465

### Instructions to reviewer on how to test:
1. Run `dodal connect i03`
2. Confirm robot is now happy

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
