### PR TITLE
Pin ophyd_async due to pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async>=0.3.1,<0.4.0", # Need to pin to <0.4.0 as this requires pydantic>2.0 see https://github.com/DiamondLightSource/dodal/issues/679
+    "ophyd-async<0.4.0",      # Need to pin to <0.4.0 as this requires pydantic>2.0 see https://github.com/DiamondLightSource/dodal/issues/679
     "bluesky",
     "pyepics",
     "dataclasses-json",
@@ -23,10 +23,10 @@ dependencies = [
     "requests",
     "graypy",
     "pydantic",
-    "opencv-python-headless",    # For pin-tip detection.
-    "aioca",                     # Required for CA support with ophyd-async.
-    "p4p",                       # Required for PVA support with ophyd-async.
-    "numpy<2.0",                 # Unpin when https://github.com/bluesky/ophyd-async/issues/387 resolved
+    "opencv-python-headless", # For pin-tip detection.
+    "aioca",                  # Required for CA support with ophyd-async.
+    "p4p",                    # Required for PVA support with ophyd-async.
+    "numpy<2.0",              # Unpin when https://github.com/bluesky/ophyd-async/issues/387 resolved
     "aiofiles",
     "aiohttp",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,19 +14,19 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async>=0.3.1",
+    "ophyd-async>=0.3.1,<0.4.0", # Need to pin to <0.4.0 as this requires pydantic>2.0 see https://github.com/DiamondLightSource/dodal/issues/679
     "bluesky",
     "pyepics",
     "dataclasses-json",
     "pillow",
-    "zocalo",
+    "zocalo>=0.32.0",
     "requests",
     "graypy",
     "pydantic",
-    "opencv-python-headless", # For pin-tip detection.
-    "aioca",                  # Required for CA support with ophyd-async.
-    "p4p",                    # Required for PVA support with ophyd-async.
-    "numpy<2.0",              # Unpin when https://github.com/bluesky/ophyd-async/issues/387 resolved
+    "opencv-python-headless",    # For pin-tip detection.
+    "aioca",                     # Required for CA support with ophyd-async.
+    "p4p",                       # Required for PVA support with ophyd-async.
+    "numpy<2.0",                 # Unpin when https://github.com/bluesky/ophyd-async/issues/387 resolved
     "aiofiles",
     "aiohttp",
 ]


### PR DESCRIPTION
See https://github.com/DiamondLightSource/dodal/issues/679

### Instructions to reviewer on how to test:
1. Re-install `dodal` and confirm dependencies are happy, particularly we're still on `pydantic<2.0`

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
