### PR TITLE
Make ruff happy

### DIFF
--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -47,7 +47,7 @@ def test_instantiating_different_device_with_same_name():
         Smargon, "device", "", False, True, None
     )
     assert dev1.name == dev2.name
-    assert type(dev1) != type(dev2)
+    assert type(dev1) is not type(dev2)
     assert dev1 not in beamline_utils.ACTIVE_DEVICES.values()
     assert dev2 in beamline_utils.ACTIVE_DEVICES.values()
 


### PR DESCRIPTION
Makes ruff happy by fixing 

 E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks

