### PR TITLE
(#698) Pin zocalo to < 1.0.0 to prevent pydantic dependency mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pyepics",
     "dataclasses-json",
     "pillow",
-    "zocalo>=0.32.0",
+    "zocalo>=0.32.0,<1.0.0",  # TODO remove pin against <1.0.0, see #679
     "requests",
     "graypy",
     "pydantic",
@@ -107,11 +107,7 @@ filterwarnings = [
     # Ignore deprecation warning from ophyd_async
     "ignore:dep_util is Deprecated. Use functions from setuptools instead.:DeprecationWarning",
     # Ignore deprecation warning from zocalo
-    "ignore:.*pkg_resources.*:DeprecationWarning",
-    # Ignore Pydantic v2 warnings about deprecated @root-validators and config
-    "ignore::pydantic.warnings.PydanticDeprecatedSince20",
-    "ignore:Valid config keys have changed in V2.*:UserWarning"
-    
+    "ignore:.*pkg_resources.*:DeprecationWarning"
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"


### PR DESCRIPTION
Fixes #698

### Instructions to reviewer on how to test:
1. `pip uninstall pydantic`
2. `pip uninstall zocalo`
3. `pip install -e .`
4. `pip freeze | grep pydantic` to prove that pydantic v1 gets installed
5. Confirm tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
