### PR TITLE
Convert fluo_detector_motion to ophyd async

### DIFF
--- a/src/dodal/devices/fluorescence_detector_motion.py
+++ b/src/dodal/devices/fluorescence_detector_motion.py
@@ -15,3 +15,4 @@ class FluorescenceDetector(StandardReadable):
             self.pos = epics_signal_r(
                 FluorescenceDetectorControlState, "-EA-FLU-01:CTRL"
             )
+        super().__init__(name)

--- a/src/dodal/devices/fluorescence_detector_motion.py
+++ b/src/dodal/devices/fluorescence_detector_motion.py
@@ -1,9 +1,17 @@
-from ophyd import Component as Cpt
-from ophyd import Device, EpicsSignal
+from enum import Enum
+
+from ophyd_async.core import StandardReadable
+from ophyd_async.epics.signal import epics_signal_r
 
 
-class FluorescenceDetector(Device):
+class FluorescenceDetectorControlState(Enum):
     OUT = 0
     IN = 1
 
-    pos = Cpt(EpicsSignal, "-EA-FLU-01:CTRL")
+
+class FluorescenceDetector(StandardReadable):
+    def __init__(self, prefix: str, name: str = ""):
+        with self.add_children_as_readables():
+            self.pos = epics_signal_r(
+                FluorescenceDetectorControlState, "-EA-FLU-01:CTRL"
+            )

--- a/src/dodal/devices/fluorescence_detector_motion.py
+++ b/src/dodal/devices/fluorescence_detector_motion.py
@@ -13,6 +13,6 @@ class FluorescenceDetector(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.pos = epics_signal_r(
-                FluorescenceDetectorControlState, "-EA-FLU-01:CTRL"
+                FluorescenceDetectorControlState, prefix + "-EA-FLU-01:CTRL"
             )
         super().__init__(name)


### PR DESCRIPTION
Fixes #692 

### Instructions to reviewer on how to test:
1. Confirm converted component is correct

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
