### PR TITLE
(DiamondLightSource/hyperion#1517) Fix panda subdirectory not created

### DIFF
--- a/src/dodal/common/udc_directory_provider.py
+++ b/src/dodal/common/udc_directory_provider.py
@@ -8,7 +8,7 @@ from dodal.log import LOGGER
 
 class PandASubdirectoryProvider(UpdatingDirectoryProvider):
     """Directory provider for the HDFPanda. Points to a panda subdirectory within the
-    directory path provided, which must exist before attempting to arm the PCAP block"""
+    directory path provided"""
 
     resource_dir = Path("panda")
 
@@ -23,9 +23,20 @@ class PandASubdirectoryProvider(UpdatingDirectoryProvider):
             else None
         )
 
-    async def update(self, *, directory: Path, **kwargs):
+    async def update(self, *, directory: Path, suffix: str = "", **kwargs):
+        """Update the root directory into which panda pcap files are written. This will result in the panda
+        subdirectory being created if it does not already exist.
+         Args:
+             directory: Path instance that identifies the root folder. This folder must exist. The panda will
+                attempt to write into the "panda" subdirectory which will be created if not already present.
+             suffix: Optional str that will be appended to the panda device name along with the file
+                type extension to construct the output filename
+        """
+        output_directory = directory / self.resource_dir
+        output_directory.mkdir(exist_ok=True)
+
         self._directory_info = DirectoryInfo(
-            root=directory, resource_dir=self.resource_dir
+            root=directory, resource_dir=self.resource_dir, suffix=suffix
         )
 
     def __call__(self) -> DirectoryInfo:

--- a/tests/common/test_udc_directory_provider.py
+++ b/tests/common/test_udc_directory_provider.py
@@ -44,3 +44,34 @@ async def test_udc_directory_provider_after_update(initial, tmp_path):
     directory_info = provider()
     assert directory_info.root == tmp_path
     assert directory_info.resource_dir == Path("panda")
+
+
+async def test_udc_directory_provider_no_suffix():
+    initial = Path("initial")
+    provider = PandASubdirectoryProvider(initial)
+    root_path = Path("/tmp/my_data")
+    await provider.update(directory=root_path)
+    directory_info = provider()
+    assert directory_info.root == root_path
+    assert directory_info.resource_dir == Path("panda")
+    assert directory_info.suffix == ""
+
+
+async def test_udc_directory_provider_with_suffix():
+    initial = Path("initial")
+    provider = PandASubdirectoryProvider(initial)
+    root_path = Path("/tmp/my_data")
+    await provider.update(directory=root_path, suffix="_123")
+    directory_info = provider()
+    assert directory_info.root == root_path
+    assert directory_info.resource_dir == Path("panda")
+    assert directory_info.suffix == "_123"
+
+
+async def test_udc_directory_provider_creates_subdirectory_if_not_exists(tmp_path):
+    root = tmp_path
+    subdir = root / Path("panda")
+    assert not subdir.exists()
+    provider = PandASubdirectoryProvider(Path("initial"))
+    await provider.update(directory=root)
+    assert subdir.exists()

--- a/tests/common/test_udc_directory_provider.py
+++ b/tests/common/test_udc_directory_provider.py
@@ -46,10 +46,11 @@ async def test_udc_directory_provider_after_update(initial, tmp_path):
     assert directory_info.resource_dir == Path("panda")
 
 
-async def test_udc_directory_provider_no_suffix():
+async def test_udc_directory_provider_no_suffix(tmp_path):
     initial = Path("initial")
     provider = PandASubdirectoryProvider(initial)
-    root_path = Path("/tmp/my_data")
+    root_path = tmp_path / "my_data"
+    root_path.mkdir()
     await provider.update(directory=root_path)
     directory_info = provider()
     assert directory_info.root == root_path
@@ -57,10 +58,11 @@ async def test_udc_directory_provider_no_suffix():
     assert directory_info.suffix == ""
 
 
-async def test_udc_directory_provider_with_suffix():
+async def test_udc_directory_provider_with_suffix(tmp_path):
     initial = Path("initial")
     provider = PandASubdirectoryProvider(initial)
-    root_path = Path("/tmp/my_data")
+    root_path = tmp_path / "my_data"
+    root_path.mkdir()
     await provider.update(directory=root_path, suffix="_123")
     directory_info = provider()
     assert directory_info.root == root_path


### PR DESCRIPTION
Fixes part of DiamondLightSource/hyperion#1517

The 'PandASubdirectoryProvider' now allows the filename suffix to be specified, and it also ensures the 'panda' subdirectory is created.

See also DiamondLightSource/hyperion#1520

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
