### PR TITLE
658 create device for pressure jump cell

### DIFF
--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -19,6 +19,7 @@ from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.i22.dcm import DoubleCrystalMonochromator
 from dodal.devices.i22.fswitch import FSwitch
 from dodal.devices.linkam3 import Linkam3
+from dodal.devices.pressure_jump_cell import PressureJumpCell
 from dodal.devices.slits import Slits
 from dodal.devices.tetramm import TetrammDetector
 from dodal.devices.undulator import Undulator
@@ -328,4 +329,17 @@ def ppump(
         "-EA-PUMP-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+    )
+
+def high_pressure_xray_cell(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> PressureJumpCell:
+    return device_instantiation(
+        PressureJumpCell,
+        "high_pressure_xray_cell",
+        "-EA-HPXC-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        adc1_prefix=f"{BeamlinePrefix(BL).beamline_prefix}-EA-ADC-01:",
+        adc2_prefix=f"{BeamlinePrefix(BL).beamline_prefix}-EA-ADC-02:",
     )

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -313,7 +313,7 @@ def linkam(
     return device_instantiation(
         Linkam3,
         "linkam",
-        "-EA-LINKM-02:",
+        f"{BeamlinePrefix(BL).insertion_prefix}-EA-LINKM-02:",
         wait_for_connection,
         fake_with_ophyd_sim,
     )
@@ -337,7 +337,7 @@ def high_pressure_xray_cell(
     return device_instantiation(
         PressureJumpCell,
         "high_pressure_xray_cell",
-        "-EA",
+        f"{BeamlinePrefix(BL).insertion_prefix}-EA",
         wait_for_connection,
         fake_with_ophyd_sim,
         cell_prefix="-HPXC-01:",

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -337,9 +337,9 @@ def high_pressure_xray_cell(
     return device_instantiation(
         PressureJumpCell,
         "high_pressure_xray_cell",
-        "-EA-HPXC-01:",
+        "-EA",
         wait_for_connection,
         fake_with_ophyd_sim,
-        adc1_prefix=f"{BeamlinePrefix(BL).beamline_prefix}-EA-ADC-01:",
-        adc2_prefix=f"{BeamlinePrefix(BL).beamline_prefix}-EA-ADC-02:",
+        cell_prefix="-HPXC-01:",
+        adc_prefix="-ADC",
     )

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -331,6 +331,7 @@ def ppump(
         fake_with_ophyd_sim,
     )
 
+
 def high_pressure_xray_cell(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> PressureJumpCell:

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -216,10 +216,14 @@ class PressureJumpCell(StandardReadable):
         adc_prefix: str = "",
         name: str = "",
     ):
-        self.all_valves_control = AllValvesControl(f"{beamline_prefix}{cell_prefix}", name)
+        self.all_valves_control = AllValvesControl(
+            f"{beamline_prefix}{cell_prefix}", name
+        )
         self.pump = Pump(f"{beamline_prefix}{cell_prefix}", name)
 
-        self.controller = PressureJumpCellController(f"{beamline_prefix}{cell_prefix}", name)
+        self.controller = PressureJumpCellController(
+            f"{beamline_prefix}{cell_prefix}", name
+        )
 
         with self.add_children_as_readables():
             self.pressure_transducers: DeviceVector[PressureTransducer] = DeviceVector(
@@ -233,6 +237,8 @@ class PressureJumpCell(StandardReadable):
                 }
             )
 
-            self.cell_temperature = epics_signal_r(float, f"{beamline_prefix}{cell_prefix}TEMP")
+            self.cell_temperature = epics_signal_r(
+                float, f"{beamline_prefix}{cell_prefix}TEMP"
+            )
 
         super().__init__(name)

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -253,15 +253,16 @@ class PressureJumpCell(StandardReadable):
         adc_prefix: str = "",
         name: str = "",
     ):
-        cellFullPrefix = prefix + cell_prefix 
+        cellFullPrefix = prefix + cell_prefix
         adcFullPrefix = prefix + adc_prefix
 
         self.valves = PressureJumpCellControlValves(cellFullPrefix, name)
         self.pump = PressureJumpCellPump(cellFullPrefix, name)
         self.transducers = PressureJumpCellPressureTransducers(
-            cellFullPrefix, name,  
-            adc1_prefix= adcFullPrefix + "-01:", 
-            adc2_prefix= adcFullPrefix + "-02:",
+            cellFullPrefix,
+            name,
+            adc1_prefix=adcFullPrefix + "-01:",
+            adc2_prefix=adcFullPrefix + "-02:",
         )
         self.controller = PressureJumpCellController(cellFullPrefix, name)
 

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -14,6 +14,7 @@ from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 
 OPENSEQ_PULSE_LENGTH = 0.2
 
+
 class PumpState(str, Enum):
     MANUAL = "Manual"
     AUTO_PRESSURE = "Auto Pressure"

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -10,7 +10,7 @@ from ophyd_async.core import (
     SignalR,
     StandardReadable,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 OPENSEQ_PULSE_LENGTH = 0.2
 

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -1,0 +1,141 @@
+from ophyd_async.core import ConfigSignal, StandardReadable
+from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+
+
+class PressureJumpCellPumpMode:
+    MANUAL = "Manual"
+    AUTO_PRESSURE = "Auto Pressure"
+    AUTO_POSITION = "Auto Position"
+
+
+class PressureJumpCellBusyStatus:
+    IDLE = "Idle"
+    BUSY = "Busy"
+
+
+class PressureJumpCellTimerState:
+    TIMEOUT = "TIMEOUT"
+    COUNTDOWN = "COUNTDOWN"
+
+
+class PressureJumpCellStopValue:
+    CONTINUE = "CONTINUE"
+    STOP = "STOP"
+
+
+class PressureJumpCell(StandardReadable):
+    """
+    High pressure X-ray cell, used to apply pressure or pressure jupmps to a sample.
+    """
+
+    def __init__(
+        self,
+        prefix: str = "",
+        adc1_prefix: str = "",
+        adc2_prefix: str = "",
+        name: str = "",
+    ) -> None:
+        with self.add_children_as_readables():
+            ## Valves ##
+            self.valve1_state = epics_signal_r(float, prefix + "V1:STA")
+            # V2 - valve manual control
+            self.valve3_state = epics_signal_r(float, prefix + "V3:STA")
+            # V4 - valve manual control
+            self.valve5_state = epics_signal_r(float, prefix + "V5:STA")
+            self.valve6_state = epics_signal_r(float, prefix + "V6:STA")
+            # V7 - valve manual control
+            # V8 - valve manual control
+
+            ## Cell ##
+            self.cell_temperature = epics_signal_r(float, prefix + "TEMP")
+
+            ## Pump ##
+            self.pump_position = epics_signal_r(float, prefix + "POS")
+            self.pump_forward_limit = epics_signal_r(float, prefix + "D74IN1")
+            self.pump_backward_limit = epics_signal_r(float, prefix + "D74IN0")
+
+            ## Pressure Transducer 1 ##
+            self.pressuretransducer1_omron_pressure = epics_signal_r(
+                float, prefix + "PP1:PRES"
+            )
+            self.pressuretransducer1_omron_voltage = epics_signal_r(
+                float, prefix + "PP1:RAW"
+            )
+            self.pressuretransducer1_beckhoff_pressure = epics_signal_r(
+                float, prefix + "STATP1:MeanValue_RBV"
+            )
+            self.pressuretransducer1_beckhoff_voltage = epics_signal_r(
+                float, adc2_prefix + "CH1"
+            )
+
+            ## Pressure Transducer 2 ##
+            self.pressuretransducer2_omron_pressure = epics_signal_r(
+                float, prefix + "PP2:PRES"
+            )
+            self.pressuretransducer2_omron_voltage = epics_signal_r(
+                float, prefix + "PP2:RAW"
+            )
+            self.pressuretransducer2_beckhoff_pressure = epics_signal_r(
+                float, prefix + "STATP2:MeanValue_RBV"
+            )
+            self.pressuretransducer2_beckhoff_voltage = epics_signal_r(
+                float, adc1_prefix + "CH2"
+            )
+
+            ## Pressure Transducer 3 ##
+            self.pressuretransducer3_omron_pressure = epics_signal_r(
+                float, prefix + "PP3:PRES"
+            )
+            self.pressuretransducer3_omron_voltage = epics_signal_r(
+                float, prefix + "PP3:RAW"
+            )
+            self.pressuretransducer3_beckhoff_pressure = epics_signal_r(
+                float, prefix + "STATP3:MeanValue_RBV"
+            )
+            self.pressuretransducer3_beckhoff_voltage = epics_signal_r(
+                float, adc1_prefix + "CH1"
+            )
+
+            ##Control Common##
+            self.control_gotobusy = epics_signal_r(
+                PressureJumpCellBusyStatus, prefix + "CTRL:GOTOBUSY"
+            )
+
+            ## Control Pressure ##
+            self.control_timer = epics_signal_r(
+                PressureJumpCellTimerState, prefix + "CTRL:TIMER"
+            )
+            self.control_counter = epics_signal_r(float, prefix + "CTRL:COUNTER")
+            self.control_script_status = epics_signal_r(str, prefix + "CTRL:RESULT")
+            self.control_routine = epics_signal_r(str, prefix + "CTRL:METHOD")
+            self.control_state = epics_signal_r(str, prefix + "CTRL:STATE")
+            self.control_iteration = epics_signal_r(int, prefix + "CTRL:ITER")
+
+        with self.add_children_as_readables(ConfigSignal):
+            ## Pump ##
+            self.pump_mode = epics_signal_rw(
+                PressureJumpCellPumpMode, prefix + "SP:AUTO"
+            )
+
+            ##Control Common##
+            self.control_stop = epics_signal_rw(
+                PressureJumpCellStopValue, prefix + "CTRL:STOP"
+            )
+
+            ## Control Pressure ##
+            self.control_target_pressure = epics_signal_rw(
+                float, prefix + "CTRL:TARGET"
+            )
+            self.control_timeout = epics_signal_rw(float, prefix + "CTRL:TIMER.HIGH")
+            self.control_go = epics_signal_rw(bool, prefix + "CTRL:GO")
+
+            ## Control Jump ##
+            self.control_jump_from_pressure = epics_signal_rw(
+                float, prefix + "CTRL:JUMPF"
+            )
+            self.control_jump_to_pressure = epics_signal_rw(
+                float, prefix + "CTRL:JUMPT"
+            )
+            self.control_jump_set = epics_signal_rw(bool, prefix + "CTRL:SETJUMP")
+
+        super().__init__(name)

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -1,32 +1,32 @@
 import asyncio
 from dataclasses import dataclass
-from enum import Enum
 
 from bluesky.protocols import HasName, Movable
 from ophyd_async.core import (
     AsyncStatus,
-    ConfigSignal,
     DeviceVector,
     SignalR,
     StandardReadable,
+    StandardReadableFormat,
+    StrictEnum,
 )
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 OPENSEQ_PULSE_LENGTH = 0.2
 
 
-class PumpState(str, Enum):
+class PumpState(StrictEnum):
     MANUAL = "Manual"
     AUTO_PRESSURE = "Auto Pressure"
     AUTO_POSITION = "Auto Position"
 
 
-class StopState(str, Enum):
+class StopState(StrictEnum):
     CONTINUE = "CONTINUE"
     STOP = "STOP"
 
 
-class FastValveControlRequest(str, Enum):
+class FastValveControlRequest(StrictEnum):
     OPEN = "Open"
     CLOSE = "Close"
     RESET = "Reset"
@@ -34,24 +34,24 @@ class FastValveControlRequest(str, Enum):
     DISARM = "Disarm"
 
 
-class ValveControlRequest(str, Enum):
+class ValveControlRequest(StrictEnum):
     OPEN = "Open"
     CLOSE = "Close"
     RESET = "Reset"
 
 
-class ValveOpenSeqRequest(int, Enum):
+class ValveOpenSeqRequest(StrictEnum):
     INACTIVE = 0
     OPEN_SEQ = 1
 
 
-class PumpMotorDirectionState(str, Enum):
+class PumpMotorDirectionState(StrictEnum):
     EMPTY = ""
     FORWARD = "Forward"
     REVERSE = "Reverse"
 
 
-class ValveState(str, Enum):
+class ValveState(StrictEnum):
     FAULT = "Fault"
     OPEN = "Open"
     OPENING = "Opening"
@@ -59,7 +59,7 @@ class ValveState(str, Enum):
     CLOSING = "Closing"
 
 
-class FastValveState(str, Enum):
+class FastValveState(StrictEnum):
     FAULT = "Fault"
     OPEN = "Open"
     OPEN_ARMED = "Open Armed"
@@ -200,7 +200,7 @@ class Pump(StandardReadable):
                 float, write_pv=prefix + "MSPEED", read_pv=prefix + "MSPEED_RBV"
             )
 
-        with self.add_children_as_readables(ConfigSignal):
+        with self.add_children_as_readables(StandardReadableFormat.CONFIG_SIGNAL):
             self.pump_mode = epics_signal_rw(PumpState, prefix + "SP:AUTO")
 
         super().__init__(name)

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -1,4 +1,5 @@
 from enum import Enum
+
 from ophyd_async.core import ConfigSignal, StandardReadable
 from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 
@@ -30,9 +31,6 @@ class PressureJumpCellValveControlRequest(str, Enum):
     RESET = "Reset"
     ARM = "Arm"
     DISARM = "Disarm"
-    # TODO the nones may not be required but FVST and SXST set
-    NONE1 = ""
-    NONE2 = ""
 
 
 class PressureJumpCellPumpMotorControlRequest(str, Enum):
@@ -60,8 +58,6 @@ class PressureJumpCellValveState(str, Enum):
     OPENING = "Opening"
     CLOSED = "Closed"
     CLOSING = "Closing"
-    NONE5 = ""
-    NONE6 = ""
 
 
 class PressureJumpCellFastValveState(str, Enum):
@@ -71,7 +67,6 @@ class PressureJumpCellFastValveState(str, Enum):
     CLOSED = "Closed"
     CLOSED_ARMED = "Closed Armed"
     NONE5 = "Unused"
-    NONE6 = ""
 
 
 class PressureJumpCellLimitSwitch(str, Enum):

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -164,24 +164,6 @@ class PressureTransducer(StandardReadable):
         super().__init__(name)
 
 
-class PressureTransducers(StandardReadable):
-    def __init__(
-        self, prefix: str, name: str = "", adc1_prefix: str = "", adc2_prefix: str = ""
-    ) -> None:
-        with self.add_children_as_readables():
-            self.pressure_transducer_1 = PressureTransducer(
-                prefix + "PP1:", name="Pressure Transducer 1", adc_prefix=adc1_prefix
-            )
-            self.pressure_transducer_2 = PressureTransducer(
-                prefix + "PP2:", name="Pressure Transducer 2", adc_prefix=adc2_prefix
-            )
-            self.pressure_transducer_3 = PressureTransducer(
-                prefix + "PP3:", name="Pressure Transducer 3", adc_prefix=adc1_prefix
-            )
-
-        super().__init__(name)
-
-
 class PressureJumpCellController(StandardReadable):
     def __init__(self, prefix: str, name: str = "") -> None:
         with self.add_children_as_readables():

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -249,18 +249,23 @@ class PressureJumpCell(StandardReadable):
     def __init__(
         self,
         prefix: str = "",
-        adc1_prefix: str = "",
-        adc2_prefix: str = "",
+        cell_prefix: str = "",
+        adc_prefix: str = "",
         name: str = "",
     ):
-        self.valves = PressureJumpCellControlValves(prefix, name)
-        self.pump = PressureJumpCellPump(prefix, name)
+        cellFullPrefix = prefix + cell_prefix 
+        adcFullPrefix = prefix + adc_prefix
+
+        self.valves = PressureJumpCellControlValves(cellFullPrefix, name)
+        self.pump = PressureJumpCellPump(cellFullPrefix, name)
         self.transducers = PressureJumpCellPressureTransducers(
-            prefix, name, adc1_prefix, adc2_prefix
+            cellFullPrefix, name,  
+            adc1_prefix= adcFullPrefix + "-01:", 
+            adc2_prefix= adcFullPrefix + "-02:",
         )
-        self.controller = PressureJumpCellController(prefix, name)
+        self.controller = PressureJumpCellController(cellFullPrefix, name)
 
         with self.add_children_as_readables():
-            self.cell_temperature = epics_signal_r(float, prefix + "TEMP")
+            self.cell_temperature = epics_signal_r(float, cellFullPrefix + "TEMP")
 
         super().__init__(name)

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -1,29 +1,30 @@
+from enum import Enum
 from ophyd_async.core import ConfigSignal, StandardReadable
 from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 
 
-class PressureJumpCellPumpMode:
+class PressureJumpCellPumpMode(str, Enum):
     MANUAL = "Manual"
     AUTO_PRESSURE = "Auto Pressure"
     AUTO_POSITION = "Auto Position"
 
 
-class PressureJumpCellBusyStatus:
+class PressureJumpCellBusyStatus(str, Enum):
     IDLE = "Idle"
     BUSY = "Busy"
 
 
-class PressureJumpCellTimerState:
+class PressureJumpCellTimerState(str, Enum):
     TIMEOUT = "TIMEOUT"
     COUNTDOWN = "COUNTDOWN"
 
 
-class PressureJumpCellStopValue:
+class PressureJumpCellStopValue(str, Enum):
     CONTINUE = "CONTINUE"
     STOP = "STOP"
 
 
-class PressureJumpCellValveControlRequest:
+class PressureJumpCellValveControlRequest(str, Enum):
     OPEN = "Open"
     CLOSE = "Close"
     RESET = "Reset"
@@ -34,7 +35,7 @@ class PressureJumpCellValveControlRequest:
     NONE2 = ""
 
 
-class PressureJumpCellPumpMotorControlRequest:
+class PressureJumpCellPumpMotorControlRequest(str, Enum):
     ENABLE = "Enable"
     DISABLE = "Disable"
     RESET = "Reset"
@@ -42,7 +43,7 @@ class PressureJumpCellPumpMotorControlRequest:
     REVERSE = "Reverse"
 
 
-class PressureJumpCellPumpMotorDirection:
+class PressureJumpCellPumpMotorDirection(str, Enum):
     ZERO = "0"
     FORWARD = "Forward"
     REVERSE = "Reverse"
@@ -53,7 +54,7 @@ class PressureJumpCellPumpMotorDirection:
     SEVEN = "7"
 
 
-class PressureJumpCellValveState:
+class PressureJumpCellValveState(str, Enum):
     FAULT = "Fault"
     OPEN = "Open"
     OPENING = "Opening"
@@ -63,7 +64,7 @@ class PressureJumpCellValveState:
     NONE6 = ""
 
 
-class PressureJumpCellFastValveState:
+class PressureJumpCellFastValveState(str, Enum):
     FAULT = "Fault"
     OPEN = "Open"
     OPEN_ARMED = "Open Armed"
@@ -73,7 +74,7 @@ class PressureJumpCellFastValveState:
     NONE6 = ""
 
 
-class PressureJumpCellLimitSwitch:
+class PressureJumpCellLimitSwitch(str, Enum):
     OFF = "Off"
     ON = "On"
 

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -53,6 +53,28 @@ class PressureJumpCellPumpMotorDirection:
     SEVEN = "7"
 
 
+class PressureJumpCellValveState:
+  FAULT = "Fault"
+  OPEN =  "Open"
+  OPENING = "Opening"
+  CLOSED = "Closed"
+  CLOSING = "Closing"
+  NONE5 = ""
+  NONE6 = ""
+
+class PressureJumpCellFastValveState:
+  FAULT = "Fault"
+  OPEN = "Open"
+  OPEN_ARMED = "Open Armed"
+  CLOSED = "Closed"
+  CLOSED_ARMED = "Closed Armed"
+  NONE5 = "Unused"
+  NONE6 = ""
+
+class PressureJumpCellLimitSwitch:
+    OFF = "Off"
+    ON = "On"
+
 class PressureJumpCell(StandardReadable):
     """
     High pressure X-ray cell, used to apply pressure or pressure jumps to a sample.
@@ -67,12 +89,12 @@ class PressureJumpCell(StandardReadable):
     ) -> None:
         with self.add_children_as_readables():
             ## Valves ##
-            self.valve1_state = epics_signal_r(float, prefix + "V1:STA")
+            self.valve1_state = epics_signal_r(PressureJumpCellValveState, prefix + "V1:STA")
             # V2 - valve manual control
-            self.valve3_state = epics_signal_r(float, prefix + "V3:STA")
+            self.valve3_state = epics_signal_r(PressureJumpCellValveState, prefix + "V3:STA")
             # V4 - valve manual control
-            self.valve5_state = epics_signal_r(float, prefix + "V5:STA")
-            self.valve6_state = epics_signal_r(float, prefix + "V6:STA")
+            self.valve5_state = epics_signal_r(PressureJumpCellFastValveState, prefix + "V5:STA")
+            self.valve6_state = epics_signal_r(PressureJumpCellFastValveState, prefix + "V6:STA")
             # V7 - valve manual control
             # V8 - valve manual control
 
@@ -81,9 +103,9 @@ class PressureJumpCell(StandardReadable):
 
             ## Pump ##
             self.pump_position = epics_signal_r(float, prefix + "POS")
-            self.pump_forward_limit = epics_signal_r(float, prefix + "D74IN1")
-            self.pump_backward_limit = epics_signal_r(float, prefix + "D74IN0")
-            self.pump_position = epics_signal_r(
+            self.pump_forward_limit = epics_signal_r(PressureJumpCellLimitSwitch, prefix + "D74IN1")
+            self.pump_backward_limit = epics_signal_r(PressureJumpCellLimitSwitch, prefix + "D74IN0")
+            self.pump_motor_direction = epics_signal_r(
                 PressureJumpCellPumpMotorDirection, prefix + "MTRDIR"
             )
             self.pump_speed_rbv = epics_signal_r(int, prefix + "MSPEED_RBV")

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -79,7 +79,7 @@ class LimitSwitchState(str, Enum):
     ON = "On"
 
 
-class ControlValves(StandardReadable):
+class AllValvesControl(StandardReadable):
     """
     valves 2, 4, 7, 8 are not controlled by the IOC,
     as they are under manual control.
@@ -227,7 +227,7 @@ class PressureJumpCell(StandardReadable):
         adc_prefix: str = "",
         name: str = "",
     ):
-        self.valves = ControlValves(f"{prefix}{cell_prefix}", name)
+        self.all_valves_control = AllValvesControl(f"{prefix}{cell_prefix}", name)
         self.pump = Pump(f"{prefix}{cell_prefix}", name)
 
         self.pressure_transducer_1 = PressureTransducer(

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -159,14 +159,14 @@ class ValveControl(StandardReadable):
         super().__init__(name)
 
     def set(self, value: ValveControlRequest | ValveOpenSeqRequest) -> AsyncStatus:
-        setStatus = None
+        set_status = None
 
         if isinstance(value, ValveControlRequest):
-            setStatus = self.close.set(value)
+            set_status = self.close.set(value)
         elif isinstance(value, ValveOpenSeqRequest):
-            setStatus = self.open.set(value)
+            set_status = self.open.set(value)
 
-        return setStatus
+        return set_status
 
 
 class FastValveControl(StandardReadable):
@@ -178,14 +178,14 @@ class FastValveControl(StandardReadable):
         super().__init__(name)
 
     def set(self, value: FastValveControlRequest | ValveOpenSeqRequest) -> AsyncStatus:
-        setStatus = None
+        set_status = None
 
         if isinstance(value, FastValveControlRequest):
-            setStatus = self.close.set(value)
+            set_status = self.close.set(value)
         elif isinstance(value, ValveOpenSeqRequest):
-            setStatus = self.open.set(value)
+            set_status = self.open.set(value)
 
-        return setStatus
+        return set_status
 
 
 class Pump(StandardReadable):

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -54,26 +54,29 @@ class PressureJumpCellPumpMotorDirection:
 
 
 class PressureJumpCellValveState:
-  FAULT = "Fault"
-  OPEN =  "Open"
-  OPENING = "Opening"
-  CLOSED = "Closed"
-  CLOSING = "Closing"
-  NONE5 = ""
-  NONE6 = ""
+    FAULT = "Fault"
+    OPEN = "Open"
+    OPENING = "Opening"
+    CLOSED = "Closed"
+    CLOSING = "Closing"
+    NONE5 = ""
+    NONE6 = ""
+
 
 class PressureJumpCellFastValveState:
-  FAULT = "Fault"
-  OPEN = "Open"
-  OPEN_ARMED = "Open Armed"
-  CLOSED = "Closed"
-  CLOSED_ARMED = "Closed Armed"
-  NONE5 = "Unused"
-  NONE6 = ""
+    FAULT = "Fault"
+    OPEN = "Open"
+    OPEN_ARMED = "Open Armed"
+    CLOSED = "Closed"
+    CLOSED_ARMED = "Closed Armed"
+    NONE5 = "Unused"
+    NONE6 = ""
+
 
 class PressureJumpCellLimitSwitch:
     OFF = "Off"
     ON = "On"
+
 
 class PressureJumpCell(StandardReadable):
     """
@@ -89,12 +92,20 @@ class PressureJumpCell(StandardReadable):
     ) -> None:
         with self.add_children_as_readables():
             ## Valves ##
-            self.valve1_state = epics_signal_r(PressureJumpCellValveState, prefix + "V1:STA")
+            self.valve1_state = epics_signal_r(
+                PressureJumpCellValveState, prefix + "V1:STA"
+            )
             # V2 - valve manual control
-            self.valve3_state = epics_signal_r(PressureJumpCellValveState, prefix + "V3:STA")
+            self.valve3_state = epics_signal_r(
+                PressureJumpCellValveState, prefix + "V3:STA"
+            )
             # V4 - valve manual control
-            self.valve5_state = epics_signal_r(PressureJumpCellFastValveState, prefix + "V5:STA")
-            self.valve6_state = epics_signal_r(PressureJumpCellFastValveState, prefix + "V6:STA")
+            self.valve5_state = epics_signal_r(
+                PressureJumpCellFastValveState, prefix + "V5:STA"
+            )
+            self.valve6_state = epics_signal_r(
+                PressureJumpCellFastValveState, prefix + "V6:STA"
+            )
             # V7 - valve manual control
             # V8 - valve manual control
 
@@ -103,8 +114,12 @@ class PressureJumpCell(StandardReadable):
 
             ## Pump ##
             self.pump_position = epics_signal_r(float, prefix + "POS")
-            self.pump_forward_limit = epics_signal_r(PressureJumpCellLimitSwitch, prefix + "D74IN1")
-            self.pump_backward_limit = epics_signal_r(PressureJumpCellLimitSwitch, prefix + "D74IN0")
+            self.pump_forward_limit = epics_signal_r(
+                PressureJumpCellLimitSwitch, prefix + "D74IN1"
+            )
+            self.pump_backward_limit = epics_signal_r(
+                PressureJumpCellLimitSwitch, prefix + "D74IN0"
+            )
             self.pump_motor_direction = epics_signal_r(
                 PressureJumpCellPumpMotorDirection, prefix + "MTRDIR"
             )

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -23,9 +23,39 @@ class PressureJumpCellStopValue:
     STOP = "STOP"
 
 
+class PressureJumpCellValveControlRequest:
+    OPEN = "Open"
+    CLOSE = "Close"
+    RESET = "Reset"
+    ARM = "Arm"
+    DISARM = "Disarm"
+    # TODO the nones may not be required but FVST and SXST set
+    NONE1 = ""
+    NONE2 = ""
+
+
+class PressureJumpCellPumpMotorControlRequest:
+    ENABLE = "Enable"
+    DISABLE = "Disable"
+    RESET = "Reset"
+    FORWARD = "Forward"
+    REVERSE = "Reverse"
+
+
+class PressureJumpCellPumpMotorDirection:
+    ZERO = "0"
+    FORWARD = "Forward"
+    REVERSE = "Reverse"
+    THREE = "3"
+    FOUR = "4"
+    FIVE = "5"
+    SIX = "6"
+    SEVEN = "7"
+
+
 class PressureJumpCell(StandardReadable):
     """
-    High pressure X-ray cell, used to apply pressure or pressure jupmps to a sample.
+    High pressure X-ray cell, used to apply pressure or pressure jumps to a sample.
     """
 
     def __init__(
@@ -53,6 +83,10 @@ class PressureJumpCell(StandardReadable):
             self.pump_position = epics_signal_r(float, prefix + "POS")
             self.pump_forward_limit = epics_signal_r(float, prefix + "D74IN1")
             self.pump_backward_limit = epics_signal_r(float, prefix + "D74IN0")
+            self.pump_position = epics_signal_r(
+                PressureJumpCellPumpMotorDirection, prefix + "MTRDIR"
+            )
+            self.pump_speed_rbv = epics_signal_r(int, prefix + "MSPEED_RBV")
 
             ## Pressure Transducer 1 ##
             self.pressuretransducer1_omron_pressure = epics_signal_r(
@@ -96,7 +130,7 @@ class PressureJumpCell(StandardReadable):
                 float, adc1_prefix + "CH1"
             )
 
-            ##Control Common##
+            ## Control Common ##
             self.control_gotobusy = epics_signal_r(
                 PressureJumpCellBusyStatus, prefix + "CTRL:GOTOBUSY"
             )
@@ -112,12 +146,39 @@ class PressureJumpCell(StandardReadable):
             self.control_iteration = epics_signal_r(int, prefix + "CTRL:ITER")
 
         with self.add_children_as_readables(ConfigSignal):
+            ## Valves ##
+            self.valve1_open = epics_signal_rw(bool, prefix + "V1:OPENSEQ")
+            self.valve1_control = epics_signal_rw(
+                PressureJumpCellValveControlRequest, prefix + "V1:CON"
+            )
+
+            self.valve3_open = epics_signal_rw(bool, prefix + "V3:OPENSEQ")
+            self.valve3_control = epics_signal_rw(
+                PressureJumpCellValveControlRequest, prefix + "V3:CON"
+            )
+
+            self.valve5_open = epics_signal_rw(bool, prefix + "V5:OPENSEQ")
+            self.valve5_control = epics_signal_rw(
+                PressureJumpCellValveControlRequest, prefix + "V5:CON"
+            )
+
+            self.valve6_open = epics_signal_rw(bool, prefix + "V6:OPENSEQ")
+            self.valve6_control = epics_signal_rw(
+                PressureJumpCellValveControlRequest, prefix + "V6CON"
+            )
+
             ## Pump ##
             self.pump_mode = epics_signal_rw(
                 PressureJumpCellPumpMode, prefix + "SP:AUTO"
             )
+            self.pump_speed = epics_signal_rw(float, prefix + "MSPEED")
+            self.pump_move_forward = epics_signal_rw(bool, prefix + "M1:FORW")
+            self.pump_move_backward = epics_signal_rw(bool, prefix + "M1:BACKW")
+            self.pump_move_backward = epics_signal_rw(
+                PressureJumpCellPumpMotorControlRequest, prefix + "M1:CON"
+            )
 
-            ##Control Common##
+            ## Control Common ##
             self.control_stop = epics_signal_rw(
                 PressureJumpCellStopValue, prefix + "CTRL:STOP"
             )

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -184,17 +184,16 @@ class PressureTransducer(StandardReadable):
 
 class PressureJumpCellController(HasName):
     def __init__(self, prefix: str, name: str = "") -> None:
-        PREFIX = prefix + "CTRL:"
-        self.stop = epics_signal_rw(StopState, f"{PREFIX}STOP")
+        self.stop = epics_signal_rw(StopState, f"{prefix}STOP")
 
-        self.target_pressure = epics_signal_rw(float, f"{PREFIX}TARGET")
-        self.timeout = epics_signal_rw(float, f"{PREFIX}TIMER.HIGH")
-        self.go = epics_signal_rw(bool, f"{PREFIX}GO")
+        self.target_pressure = epics_signal_rw(float, f"{prefix}TARGET")
+        self.timeout = epics_signal_rw(float, f"{prefix}TIMER.HIGH")
+        self.go = epics_signal_rw(bool, f"{prefix}GO")
 
         ## Jump logic ##
-        self.start_pressure = epics_signal_rw(float, f"{PREFIX}JUMPF")
-        self.target_pressure = epics_signal_rw(float, f"{PREFIX}JUMPT")
-        self.jump_ready = epics_signal_rw(bool, f"{PREFIX}SETJUMP")
+        self.start_pressure = epics_signal_rw(float, f"{prefix}JUMPF")
+        self.target_pressure = epics_signal_rw(float, f"{prefix}JUMPT")
+        self.jump_ready = epics_signal_rw(bool, f"{prefix}SETJUMP")
 
         self._name = name
         super().__init__()
@@ -211,9 +210,10 @@ class PressureJumpCell(StandardReadable):
 
     def __init__(
         self,
-        beamline_prefix: str = "",
-        cell_prefix: str = "",
-        adc_prefix: str = "",
+        beamline_prefix: str,
+        cell_prefix: str = "-HPXC-01:",
+        adc_prefix: str = "-ADC",
+        ctrl_prefix: str = "CTRL:",
         name: str = "",
     ):
         self.all_valves_control = AllValvesControl(
@@ -222,7 +222,7 @@ class PressureJumpCell(StandardReadable):
         self.pump = Pump(f"{beamline_prefix}{cell_prefix}", name)
 
         self.controller = PressureJumpCellController(
-            f"{beamline_prefix}{cell_prefix}", name
+            f"{beamline_prefix}{cell_prefix}{ctrl_prefix}", name
         )
 
         with self.add_children_as_readables():

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -224,25 +224,26 @@ class PressureJumpCell(StandardReadable):
     def __init__(
         self,
         beamline_prefix: str,
+        prefix: str,
         cell_prefix: str = "-HPXC-01:",
         adc_prefix: str = "-ADC",
         ctrl_prefix: str = "CTRL:",
         name: str = "",
     ):
         self.all_valves_control = AllValvesControl(
-            f"{beamline_prefix}{cell_prefix}", name
+            f"{beamline_prefix}{prefix}{cell_prefix}", name
         )
-        self.pump = Pump(f"{beamline_prefix}{cell_prefix}", name)
+        self.pump = Pump(f"{beamline_prefix}{prefix}{cell_prefix}", name)
 
         self.controller = PressureJumpCellController(
-            f"{beamline_prefix}{cell_prefix}{ctrl_prefix}", name
+            f"{beamline_prefix}{prefix}{cell_prefix}{ctrl_prefix}", name
         )
 
         with self.add_children_as_readables():
             self.pressure_transducers: DeviceVector[PressureTransducer] = DeviceVector(
                 {
                     i: PressureTransducer(
-                        prefix=f"{beamline_prefix}{cell_prefix}",
+                        prefix=f"{beamline_prefix}{prefix}{cell_prefix}",
                         number=i,
                         adc_prefix=f"{beamline_prefix}{adc_prefix}-0{i}:",
                     )
@@ -251,7 +252,7 @@ class PressureJumpCell(StandardReadable):
             )
 
             self.cell_temperature = epics_signal_r(
-                float, f"{beamline_prefix}{cell_prefix}TEMP"
+                float, f"{beamline_prefix}{prefix}{cell_prefix}TEMP"
             )
 
         super().__init__(name)

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -4,12 +4,9 @@ import pytest
 from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
 
 from dodal.devices.pressure_jump_cell import (
-    BusyState,
     FastValveState,
-    LimitSwitchState,
     PressureJumpCell,
     PumpMotorDirectionState,
-    TimerState,
     ValveState,
 )
 

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -6,12 +6,13 @@ from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
 from dodal.devices.pressure_jump_cell import (
     PressureJumpCell,
     PressureJumpCellBusyStatus,
+    PressureJumpCellFastValveState,
+    PressureJumpCellLimitSwitch,
     PressureJumpCellPumpMotorDirection,
     PressureJumpCellTimerState,
     PressureJumpCellValveState,
-    PressureJumpCellFastValveState,
-    PressureJumpCellLimitSwitch
 )
+
 
 @pytest.fixture
 async def pressurejumpcell() -> PressureJumpCell:
@@ -26,18 +27,25 @@ async def test_reading_pjumpcell_includes_read_fields(
 ):
     set_mock_value(pressurejumpcell.valve1_state, PressureJumpCellValveState.CLOSED)
     set_mock_value(pressurejumpcell.valve3_state, PressureJumpCellValveState.OPEN)
-    set_mock_value(pressurejumpcell.valve5_state, PressureJumpCellFastValveState.CLOSED_ARMED)
-    set_mock_value(pressurejumpcell.valve6_state, PressureJumpCellFastValveState.OPEN_ARMED)
+    set_mock_value(
+        pressurejumpcell.valve5_state, PressureJumpCellFastValveState.CLOSED_ARMED
+    )
+    set_mock_value(
+        pressurejumpcell.valve6_state, PressureJumpCellFastValveState.OPEN_ARMED
+    )
     set_mock_value(pressurejumpcell.cell_temperature, 12.3)
-    set_mock_value(pressurejumpcell.pump_position,  100)
+    set_mock_value(pressurejumpcell.pump_position, 100)
     set_mock_value(pressurejumpcell.pump_forward_limit, PressureJumpCellLimitSwitch.OFF)
     set_mock_value(pressurejumpcell.pump_backward_limit, PressureJumpCellLimitSwitch.ON)
-    set_mock_value(pressurejumpcell.pump_motor_direction, PressureJumpCellPumpMotorDirection.FORWARD)
+    set_mock_value(
+        pressurejumpcell.pump_motor_direction,
+        PressureJumpCellPumpMotorDirection.FORWARD,
+    )
     set_mock_value(pressurejumpcell.pump_speed_rbv, 100)
     set_mock_value(pressurejumpcell.pressuretransducer1_omron_pressure, 1001)
     set_mock_value(pressurejumpcell.pressuretransducer1_omron_voltage, 2.51)
     set_mock_value(pressurejumpcell.pressuretransducer1_beckhoff_pressure, 1001.1)
-    set_mock_value(pressurejumpcell.pressuretransducer1_beckhoff_voltage,  2.51)
+    set_mock_value(pressurejumpcell.pressuretransducer1_beckhoff_voltage, 2.51)
     set_mock_value(pressurejumpcell.pressuretransducer2_omron_pressure, 1002)
     set_mock_value(pressurejumpcell.pressuretransducer2_omron_voltage, 2.52)
     set_mock_value(pressurejumpcell.pressuretransducer2_beckhoff_pressure, 1002.2)
@@ -50,10 +58,9 @@ async def test_reading_pjumpcell_includes_read_fields(
     set_mock_value(pressurejumpcell.control_timer, PressureJumpCellTimerState.COUNTDOWN)
     set_mock_value(pressurejumpcell.control_counter, 123)
     set_mock_value(pressurejumpcell.control_script_status, "ABC")
-    set_mock_value(pressurejumpcell.control_routine,  "CDE")
+    set_mock_value(pressurejumpcell.control_routine, "CDE")
     set_mock_value(pressurejumpcell.control_state, "EFG")
     set_mock_value(pressurejumpcell.control_iteration, 456)
-
 
     await assert_reading(
         pressurejumpcell,
@@ -205,4 +212,3 @@ async def test_reading_pjumpcell_includes_read_fields(
             },
         },
     )
-

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -1,5 +1,6 @@
-from unittest.mock import ANY
 import asyncio
+from unittest.mock import ANY
+
 import pytest
 from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
 
@@ -131,14 +132,13 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
     )
 
     # Set new values
-    
+
     await cell.all_valves_control.set_valve(1, ValveControlRequest.CLOSE)
     await cell.all_valves_control.set_valve(6, FastValveControlRequest.ARM)
 
     await asyncio.gather(
         cell.all_valves_control.set_valve(1, ValveControlRequest.OPEN),
         cell.all_valves_control.set_valve(6, FastValveControlRequest.OPEN),
-
         # Check valves requested to open are set to OPEN_SEQ on initially calling
         # set_valve()
         assert_reading(
@@ -153,7 +153,7 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
                     "value": ANY,
                     "timestamp": ANY,
                     "alarm_severity": 0,
-            },
+                },
             },
         ),
         assert_reading(
@@ -168,10 +168,9 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
                     "value": ANY,
                     "timestamp": ANY,
                     "alarm_severity": 0,
+                },
             },
-            },
-        )
-
+        ),
     )
 
     # Check slow valves have been set to the new value and valves requested to open are

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -66,13 +66,13 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
     cell: PressureJumpCell,
 ):
     set_mock_value(cell.pump.pump_position, 100)
-    set_mock_value(cell.pump.pump_forward_limit, LimitSwitchState.OFF)
-    set_mock_value(cell.pump.pump_backward_limit, LimitSwitchState.ON)
+    # set_mock_value(cell.pump.pump_forward_limit, LimitSwitchState.OFF)
+    # set_mock_value(cell.pump.pump_backward_limit, LimitSwitchState.ON)
     set_mock_value(
         cell.pump.pump_motor_direction,
         PumpMotorDirectionState.FORWARD,
     )
-    set_mock_value(cell.pump.pump_speed_rbv, 100)
+    set_mock_value(cell.pump.pump_speed, 100)
 
     await assert_reading(
         cell.pump,
@@ -82,22 +82,12 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pump-pump_forward_limit": {
-                "value": LimitSwitchState.OFF,
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-pump-pump_backward_limit": {
-                "value": LimitSwitchState.ON,
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
             "pjump-pump-pump_motor_direction": {
                 "value": PumpMotorDirectionState.FORWARD,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pump-pump_speed_rbv": {
+            "pjump-pump-pump_speed": {
                 "value": 100,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -194,59 +184,6 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
             },
             "pjump-pressure_transducers-3-beckhoff_voltage": {
                 "value": 2.53,
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-        },
-    )
-
-
-async def test_reading_pjumpcell_includes_read_fields_controller(
-    cell: PressureJumpCell,
-):
-    set_mock_value(cell.controller.control_gotobusy, BusyState.IDLE)
-    set_mock_value(cell.controller.control_timer, TimerState.COUNTDOWN)
-    set_mock_value(cell.controller.control_counter, 123)
-    set_mock_value(cell.controller.control_script_status, "ABC")
-    set_mock_value(cell.controller.control_routine, "CDE")
-    set_mock_value(cell.controller.state, "EFG")
-    set_mock_value(cell.controller.control_iteration, 456)
-
-    await assert_reading(
-        cell.controller,
-        {
-            "pjump-controller-control_gotobusy": {
-                "value": BusyState.IDLE,
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-controller-control_timer": {
-                "value": TimerState.COUNTDOWN,
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-controller-control_counter": {
-                "value": 123,
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-controller-control_script_status": {
-                "value": "ABC",
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-controller-control_routine": {
-                "value": "CDE",
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-controller-control_state": {
-                "value": "EFG",
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-controller-control_iteration": {
-                "value": 456,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -22,191 +22,266 @@ async def pressurejumpcell() -> PressureJumpCell:
     return pjump
 
 
-async def test_reading_pjumpcell_includes_read_fields(
+async def test_reading_pjumpcell_includes_read_fields_valves(
     pressurejumpcell: PressureJumpCell,
 ):
-    set_mock_value(pressurejumpcell.valve1_state, PressureJumpCellValveState.CLOSED)
-    set_mock_value(pressurejumpcell.valve3_state, PressureJumpCellValveState.OPEN)
     set_mock_value(
-        pressurejumpcell.valve5_state, PressureJumpCellFastValveState.CLOSED_ARMED
+        pressurejumpcell.valves.valve1_state, PressureJumpCellValveState.CLOSED
     )
     set_mock_value(
-        pressurejumpcell.valve6_state, PressureJumpCellFastValveState.OPEN_ARMED
+        pressurejumpcell.valves.valve3_state, PressureJumpCellValveState.OPEN
     )
-    set_mock_value(pressurejumpcell.cell_temperature, 12.3)
-    set_mock_value(pressurejumpcell.pump_position, 100)
-    set_mock_value(pressurejumpcell.pump_forward_limit, PressureJumpCellLimitSwitch.OFF)
-    set_mock_value(pressurejumpcell.pump_backward_limit, PressureJumpCellLimitSwitch.ON)
     set_mock_value(
-        pressurejumpcell.pump_motor_direction,
-        PressureJumpCellPumpMotorDirection.FORWARD,
+        pressurejumpcell.valves.valve5_state,
+        PressureJumpCellFastValveState.CLOSED_ARMED,
     )
-    set_mock_value(pressurejumpcell.pump_speed_rbv, 100)
-    set_mock_value(pressurejumpcell.pressuretransducer1_omron_pressure, 1001)
-    set_mock_value(pressurejumpcell.pressuretransducer1_omron_voltage, 2.51)
-    set_mock_value(pressurejumpcell.pressuretransducer1_beckhoff_pressure, 1001.1)
-    set_mock_value(pressurejumpcell.pressuretransducer1_beckhoff_voltage, 2.51)
-    set_mock_value(pressurejumpcell.pressuretransducer2_omron_pressure, 1002)
-    set_mock_value(pressurejumpcell.pressuretransducer2_omron_voltage, 2.52)
-    set_mock_value(pressurejumpcell.pressuretransducer2_beckhoff_pressure, 1002.2)
-    set_mock_value(pressurejumpcell.pressuretransducer2_beckhoff_voltage, 2.52)
-    set_mock_value(pressurejumpcell.pressuretransducer3_omron_pressure, 1003)
-    set_mock_value(pressurejumpcell.pressuretransducer3_omron_voltage, 2.53)
-    set_mock_value(pressurejumpcell.pressuretransducer3_beckhoff_pressure, 1003.3)
-    set_mock_value(pressurejumpcell.pressuretransducer3_beckhoff_voltage, 2.53)
-    set_mock_value(pressurejumpcell.control_gotobusy, PressureJumpCellBusyStatus.IDLE)
-    set_mock_value(pressurejumpcell.control_timer, PressureJumpCellTimerState.COUNTDOWN)
-    set_mock_value(pressurejumpcell.control_counter, 123)
-    set_mock_value(pressurejumpcell.control_script_status, "ABC")
-    set_mock_value(pressurejumpcell.control_routine, "CDE")
-    set_mock_value(pressurejumpcell.control_state, "EFG")
-    set_mock_value(pressurejumpcell.control_iteration, 456)
+    set_mock_value(
+        pressurejumpcell.valves.valve6_state, PressureJumpCellFastValveState.OPEN_ARMED
+    )
 
     await assert_reading(
-        pressurejumpcell,
+        pressurejumpcell.valves,
         {
-            "pjump-valve1_state": {
+            "pjump-valves-valve1_state": {
                 "value": PressureJumpCellValveState.CLOSED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-valve3_state": {
+            "pjump-valves-valve3_state": {
                 "value": PressureJumpCellValveState.OPEN,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-valve5_state": {
+            "pjump-valves-valve5_state": {
                 "value": PressureJumpCellFastValveState.CLOSED_ARMED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-valve6_state": {
+            "pjump-valves-valve6_state": {
                 "value": PressureJumpCellFastValveState.OPEN_ARMED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-cell_temperature": {
-                "value": 12.3,
-                "timestamp": ANY,
-                "alarm_severity": 0,
-            },
-            "pjump-pump_position": {
+        },
+    )
+
+
+async def test_reading_pjumpcell_includes_read_fields_pump(
+    pressurejumpcell: PressureJumpCell,
+):
+    set_mock_value(pressurejumpcell.pump.pump_position, 100)
+    set_mock_value(
+        pressurejumpcell.pump.pump_forward_limit, PressureJumpCellLimitSwitch.OFF
+    )
+    set_mock_value(
+        pressurejumpcell.pump.pump_backward_limit, PressureJumpCellLimitSwitch.ON
+    )
+    set_mock_value(
+        pressurejumpcell.pump.pump_motor_direction,
+        PressureJumpCellPumpMotorDirection.FORWARD,
+    )
+    set_mock_value(pressurejumpcell.pump.pump_speed_rbv, 100)
+
+    await assert_reading(
+        pressurejumpcell.pump,
+        {
+            "pjump-pump-pump_position": {
                 "value": 100,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pump_forward_limit": {
+            "pjump-pump-pump_forward_limit": {
                 "value": PressureJumpCellLimitSwitch.OFF,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pump_backward_limit": {
+            "pjump-pump-pump_backward_limit": {
                 "value": PressureJumpCellLimitSwitch.ON,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pump_motor_direction": {
+            "pjump-pump-pump_motor_direction": {
                 "value": PressureJumpCellPumpMotorDirection.FORWARD,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pump_speed_rbv": {
+            "pjump-pump-pump_speed_rbv": {
                 "value": 100,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer1_omron_pressure": {
+        },
+    )
+
+
+async def test_reading_pjumpcell_includes_read_fields_transducers(
+    pressurejumpcell: PressureJumpCell,
+):
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer1_omron_pressure, 1001
+    )
+    set_mock_value(pressurejumpcell.transducers.pressuretransducer1_omron_voltage, 2.51)
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer1_beckhoff_pressure, 1001.1
+    )
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer1_beckhoff_voltage, 2.51
+    )
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer2_omron_pressure, 1002
+    )
+    set_mock_value(pressurejumpcell.transducers.pressuretransducer2_omron_voltage, 2.52)
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer2_beckhoff_pressure, 1002.2
+    )
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer2_beckhoff_voltage, 2.52
+    )
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer3_omron_pressure, 1003
+    )
+    set_mock_value(pressurejumpcell.transducers.pressuretransducer3_omron_voltage, 2.53)
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer3_beckhoff_pressure, 1003.3
+    )
+    set_mock_value(
+        pressurejumpcell.transducers.pressuretransducer3_beckhoff_voltage, 2.53
+    )
+
+    await assert_reading(
+        pressurejumpcell.transducers,
+        {
+            "pjump-transducers-pressuretransducer1_omron_pressure": {
                 "value": 1001,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer1_omron_voltage": {
+            "pjump-transducers-pressuretransducer1_omron_voltage": {
                 "value": 2.51,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer1_beckhoff_pressure": {
+            "pjump-transducers-pressuretransducer1_beckhoff_pressure": {
                 "value": 1001.1,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer1_beckhoff_voltage": {
+            "pjump-transducers-pressuretransducer1_beckhoff_voltage": {
                 "value": 2.51,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer2_omron_pressure": {
+            "pjump-transducers-pressuretransducer2_omron_pressure": {
                 "value": 1002,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer2_omron_voltage": {
+            "pjump-transducers-pressuretransducer2_omron_voltage": {
                 "value": 2.52,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer2_beckhoff_pressure": {
+            "pjump-transducers-pressuretransducer2_beckhoff_pressure": {
                 "value": 1002.2,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer2_beckhoff_voltage": {
+            "pjump-transducers-pressuretransducer2_beckhoff_voltage": {
                 "value": 2.52,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer3_omron_pressure": {
+            "pjump-transducers-pressuretransducer3_omron_pressure": {
                 "value": 1003,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer3_omron_voltage": {
+            "pjump-transducers-pressuretransducer3_omron_voltage": {
                 "value": 2.53,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer3_beckhoff_pressure": {
+            "pjump-transducers-pressuretransducer3_beckhoff_pressure": {
                 "value": 1003.3,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressuretransducer3_beckhoff_voltage": {
+            "pjump-transducers-pressuretransducer3_beckhoff_voltage": {
                 "value": 2.53,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-control_gotobusy": {
+        },
+    )
+
+
+async def test_reading_pjumpcell_includes_read_fields_controller(
+    pressurejumpcell: PressureJumpCell,
+):
+    set_mock_value(
+        pressurejumpcell.controller.control_gotobusy, PressureJumpCellBusyStatus.IDLE
+    )
+    set_mock_value(
+        pressurejumpcell.controller.control_timer, PressureJumpCellTimerState.COUNTDOWN
+    )
+    set_mock_value(pressurejumpcell.controller.control_counter, 123)
+    set_mock_value(pressurejumpcell.controller.control_script_status, "ABC")
+    set_mock_value(pressurejumpcell.controller.control_routine, "CDE")
+    set_mock_value(pressurejumpcell.controller.control_state, "EFG")
+    set_mock_value(pressurejumpcell.controller.control_iteration, 456)
+
+    await assert_reading(
+        pressurejumpcell.controller,
+        {
+            "pjump-controller-control_gotobusy": {
                 "value": PressureJumpCellBusyStatus.IDLE,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-control_timer": {
+            "pjump-controller-control_timer": {
                 "value": PressureJumpCellTimerState.COUNTDOWN,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-control_counter": {
+            "pjump-controller-control_counter": {
                 "value": 123,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-control_script_status": {
+            "pjump-controller-control_script_status": {
                 "value": "ABC",
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-control_routine": {
+            "pjump-controller-control_routine": {
                 "value": "CDE",
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-control_state": {
+            "pjump-controller-control_state": {
                 "value": "EFG",
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-control_iteration": {
+            "pjump-controller-control_iteration": {
                 "value": 456,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+        },
+    )
+
+
+async def test_reading_pjumpcell_includes_read_fields(
+    pressurejumpcell: PressureJumpCell,
+):
+    set_mock_value(pressurejumpcell.cell_temperature, 12.3)
+
+    await assert_reading(
+        pressurejumpcell,
+        {
+            "pjump-cell_temperature": {
+                "value": 12.3,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -1,0 +1,208 @@
+from unittest.mock import ANY
+
+import pytest
+from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
+
+from dodal.devices.pressure_jump_cell import (
+    PressureJumpCell,
+    PressureJumpCellBusyStatus,
+    PressureJumpCellPumpMotorDirection,
+    PressureJumpCellTimerState,
+    PressureJumpCellValveState,
+    PressureJumpCellFastValveState,
+    PressureJumpCellLimitSwitch
+)
+
+@pytest.fixture
+async def pressurejumpcell() -> PressureJumpCell:
+    async with DeviceCollector(mock=True):
+        pjump = PressureJumpCell("DEMO-PJUMPCELL-01:")
+
+    return pjump
+
+
+async def test_reading_pjumpcell_includes_read_fields(
+    pressurejumpcell: PressureJumpCell,
+):
+    set_mock_value(pressurejumpcell.valve1_state, PressureJumpCellValveState.CLOSED)
+    set_mock_value(pressurejumpcell.valve3_state, PressureJumpCellValveState.OPEN)
+    set_mock_value(pressurejumpcell.valve5_state, PressureJumpCellFastValveState.CLOSED_ARMED)
+    set_mock_value(pressurejumpcell.valve6_state, PressureJumpCellFastValveState.OPEN_ARMED)
+    set_mock_value(pressurejumpcell.cell_temperature, 12.3)
+    set_mock_value(pressurejumpcell.pump_position,  100)
+    set_mock_value(pressurejumpcell.pump_forward_limit, PressureJumpCellLimitSwitch.OFF)
+    set_mock_value(pressurejumpcell.pump_backward_limit, PressureJumpCellLimitSwitch.ON)
+    set_mock_value(pressurejumpcell.pump_motor_direction, PressureJumpCellPumpMotorDirection.FORWARD)
+    set_mock_value(pressurejumpcell.pump_speed_rbv, 100)
+    set_mock_value(pressurejumpcell.pressuretransducer1_omron_pressure, 1001)
+    set_mock_value(pressurejumpcell.pressuretransducer1_omron_voltage, 2.51)
+    set_mock_value(pressurejumpcell.pressuretransducer1_beckhoff_pressure, 1001.1)
+    set_mock_value(pressurejumpcell.pressuretransducer1_beckhoff_voltage,  2.51)
+    set_mock_value(pressurejumpcell.pressuretransducer2_omron_pressure, 1002)
+    set_mock_value(pressurejumpcell.pressuretransducer2_omron_voltage, 2.52)
+    set_mock_value(pressurejumpcell.pressuretransducer2_beckhoff_pressure, 1002.2)
+    set_mock_value(pressurejumpcell.pressuretransducer2_beckhoff_voltage, 2.52)
+    set_mock_value(pressurejumpcell.pressuretransducer3_omron_pressure, 1003)
+    set_mock_value(pressurejumpcell.pressuretransducer3_omron_voltage, 2.53)
+    set_mock_value(pressurejumpcell.pressuretransducer3_beckhoff_pressure, 1003.3)
+    set_mock_value(pressurejumpcell.pressuretransducer3_beckhoff_voltage, 2.53)
+    set_mock_value(pressurejumpcell.control_gotobusy, PressureJumpCellBusyStatus.IDLE)
+    set_mock_value(pressurejumpcell.control_timer, PressureJumpCellTimerState.COUNTDOWN)
+    set_mock_value(pressurejumpcell.control_counter, 123)
+    set_mock_value(pressurejumpcell.control_script_status, "ABC")
+    set_mock_value(pressurejumpcell.control_routine,  "CDE")
+    set_mock_value(pressurejumpcell.control_state, "EFG")
+    set_mock_value(pressurejumpcell.control_iteration, 456)
+
+
+    await assert_reading(
+        pressurejumpcell,
+        {
+            "pjump-valve1_state": {
+                "value": PressureJumpCellValveState.CLOSED,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-valve3_state": {
+                "value": PressureJumpCellValveState.OPEN,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-valve5_state": {
+                "value": PressureJumpCellFastValveState.CLOSED_ARMED,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-valve6_state": {
+                "value": PressureJumpCellFastValveState.OPEN_ARMED,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-cell_temperature": {
+                "value": 12.3,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pump_position": {
+                "value": 100,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pump_forward_limit": {
+                "value": PressureJumpCellLimitSwitch.OFF,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pump_backward_limit": {
+                "value": PressureJumpCellLimitSwitch.ON,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pump_motor_direction": {
+                "value": PressureJumpCellPumpMotorDirection.FORWARD,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pump_speed_rbv": {
+                "value": 100,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer1_omron_pressure": {
+                "value": 1001,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer1_omron_voltage": {
+                "value": 2.51,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer1_beckhoff_pressure": {
+                "value": 1001.1,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer1_beckhoff_voltage": {
+                "value": 2.51,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer2_omron_pressure": {
+                "value": 1002,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer2_omron_voltage": {
+                "value": 2.52,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer2_beckhoff_pressure": {
+                "value": 1002.2,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer2_beckhoff_voltage": {
+                "value": 2.52,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer3_omron_pressure": {
+                "value": 1003,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer3_omron_voltage": {
+                "value": 2.53,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer3_beckhoff_pressure": {
+                "value": 1003.3,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-pressuretransducer3_beckhoff_voltage": {
+                "value": 2.53,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-control_gotobusy": {
+                "value": PressureJumpCellBusyStatus.IDLE,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-control_timer": {
+                "value": PressureJumpCellTimerState.COUNTDOWN,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-control_counter": {
+                "value": 123,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-control_script_status": {
+                "value": "ABC",
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-control_routine": {
+                "value": "CDE",
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-control_state": {
+                "value": "EFG",
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-control_iteration": {
+                "value": 456,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+        },
+    )
+

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -109,38 +109,40 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
 async def test_reading_pjumpcell_includes_read_fields_transducers(
     cell: PressureJumpCell,
 ):
-    set_mock_value(cell.pressure_transducer_1.omron_pressure, 1001)
-    set_mock_value(cell.pressure_transducer_1.omron_voltage, 2.51)
-    set_mock_value(cell.pressure_transducer_1.beckhoff_pressure, 1001.1)
-    set_mock_value(cell.pressure_transducer_1.beckhoff_voltage, 2.51)
-    set_mock_value(cell.pressure_transducer_2.omron_pressure, 1002)
-    set_mock_value(cell.pressure_transducer_2.omron_voltage, 2.52)
-    set_mock_value(cell.pressure_transducer_2.beckhoff_pressure, 1002.2)
-    set_mock_value(cell.pressure_transducer_2.beckhoff_voltage, 2.52)
-    set_mock_value(cell.pressure_transducer_3.omron_pressure, 1003)
-    set_mock_value(cell.pressure_transducer_3.omron_voltage, 2.53)
-    set_mock_value(cell.pressure_transducer_3.beckhoff_pressure, 1003.3)
-    set_mock_value(cell.pressure_transducer_3.beckhoff_voltage, 2.53)
+    set_mock_value(cell.pressure_transducers[1].omron_pressure, 1001)
+    set_mock_value(cell.pressure_transducers[1].omron_voltage, 2.51)
+    set_mock_value(cell.pressure_transducers[1].beckhoff_pressure, 1001.1)
+    set_mock_value(cell.pressure_transducers[1].beckhoff_voltage, 2.51)
+
+    set_mock_value(cell.pressure_transducers[2].omron_pressure, 1002)
+    set_mock_value(cell.pressure_transducers[2].omron_voltage, 2.52)
+    set_mock_value(cell.pressure_transducers[2].beckhoff_pressure, 1002.2)
+    set_mock_value(cell.pressure_transducers[2].beckhoff_voltage, 2.52)
+
+    set_mock_value(cell.pressure_transducers[3].omron_pressure, 1003)
+    set_mock_value(cell.pressure_transducers[3].omron_voltage, 2.53)
+    set_mock_value(cell.pressure_transducers[3].beckhoff_pressure, 1003.3)
+    set_mock_value(cell.pressure_transducers[3].beckhoff_voltage, 2.53)
 
     await assert_reading(
-        cell.pressure_transducer_1,
+        cell.pressure_transducers[1],
         {
-            "pjump-pressure_transducer_1-omron_pressure": {
+            "pjump-pressure_transducers-1-omron_pressure": {
                 "value": 1001,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_1-omron_voltage": {
+            "pjump-pressure_transducers-1-omron_voltage": {
                 "value": 2.51,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_1-beckhoff_pressure": {
+            "pjump-pressure_transducers-1-beckhoff_pressure": {
                 "value": 1001.1,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_1-beckhoff_voltage": {
+            "pjump-pressure_transducers-1-beckhoff_voltage": {
                 "value": 2.51,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -148,24 +150,24 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
         },
     )
     await assert_reading(
-        cell.pressure_transducer_2,
+        cell.pressure_transducers[2],
         {
-            "pjump-pressure_transducer_2-omron_pressure": {
+            "pjump-pressure_transducers-2-omron_pressure": {
                 "value": 1002,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_2-omron_voltage": {
+            "pjump-pressure_transducers-2-omron_voltage": {
                 "value": 2.52,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_2-beckhoff_pressure": {
+            "pjump-pressure_transducers-2-beckhoff_pressure": {
                 "value": 1002.2,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_2-beckhoff_voltage": {
+            "pjump-pressure_transducers-2-beckhoff_voltage": {
                 "value": 2.52,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -173,24 +175,24 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
         },
     )
     await assert_reading(
-        cell.pressure_transducer_3,
+        cell.pressure_transducers[3],
         {
-            "pjump-pressure_transducer_3-omron_pressure": {
+            "pjump-pressure_transducers-3-omron_pressure": {
                 "value": 1003,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_3-omron_voltage": {
+            "pjump-pressure_transducers-3-omron_voltage": {
                 "value": 2.53,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_3-beckhoff_pressure": {
+            "pjump-pressure_transducers-3-beckhoff_pressure": {
                 "value": 1003.3,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducer_3-beckhoff_voltage": {
+            "pjump-pressure_transducers-3-beckhoff_voltage": {
                 "value": 2.53,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -258,7 +260,7 @@ async def test_reading_pjumpcell_includes_read_fields(
     set_mock_value(cell.cell_temperature, 12.3)
 
     await assert_reading(
-        cell,
+        cell.cell_temperature,
         {
             "pjump-cell_temperature": {
                 "value": 12.3,

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -15,7 +15,7 @@ from dodal.devices.pressure_jump_cell import (
 
 
 @pytest.fixture
-async def pressurejumpcell() -> PressureJumpCell:
+async def cell() -> PressureJumpCell:
     async with DeviceCollector(mock=True):
         pjump = PressureJumpCell("DEMO-PJUMPCELL-01:")
 
@@ -23,35 +23,37 @@ async def pressurejumpcell() -> PressureJumpCell:
 
 
 async def test_reading_pjumpcell_includes_read_fields_valves(
-    pressurejumpcell: PressureJumpCell,
+    cell: PressureJumpCell,
 ):
-    set_mock_value(pressurejumpcell.valves.valve1_state, ValveState.CLOSED)
-    set_mock_value(pressurejumpcell.valves.valve3_state, ValveState.OPEN)
+    set_mock_value(cell.all_valves_control.valve_states[1], ValveState.CLOSED)
+    set_mock_value(cell.all_valves_control.valve_states[3], ValveState.OPEN)
     set_mock_value(
-        pressurejumpcell.valves.valve5_state,
+        cell.all_valves_control.fast_valve_states[5],
         FastValveState.CLOSED_ARMED,
     )
-    set_mock_value(pressurejumpcell.valves.valve6_state, FastValveState.OPEN_ARMED)
+    set_mock_value(
+        cell.all_valves_control.fast_valve_states[6], FastValveState.OPEN_ARMED
+    )
 
     await assert_reading(
-        pressurejumpcell.valves,
+        cell.all_valves_control,
         {
-            "pjump-valves-valve1_state": {
+            "pjump-all_valves_control-valve_states-1": {
                 "value": ValveState.CLOSED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-valves-valve3_state": {
+            "pjump-all_valves_control-valve_states-3": {
                 "value": ValveState.OPEN,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-valves-valve5_state": {
+            "pjump-all_valves_control-fast_valve_states-5": {
                 "value": FastValveState.CLOSED_ARMED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-valves-valve6_state": {
+            "pjump-all_valves_control-fast_valve_states-6": {
                 "value": FastValveState.OPEN_ARMED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -61,19 +63,19 @@ async def test_reading_pjumpcell_includes_read_fields_valves(
 
 
 async def test_reading_pjumpcell_includes_read_fields_pump(
-    pressurejumpcell: PressureJumpCell,
+    cell: PressureJumpCell,
 ):
-    set_mock_value(pressurejumpcell.pump.pump_position, 100)
-    set_mock_value(pressurejumpcell.pump.pump_forward_limit, LimitSwitchState.OFF)
-    set_mock_value(pressurejumpcell.pump.pump_backward_limit, LimitSwitchState.ON)
+    set_mock_value(cell.pump.pump_position, 100)
+    set_mock_value(cell.pump.pump_forward_limit, LimitSwitchState.OFF)
+    set_mock_value(cell.pump.pump_backward_limit, LimitSwitchState.ON)
     set_mock_value(
-        pressurejumpcell.pump.pump_motor_direction,
+        cell.pump.pump_motor_direction,
         PumpMotorDirectionState.FORWARD,
     )
-    set_mock_value(pressurejumpcell.pump.pump_speed_rbv, 100)
+    set_mock_value(cell.pump.pump_speed_rbv, 100)
 
     await assert_reading(
-        pressurejumpcell.pump,
+        cell.pump,
         {
             "pjump-pump-pump_position": {
                 "value": 100,
@@ -105,98 +107,90 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
 
 
 async def test_reading_pjumpcell_includes_read_fields_transducers(
-    pressurejumpcell: PressureJumpCell,
+    cell: PressureJumpCell,
 ):
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer1_omron_pressure, 1001
-    )
-    set_mock_value(pressurejumpcell.transducers.pressuretransducer1_omron_voltage, 2.51)
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer1_beckhoff_pressure, 1001.1
-    )
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer1_beckhoff_voltage, 2.51
-    )
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer2_omron_pressure, 1002
-    )
-    set_mock_value(pressurejumpcell.transducers.pressuretransducer2_omron_voltage, 2.52)
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer2_beckhoff_pressure, 1002.2
-    )
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer2_beckhoff_voltage, 2.52
-    )
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer3_omron_pressure, 1003
-    )
-    set_mock_value(pressurejumpcell.transducers.pressuretransducer3_omron_voltage, 2.53)
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer3_beckhoff_pressure, 1003.3
-    )
-    set_mock_value(
-        pressurejumpcell.transducers.pressuretransducer3_beckhoff_voltage, 2.53
-    )
+    set_mock_value(cell.pressure_transducer_1.omron_pressure, 1001)
+    set_mock_value(cell.pressure_transducer_1.omron_voltage, 2.51)
+    set_mock_value(cell.pressure_transducer_1.beckhoff_pressure, 1001.1)
+    set_mock_value(cell.pressure_transducer_1.beckhoff_voltage, 2.51)
+    set_mock_value(cell.pressure_transducer_2.omron_pressure, 1002)
+    set_mock_value(cell.pressure_transducer_2.omron_voltage, 2.52)
+    set_mock_value(cell.pressure_transducer_2.beckhoff_pressure, 1002.2)
+    set_mock_value(cell.pressure_transducer_2.beckhoff_voltage, 2.52)
+    set_mock_value(cell.pressure_transducer_3.omron_pressure, 1003)
+    set_mock_value(cell.pressure_transducer_3.omron_voltage, 2.53)
+    set_mock_value(cell.pressure_transducer_3.beckhoff_pressure, 1003.3)
+    set_mock_value(cell.pressure_transducer_3.beckhoff_voltage, 2.53)
 
     await assert_reading(
-        pressurejumpcell.transducers,
+        cell.pressure_transducer_1,
         {
-            "pjump-transducers-pressuretransducer1_omron_pressure": {
+            "pjump-pressure_transducer_1-omron_pressure": {
                 "value": 1001,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer1_omron_voltage": {
+            "pjump-pressure_transducer_1-omron_voltage": {
                 "value": 2.51,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer1_beckhoff_pressure": {
+            "pjump-pressure_transducer_1-beckhoff_pressure": {
                 "value": 1001.1,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer1_beckhoff_voltage": {
+            "pjump-pressure_transducer_1-beckhoff_voltage": {
                 "value": 2.51,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer2_omron_pressure": {
+        },
+    )
+    await assert_reading(
+        cell.pressure_transducer_2,
+        {
+            "pjump-pressure_transducer_2-omron_pressure": {
                 "value": 1002,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer2_omron_voltage": {
+            "pjump-pressure_transducer_2-omron_voltage": {
                 "value": 2.52,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer2_beckhoff_pressure": {
+            "pjump-pressure_transducer_2-beckhoff_pressure": {
                 "value": 1002.2,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer2_beckhoff_voltage": {
+            "pjump-pressure_transducer_2-beckhoff_voltage": {
                 "value": 2.52,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer3_omron_pressure": {
+        },
+    )
+    await assert_reading(
+        cell.pressure_transducer_3,
+        {
+            "pjump-pressure_transducer_3-omron_pressure": {
                 "value": 1003,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer3_omron_voltage": {
+            "pjump-pressure_transducer_3-omron_voltage": {
                 "value": 2.53,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer3_beckhoff_pressure": {
+            "pjump-pressure_transducer_3-beckhoff_pressure": {
                 "value": 1003.3,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-transducers-pressuretransducer3_beckhoff_voltage": {
+            "pjump-pressure_transducer_3-beckhoff_voltage": {
                 "value": 2.53,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -206,18 +200,18 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
 
 
 async def test_reading_pjumpcell_includes_read_fields_controller(
-    pressurejumpcell: PressureJumpCell,
+    cell: PressureJumpCell,
 ):
-    set_mock_value(pressurejumpcell.controller.control_gotobusy, BusyState.IDLE)
-    set_mock_value(pressurejumpcell.controller.control_timer, TimerState.COUNTDOWN)
-    set_mock_value(pressurejumpcell.controller.control_counter, 123)
-    set_mock_value(pressurejumpcell.controller.control_script_status, "ABC")
-    set_mock_value(pressurejumpcell.controller.control_routine, "CDE")
-    set_mock_value(pressurejumpcell.controller.control_state, "EFG")
-    set_mock_value(pressurejumpcell.controller.control_iteration, 456)
+    set_mock_value(cell.controller.control_gotobusy, BusyState.IDLE)
+    set_mock_value(cell.controller.control_timer, TimerState.COUNTDOWN)
+    set_mock_value(cell.controller.control_counter, 123)
+    set_mock_value(cell.controller.control_script_status, "ABC")
+    set_mock_value(cell.controller.control_routine, "CDE")
+    set_mock_value(cell.controller.control_state, "EFG")
+    set_mock_value(cell.controller.control_iteration, 456)
 
     await assert_reading(
-        pressurejumpcell.controller,
+        cell.controller,
         {
             "pjump-controller-control_gotobusy": {
                 "value": BusyState.IDLE,
@@ -259,12 +253,12 @@ async def test_reading_pjumpcell_includes_read_fields_controller(
 
 
 async def test_reading_pjumpcell_includes_read_fields(
-    pressurejumpcell: PressureJumpCell,
+    cell: PressureJumpCell,
 ):
-    set_mock_value(pressurejumpcell.cell_temperature, 12.3)
+    set_mock_value(cell.cell_temperature, 12.3)
 
     await assert_reading(
-        pressurejumpcell,
+        cell,
         {
             "pjump-cell_temperature": {
                 "value": 12.3,

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -4,13 +4,13 @@ import pytest
 from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
 
 from dodal.devices.pressure_jump_cell import (
+    BusyState,
+    FastValveState,
+    LimitSwitchState,
     PressureJumpCell,
-    PressureJumpCellBusyStatus,
-    PressureJumpCellFastValveState,
-    PressureJumpCellLimitSwitch,
-    PressureJumpCellPumpMotorDirection,
-    PressureJumpCellTimerState,
-    PressureJumpCellValveState,
+    PumpMotorDirectionState,
+    TimerState,
+    ValveState,
 )
 
 
@@ -25,40 +25,34 @@ async def pressurejumpcell() -> PressureJumpCell:
 async def test_reading_pjumpcell_includes_read_fields_valves(
     pressurejumpcell: PressureJumpCell,
 ):
-    set_mock_value(
-        pressurejumpcell.valves.valve1_state, PressureJumpCellValveState.CLOSED
-    )
-    set_mock_value(
-        pressurejumpcell.valves.valve3_state, PressureJumpCellValveState.OPEN
-    )
+    set_mock_value(pressurejumpcell.valves.valve1_state, ValveState.CLOSED)
+    set_mock_value(pressurejumpcell.valves.valve3_state, ValveState.OPEN)
     set_mock_value(
         pressurejumpcell.valves.valve5_state,
-        PressureJumpCellFastValveState.CLOSED_ARMED,
+        FastValveState.CLOSED_ARMED,
     )
-    set_mock_value(
-        pressurejumpcell.valves.valve6_state, PressureJumpCellFastValveState.OPEN_ARMED
-    )
+    set_mock_value(pressurejumpcell.valves.valve6_state, FastValveState.OPEN_ARMED)
 
     await assert_reading(
         pressurejumpcell.valves,
         {
             "pjump-valves-valve1_state": {
-                "value": PressureJumpCellValveState.CLOSED,
+                "value": ValveState.CLOSED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
             "pjump-valves-valve3_state": {
-                "value": PressureJumpCellValveState.OPEN,
+                "value": ValveState.OPEN,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
             "pjump-valves-valve5_state": {
-                "value": PressureJumpCellFastValveState.CLOSED_ARMED,
+                "value": FastValveState.CLOSED_ARMED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
             "pjump-valves-valve6_state": {
-                "value": PressureJumpCellFastValveState.OPEN_ARMED,
+                "value": FastValveState.OPEN_ARMED,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
@@ -70,15 +64,11 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
     pressurejumpcell: PressureJumpCell,
 ):
     set_mock_value(pressurejumpcell.pump.pump_position, 100)
-    set_mock_value(
-        pressurejumpcell.pump.pump_forward_limit, PressureJumpCellLimitSwitch.OFF
-    )
-    set_mock_value(
-        pressurejumpcell.pump.pump_backward_limit, PressureJumpCellLimitSwitch.ON
-    )
+    set_mock_value(pressurejumpcell.pump.pump_forward_limit, LimitSwitchState.OFF)
+    set_mock_value(pressurejumpcell.pump.pump_backward_limit, LimitSwitchState.ON)
     set_mock_value(
         pressurejumpcell.pump.pump_motor_direction,
-        PressureJumpCellPumpMotorDirection.FORWARD,
+        PumpMotorDirectionState.FORWARD,
     )
     set_mock_value(pressurejumpcell.pump.pump_speed_rbv, 100)
 
@@ -91,17 +81,17 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
                 "alarm_severity": 0,
             },
             "pjump-pump-pump_forward_limit": {
-                "value": PressureJumpCellLimitSwitch.OFF,
+                "value": LimitSwitchState.OFF,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
             "pjump-pump-pump_backward_limit": {
-                "value": PressureJumpCellLimitSwitch.ON,
+                "value": LimitSwitchState.ON,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
             "pjump-pump-pump_motor_direction": {
-                "value": PressureJumpCellPumpMotorDirection.FORWARD,
+                "value": PumpMotorDirectionState.FORWARD,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
@@ -218,12 +208,8 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
 async def test_reading_pjumpcell_includes_read_fields_controller(
     pressurejumpcell: PressureJumpCell,
 ):
-    set_mock_value(
-        pressurejumpcell.controller.control_gotobusy, PressureJumpCellBusyStatus.IDLE
-    )
-    set_mock_value(
-        pressurejumpcell.controller.control_timer, PressureJumpCellTimerState.COUNTDOWN
-    )
+    set_mock_value(pressurejumpcell.controller.control_gotobusy, BusyState.IDLE)
+    set_mock_value(pressurejumpcell.controller.control_timer, TimerState.COUNTDOWN)
     set_mock_value(pressurejumpcell.controller.control_counter, 123)
     set_mock_value(pressurejumpcell.controller.control_script_status, "ABC")
     set_mock_value(pressurejumpcell.controller.control_routine, "CDE")
@@ -234,12 +220,12 @@ async def test_reading_pjumpcell_includes_read_fields_controller(
         pressurejumpcell.controller,
         {
             "pjump-controller-control_gotobusy": {
-                "value": PressureJumpCellBusyStatus.IDLE,
+                "value": BusyState.IDLE,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
             "pjump-controller-control_timer": {
-                "value": PressureJumpCellTimerState.COUNTDOWN,
+                "value": TimerState.COUNTDOWN,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -99,17 +99,17 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
     set_mock_value(cell.pressure_transducers[1].omron_pressure, 1001)
     set_mock_value(cell.pressure_transducers[1].omron_voltage, 2.51)
     set_mock_value(cell.pressure_transducers[1].beckhoff_pressure, 1001.1)
-    set_mock_value(cell.pressure_transducers[1].beckhoff_voltage, 2.51)
+    set_mock_value(cell.pressure_transducers[1].slow_beckhoff_voltage_readout, 2.51)
 
     set_mock_value(cell.pressure_transducers[2].omron_pressure, 1002)
     set_mock_value(cell.pressure_transducers[2].omron_voltage, 2.52)
     set_mock_value(cell.pressure_transducers[2].beckhoff_pressure, 1002.2)
-    set_mock_value(cell.pressure_transducers[2].beckhoff_voltage, 2.52)
+    set_mock_value(cell.pressure_transducers[2].slow_beckhoff_voltage_readout, 2.52)
 
     set_mock_value(cell.pressure_transducers[3].omron_pressure, 1003)
     set_mock_value(cell.pressure_transducers[3].omron_voltage, 2.53)
     set_mock_value(cell.pressure_transducers[3].beckhoff_pressure, 1003.3)
-    set_mock_value(cell.pressure_transducers[3].beckhoff_voltage, 2.53)
+    set_mock_value(cell.pressure_transducers[3].slow_beckhoff_voltage_readout, 2.53)
 
     await assert_reading(
         cell.pressure_transducers[1],

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -209,7 +209,7 @@ async def test_reading_pjumpcell_includes_read_fields_controller(
     set_mock_value(cell.controller.control_counter, 123)
     set_mock_value(cell.controller.control_script_status, "ABC")
     set_mock_value(cell.controller.control_routine, "CDE")
-    set_mock_value(cell.controller.control_state, "EFG")
+    set_mock_value(cell.controller.state, "EFG")
     set_mock_value(cell.controller.control_iteration, 456)
 
     await assert_reading(


### PR DESCRIPTION
closes #658
Ophyd device for pressure jump cell #658, required for pressure jump experiment.

Initial control PVs, TODO fast adc capture.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
