### PR TITLE
Fix misleading zocalo results message

### DIFF
--- a/src/dodal/devices/zocalo/zocalo_results.py
+++ b/src/dodal/devices/zocalo/zocalo_results.py
@@ -154,7 +154,7 @@ class ZocaloResults(StandardReadable, Triggerable):
             )
 
             raw_results = self._raw_results_received.get(timeout=self.timeout_s)
-            LOGGER.info(f"Zocalo: found {len(raw_results)} crystals.")
+            LOGGER.info(f"Zocalo: found {len(raw_results['results'])} crystals.")
             # Sort from strongest to weakest in case of multiple crystals
             await self._put_results(
                 sorted(


### PR DESCRIPTION
Fixes a minor issue with logging found during investigation of i03 "gonio slump" - a log message from `zocalo_results.py` which suggests there are always 2 found crystals.

### Instructions to reviewer on how to test:
1. Tests pass
2. Everything works normally
3. Log reports correct number of found crystals

