### PR TITLE
706 make undulator gap writeable i18

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -335,7 +335,6 @@ def undulator_dcm(
         undulator=undulator(wait_for_connection, fake_with_ophyd_sim),
         dcm=dcm(wait_for_connection, fake_with_ophyd_sim),
         daq_configuration_path=DAQ_CONFIGURATION_PATH,
-        id_gap_lookup_table_path="/dls_sw/i03/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -316,6 +316,7 @@ def undulator(
         wait_for_connection,
         fake_with_ophyd_sim,
         bl_prefix=False,
+        id_gap_lookup_table_path="/dls_sw/i03/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -308,7 +308,7 @@ def undulator(
         wait_for_connection,
         fake_with_ophyd_sim,
         bl_prefix=False,
-        id_gap_lookup_table_path="/dls_sw/i03/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
+        id_gap_lookup_table_path="/dls_sw/i04/software/gda/config/lookupTables/BeamLine_Undulator_toGap.txt",
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -308,6 +308,7 @@ def undulator(
         wait_for_connection,
         fake_with_ophyd_sim,
         bl_prefix=False,
+        id_gap_lookup_table_path="/dls_sw/i03/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
     )
 
 

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -199,6 +199,7 @@ def undulator(
         bl_prefix=False,
         poles=80,
         length=2.0,
+        id_gap_lookup_table_path="/dls_sw/i22/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
     )
 
 

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -106,9 +106,7 @@ class Undulator(StandardReadable, Movable):
         Args:
             value: energy in keV
         """
-        await asyncio.gather(
-            self._set_undulator_gap(value),
-        )
+        await self._set_undulator_gap(value)
 
     async def _set_undulator_gap(self, energy_kev: float) -> None:
         access_level = await self.gap_access.get_value()

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -93,9 +93,15 @@ class Undulator(StandardReadable, Movable):
         super().__init__(name)
 
     @AsyncStatus.wrap
-    async def set(self, energy_value_kev: float):
+    async def set(self, value: float):
+        """
+        set the undulator gap to a given ENERGY
+
+        Args:
+            value: energy in keV
+        """
         await asyncio.gather(
-            self._set_undulator_gap(energy_value_kev),
+            self._set_undulator_gap(value),
         )
 
     async def _set_undulator_gap(self, energy_kev: float) -> None:

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -93,13 +93,13 @@ class Undulator(StandardReadable, Movable):
         super().__init__(name)
 
     @AsyncStatus.wrap
-    async def set(self, value: float):
+    async def set(self, energy_value_kev: float):
         await asyncio.gather(
-            self._set_undulator_gap(value),
+            self._set_undulator_gap(energy_value_kev),
         )
 
     async def _set_undulator_gap(self, energy_kev: float) -> None:
-        LOGGER.info(f"Setting DCM energy to {energy_kev:.2f} kev")
+        LOGGER.info(f"Setting undulator gap to {energy_kev:.2f} kev")
         gap_to_match_dcm_energy = await self._gap_to_match_dcm_energy(energy_kev)
 
         # Check if undulator gap is close enough to the value from the DCM

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -25,6 +25,8 @@ class AccessError(Exception):
 
 # Enable to allow testing when the beamline is down, do not change in production!
 TEST_MODE = False
+# will be made more generic in https://github.com/DiamondLightSource/dodal/issues/754
+
 
 # The acceptable difference, in mm, between the undulator gap and the DCM
 # energy, when the latter is converted to mm using lookup tables

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -1,12 +1,30 @@
+import asyncio
 from enum import Enum
 
-from ophyd_async.core import ConfigSignal, StandardReadable, soft_signal_r_and_setter
+import numpy as np
+from bluesky.protocols import Movable
+from numpy import argmin, ndarray
+from ophyd_async.core import (
+    AsyncStatus,
+    ConfigSignal,
+    StandardReadable,
+    soft_signal_r_and_setter,
+)
+from ophyd_async.epics.motion import Motor
 from ophyd_async.epics.motor import Motor
 from ophyd_async.epics.signal import epics_signal_r
+
+from dodal.log import LOGGER
+
+from .util.lookup_tables import energy_distance_table
+
+# Enable to allow testing when the beamline is down, do not change in production!
+TEST_MODE = False
 
 # The acceptable difference, in mm, between the undulator gap and the DCM
 # energy, when the latter is converted to mm using lookup tables
 UNDULATOR_DISCREPANCY_THRESHOLD_MM = 2e-3
+STATUS_TIMEOUT_S: float = 10.0
 
 
 class UndulatorGapAccess(str, Enum):
@@ -14,7 +32,15 @@ class UndulatorGapAccess(str, Enum):
     DISABLED = "DISABLED"
 
 
-class Undulator(StandardReadable):
+def _get_closest_gap_for_energy(
+    dcm_energy_ev: float, energy_to_distance_table: ndarray
+) -> float:
+    table = energy_to_distance_table.transpose()
+    idx = argmin(np.abs(table[0] - dcm_energy_ev))
+    return table[1][idx]
+
+
+class Undulator(StandardReadable, Movable):
     """
     An Undulator-type insertion device, used to control photon emission at a given
     beam energy.
@@ -23,6 +49,7 @@ class Undulator(StandardReadable):
     def __init__(
         self,
         prefix: str,
+        id_gap_lookup_table_path: str,
         name: str = "",
         poles: int | None = None,
         length: float | None = None,
@@ -36,6 +63,7 @@ class Undulator(StandardReadable):
             name (str, optional): Name for device. Defaults to "".
         """
 
+        self.id_gap_lookup_table_path = id_gap_lookup_table_path
         with self.add_children_as_readables():
             self.gap_motor = Motor(prefix + "BLGAPMTR")
             self.current_gap = epics_signal_r(float, prefix + "CURRGAPD")
@@ -63,3 +91,49 @@ class Undulator(StandardReadable):
                 self.length = None
 
         super().__init__(name)
+
+    @AsyncStatus.wrap
+    async def set(self, value: float):
+        await asyncio.gather(
+            self._set_undulator_gap(value),
+        )
+
+    async def _set_undulator_gap(self, energy_kev: float) -> None:
+        LOGGER.info(f"Setting DCM energy to {energy_kev:.2f} kev")
+        gap_to_match_dcm_energy = await self._gap_to_match_dcm_energy(energy_kev)
+
+        # Check if undulator gap is close enough to the value from the DCM
+        current_gap = await self.current_gap.get_value()
+        tolerance = await self.gap_discrepancy_tolerance_mm.get_value()
+        difference = abs(gap_to_match_dcm_energy - current_gap)
+        if difference > tolerance:
+            LOGGER.info(
+                f"Undulator gap mismatch. {difference:.3f}mm is outside tolerance.\
+                Moving gap to nominal value, {gap_to_match_dcm_energy:.3f}mm"
+            )
+            if not TEST_MODE:
+                # Only move if the gap is sufficiently different to the value from the
+                # DCM lookup table AND we're not in TEST_MODE
+                await self.gap_motor.set(
+                    gap_to_match_dcm_energy,
+                    timeout=STATUS_TIMEOUT_S,
+                )
+            else:
+                LOGGER.debug("In test mode, not moving ID gap")
+        else:
+            LOGGER.debug(
+                "Gap is already in the correct place for the new energy value "
+                f"{energy_kev}, no need to ask it to move"
+            )
+
+    async def _gap_to_match_dcm_energy(self, energy_kev: float) -> float:
+        # from lookup table a get a 2d np.array converting energies to undulator gap distance
+        energy_to_distance_table: np.ndarray = await energy_distance_table(
+            self.id_gap_lookup_table_path
+        )
+
+        # Use the lookup table to get the undulator gap associated with this dcm energy
+        return _get_closest_gap_for_energy(
+            energy_kev * 1000,
+            energy_to_distance_table,
+        )

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -10,7 +10,6 @@ from ophyd_async.core import (
     StandardReadable,
     soft_signal_r_and_setter,
 )
-from ophyd_async.epics import Motor
 from ophyd_async.epics.motor import Motor
 from ophyd_async.epics.signal import epics_signal_r
 

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -1,4 +1,3 @@
-import asyncio
 from enum import Enum
 
 import numpy as np

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -18,6 +18,11 @@ from dodal.log import LOGGER
 
 from .util.lookup_tables import energy_distance_table
 
+
+class AccessError(Exception):
+    pass
+
+
 # Enable to allow testing when the beamline is down, do not change in production!
 TEST_MODE = False
 
@@ -105,6 +110,9 @@ class Undulator(StandardReadable, Movable):
         )
 
     async def _set_undulator_gap(self, energy_kev: float) -> None:
+        access_level = await self.gap_access.get_value()
+        if access_level is UndulatorGapAccess.DISABLED and not TEST_MODE:
+            raise AccessError("Undulator gap access is disabled. Contact Control Room")
         LOGGER.info(f"Setting undulator gap to {energy_kev:.2f} kev")
         gap_to_match_dcm_energy = await self._gap_to_match_dcm_energy(energy_kev)
 

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -10,7 +10,7 @@ from ophyd_async.core import (
     StandardReadable,
     soft_signal_r_and_setter,
 )
-from ophyd_async.epics.motion import Motor
+from ophyd_async.epics import Motor
 from ophyd_async.epics.motor import Motor
 from ophyd_async.epics.signal import epics_signal_r
 

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -63,7 +63,7 @@ class UndulatorDCM(StandardReadable, Movable):
     async def set(self, value: float):
         await asyncio.gather(
             self._set_dcm_energy(value),
-            self.undulator._set_undulator_gap(value),
+            self.undulator.set(value),
         )
 
     async def _set_dcm_energy(self, energy_kev: float) -> None:

--- a/tests/devices/system_tests/test_undulator_system.py
+++ b/tests/devices/system_tests/test_undulator_system.py
@@ -13,7 +13,7 @@ ID_GAP_LOOKUP_TABLE_PATH: str = (
 @pytest.mark.s03
 def test_undulator_connects():
     with DeviceCollector():
-        undulator = Undulator(
+        undulator = Undulator(  # noqa: F841
             f"{SIM_INSERTION_PREFIX}-MO-SERVC-01:",
             id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
-        )  # noqa: F841
+        )

--- a/tests/devices/system_tests/test_undulator_system.py
+++ b/tests/devices/system_tests/test_undulator_system.py
@@ -5,8 +5,15 @@ from dodal.devices.undulator import Undulator
 
 SIM_INSERTION_PREFIX = "SR03S"
 
+ID_GAP_LOOKUP_TABLE_PATH: str = (
+    "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"
+)
+
 
 @pytest.mark.s03
 def test_undulator_connects():
     with DeviceCollector():
-        undulator = Undulator(f"{SIM_INSERTION_PREFIX}-MO-SERVC-01:")  # noqa: F841
+        undulator = Undulator(
+            f"{SIM_INSERTION_PREFIX}-MO-SERVC-01:",
+            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
+        )  # noqa: F841

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -10,11 +10,11 @@ from ophyd_async.core import (
 )
 
 from dodal.devices.undulator import (
+    AccessError,
     Undulator,
     UndulatorGapAccess,
     _get_closest_gap_for_energy,
 )
-from dodal.devices.undulator_dcm import AccessError
 
 ID_GAP_LOOKUP_TABLE_PATH: str = (
     "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -9,6 +9,10 @@ from ophyd_async.core import (
 
 from dodal.devices.undulator import Undulator, UndulatorGapAccess
 
+ID_GAP_LOOKUP_TABLE_PATH: str = (
+    "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"
+)
+
 
 @pytest.fixture
 async def undulator() -> Undulator:
@@ -18,6 +22,7 @@ async def undulator() -> Undulator:
             name="undulator",
             poles=80,
             length=2.0,
+            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
         )
     return undulator
 
@@ -84,6 +89,7 @@ async def test_poles_not_propagated_if_not_supplied():
             "UND-01",
             name="undulator",
             length=2.0,
+            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
         )
     assert undulator.poles is None
     assert "undulator-poles" not in (await undulator.read_configuration())
@@ -95,6 +101,7 @@ async def test_length_not_propagated_if_not_supplied():
             "UND-01",
             name="undulator",
             poles=80,
+            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
         )
     assert undulator.length is None
     assert "undulator-length" not in (await undulator.read_configuration())

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -130,4 +130,5 @@ async def test_when_gap_access_is_disabled_set_energy_then_error_is_raised(
 ):
     set_mock_value(undulator.gap_access, UndulatorGapAccess.DISABLED)
     with pytest.raises(AccessError):
+        # AccessError("Undulator gap access is disabled. Contact Control Room")
         await undulator.set(5)

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -115,13 +115,12 @@ async def test_length_not_propagated_if_not_supplied():
 
 
 @pytest.mark.parametrize(
-    "dcm_energy, expected_output", [(5730, 5.4606), (7200, 6.045), (9000, 6.404)]
+    "energy, expected_output", [(5730, 5.4606), (7200, 6.045), (9000, 6.404)]
 )
-def test_correct_closest_distance_to_energy_from_table(dcm_energy, expected_output):
+def test_correct_closest_distance_to_energy_from_table(energy, expected_output):
     energy_to_distance_table = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
     assert (
-        _get_closest_gap_for_energy(dcm_energy, energy_to_distance_table)
-        == expected_output
+        _get_closest_gap_for_energy(energy, energy_to_distance_table) == expected_output
     )
 
 
@@ -130,5 +129,4 @@ async def test_when_gap_access_is_disabled_set_energy_then_error_is_raised(
 ):
     set_mock_value(undulator.gap_access, UndulatorGapAccess.DISABLED)
     with pytest.raises(AccessError):
-        # AccessError("Undulator gap access is disabled. Contact Control Room")
         await undulator.set(5)

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -58,11 +58,11 @@ async def fake_undulator_dcm() -> UndulatorDCM:
 def test_lookup_table_paths_passed(fake_undulator_dcm: UndulatorDCM):
     assert fake_undulator_dcm.id_gap_lookup_table_path == ID_GAP_LOOKUP_TABLE_PATH
     assert (
-        fake_undulator_dcm.dcm_pitch_converter_lookup_table_path
+        fake_undulator_dcm.pitch_energy_table_path
         == MOCK_DAQ_CONFIG_PATH + "/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
     )
     assert (
-        fake_undulator_dcm.dcm_roll_converter_lookup_table_path
+        fake_undulator_dcm.roll_energy_table_path
         == MOCK_DAQ_CONFIG_PATH + "/lookup/BeamLineEnergy_DCM_Roll_converter.txt"
     )
 

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -13,10 +13,8 @@ from dodal.devices.dcm import DCM
 from dodal.devices.undulator import (
     Undulator,
     UndulatorGapAccess,
-    _get_closest_gap_for_energy,
 )
 from dodal.devices.undulator_dcm import (
-    AccessError,
     UndulatorDCM,
 )
 from dodal.log import LOGGER
@@ -75,25 +73,6 @@ def test_lookup_table_paths_passed(fake_undulator_dcm: UndulatorDCM):
 
 async def test_fixed_offset_decoded(fake_undulator_dcm: UndulatorDCM):
     assert fake_undulator_dcm.dcm_fixed_offset_mm == 25.6
-
-
-async def test_when_gap_access_is_disabled_set_energy_then_error_is_raised(
-    fake_undulator_dcm: UndulatorDCM,
-):
-    set_mock_value(fake_undulator_dcm.undulator.gap_access, UndulatorGapAccess.DISABLED)
-    with pytest.raises(AccessError):
-        await fake_undulator_dcm.set(5)
-
-
-@pytest.mark.parametrize(
-    "dcm_energy, expected_output", [(5730, 5.4606), (7200, 6.045), (9000, 6.404)]
-)
-def test_correct_closest_distance_to_energy_from_table(dcm_energy, expected_output):
-    energy_to_distance_table = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
-    assert (
-        _get_closest_gap_for_energy(dcm_energy, energy_to_distance_table)
-        == expected_output
-    )
 
 
 @patch("dodal.devices.util.lookup_tables.loadtxt")

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -10,11 +10,14 @@ from ophyd_async.core import (
 )
 
 from dodal.devices.dcm import DCM
-from dodal.devices.undulator import Undulator, UndulatorGapAccess
+from dodal.devices.undulator import (
+    Undulator,
+    UndulatorGapAccess,
+    _get_closest_gap_for_energy,
+)
 from dodal.devices.undulator_dcm import (
     AccessError,
     UndulatorDCM,
-    _get_closest_gap_for_energy,
 )
 from dodal.log import LOGGER
 
@@ -42,13 +45,13 @@ async def fake_undulator_dcm() -> UndulatorDCM:
             "UND-01",
             name="undulator",
             poles=80,
+            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
             length=2.0,
         )
         dcm = DCM("DCM-01", name="dcm")
         undulator_dcm = UndulatorDCM(
             undulator,
             dcm,
-            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
             daq_configuration_path=MOCK_DAQ_CONFIG_PATH,
             name="undulator_dcm",
         )
@@ -56,7 +59,10 @@ async def fake_undulator_dcm() -> UndulatorDCM:
 
 
 def test_lookup_table_paths_passed(fake_undulator_dcm: UndulatorDCM):
-    assert fake_undulator_dcm.id_gap_lookup_table_path == ID_GAP_LOOKUP_TABLE_PATH
+    assert (
+        fake_undulator_dcm.undulator.id_gap_lookup_table_path
+        == ID_GAP_LOOKUP_TABLE_PATH
+    )
     assert (
         fake_undulator_dcm.pitch_energy_table_path
         == MOCK_DAQ_CONFIG_PATH + "/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
@@ -91,7 +97,7 @@ def test_correct_closest_distance_to_energy_from_table(dcm_energy, expected_outp
 
 
 @patch("dodal.devices.util.lookup_tables.loadtxt")
-@patch("dodal.devices.undulator_dcm.LOGGER")
+@patch("dodal.devices.undulator.LOGGER")
 async def test_if_gap_is_wrong_then_logger_info_is_called_and_gap_is_set_correctly(
     mock_logger: MagicMock, mock_load: MagicMock, fake_undulator_dcm: UndulatorDCM
 ):
@@ -110,8 +116,9 @@ async def test_if_gap_is_wrong_then_logger_info_is_called_and_gap_is_set_correct
 
 
 @patch("dodal.devices.util.lookup_tables.loadtxt")
-@patch("dodal.devices.undulator_dcm.LOGGER")
+@patch("dodal.devices.undulator.LOGGER")
 @patch("dodal.devices.undulator_dcm.TEST_MODE", True)
+@patch("dodal.devices.undulator.TEST_MODE", True)
 async def test_when_gap_access_is_not_checked_if_test_mode_enabled(
     mock_logger: MagicMock, mock_load: MagicMock, fake_undulator_dcm: UndulatorDCM
 ):
@@ -137,7 +144,7 @@ async def test_when_gap_access_is_not_checked_if_test_mode_enabled(
 
 
 @patch("dodal.devices.util.lookup_tables.loadtxt")
-@patch("dodal.devices.undulator_dcm.LOGGER")
+@patch("dodal.devices.undulator.LOGGER")
 async def test_if_gap_is_already_correct_then_dont_move_gap(
     mock_logger: MagicMock, mock_load: MagicMock, fake_undulator_dcm: UndulatorDCM
 ):


### PR DESCRIPTION
Fixes #706

needed for i18 #710 and https://github.com/DiamondLightSource/i18-bluesky/issues/4

### Instructions to reviewer on how to test:
1. run the undulator_dcm routine for lookup table update
2. Confirm nothing breaks happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
