### PR TITLE
Increase odin meta timeout to 30s but warn at 10s

### DIFF
--- a/src/dodal/devices/status.py
+++ b/src/dodal/devices/status.py
@@ -1,8 +1,43 @@
+from threading import Timer
 from typing import Any, TypeVar
 
 from ophyd.status import SubscriptionStatus
 
+from dodal.log import LOGGER
+
 T = TypeVar("T")
+
+
+class WarningSubscriptionStatus(SubscriptionStatus):
+    def __init__(
+        self,
+        device,
+        callback,
+        event_type=None,
+        timeout=None,
+        settle_time=None,
+        run=True,
+        warn_at=None,
+        warning_extra_msg="",
+    ):
+        """SubscriptionStatus which logs a warning if the time taken is longer than
+        warn_at seconds. Appends warning_extra_msg to the log message"""
+        super().__init__(device, callback, event_type, timeout, settle_time, run)
+        if warn_at:
+            self._warning_timer = Timer(
+                warn_at,
+                lambda: LOGGER.warning(
+                    f"Status {self} took more than {warn_at} seconds to complete! {warning_extra_msg}"
+                ),
+            )
+            self._warning_timer.start()
+        else:
+            self._warning_timer = None
+
+    def set_finished(self):
+        if self._warning_timer and not self._warning_timer.finished:
+            self._warning_timer.cancel()
+        return super().set_finished()
 
 
 def await_value(
@@ -12,6 +47,25 @@ def await_value(
         return value == expected_value
 
     return SubscriptionStatus(subscribable, value_is, timeout=timeout)
+
+
+def await_value_and_warn_if_long(
+    subscribable: Any,
+    expected_value: T,
+    timeout: None | int = None,
+    warn_at=None,
+    warning_extra_msg="",
+) -> SubscriptionStatus:
+    def value_is(value, **_):
+        return value == expected_value
+
+    return WarningSubscriptionStatus(
+        subscribable,
+        value_is,
+        timeout=timeout,
+        warn_at=warn_at,
+        warning_extra_msg=warning_extra_msg,
+    )
 
 
 def await_value_in_list(

--- a/tests/devices/unit_tests/test_status.py
+++ b/tests/devices/unit_tests/test_status.py
@@ -1,8 +1,11 @@
+from time import sleep
+from unittest.mock import patch
+
 import pytest
 from ophyd import Component, Device, EpicsSignalRO
 from ophyd.sim import make_fake_device
 
-from dodal.devices.status import await_value_in_list
+from dodal.devices.status import await_value_and_warn_if_long, await_value_in_list
 
 
 class FakeDevice(Device):
@@ -27,3 +30,39 @@ def test_await_value_in_list_success(fake_device):
     assert status.done is False
     fake_device.pv.sim_put(5)  # type: ignore
     status.wait(timeout=1)
+
+
+@patch("dodal.devices.status.LOGGER")
+def test_await_status_warn_at_warns_at(mock_logger, fake_device):
+    status = await_value_and_warn_if_long(
+        fake_device.pv,
+        expected_value=5,
+        timeout=1,
+        warn_at=0.1,
+        warning_extra_msg="status took long",  # type: ignore
+    )
+    mock_logger.assert_not_called()
+    assert status.done is False
+    sleep(0.12)
+    fake_device.pv.sim_put(5)  # type: ignore
+    status.wait()
+    assert status.done is True
+    mock_logger.warning.assert_called()
+    assert "status took long" in mock_logger.warning.call_args.args[0]
+
+
+@patch("dodal.devices.status.LOGGER")
+def test_await_status_doesnt_warn_before_warns_at(mock_logger, fake_device):
+    status = await_value_and_warn_if_long(
+        fake_device.pv,
+        expected_value=5,
+        timeout=1,
+        warn_at=0.1,
+        warning_extra_msg="status took long",  # type: ignore
+    )
+    mock_logger.assert_not_called()
+    assert status.done is False
+    fake_device.pv.sim_put(5)  # type: ignore
+    status.wait()
+    assert status.done is True
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
Fixes #654 

### Instructions to reviewer on how to test:
1. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
