### PR TITLE
Pin sphinx version to ensure API documentation gets built properly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pytest-cov",
     "pytest-random-order",
     "ruff",
+    "sphinx<7.4.6",  #  pinned due to https://github.com/sphinx-doc/sphinx/issues/12660
     "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinxcontrib-mermaid",


### PR DESCRIPTION
Fixes API documentation generation breakage caused by regression in sphinx 7.4.6

See https://github.com/sphinx-doc/sphinx/issues/12660

This causes sub-packages in the API documentation that were generated recusrively by `autosummary` to no longer be included

### Instructions to reviewer on how to test:
1. `pip uninstall sphinx`
2. `pip install -e .[dev]`
3. `pip show sphinx` should show sphinx < 7.4.6
4. `tox -e docs` (you may have to clean out `build/html`, `.tox` and `docs/reference/generated` folders first)
5. Viewing built docs should now show API for beamlines, devices etc, instead of just the top-level modules

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
