### PR TITLE
Remove QBPM as it's not currently used

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -21,7 +21,6 @@ from dodal.devices.focusing_mirror import FocusingMirrorWithStripes, VFMMirrorVo
 from dodal.devices.motors import XYZPositioner
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
-from dodal.devices.qbpm1 import QBPM1
 from dodal.devices.robot import BartRobot
 from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.smargon import Smargon
@@ -100,17 +99,6 @@ def dcm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> 
         "-MO-DCM-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
-    )
-
-
-@skip_device(lambda: BL == "s03")
-def qbpm1(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> QBPM1:
-    return device_instantiation(
-        device_factory=QBPM1,
-        name="qbpm1",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
     )
 
 

--- a/src/dodal/devices/qbpm1.py
+++ b/src/dodal/devices/qbpm1.py
@@ -1,8 +1,0 @@
-from ophyd import Component as Cpt
-from ophyd import Device, EpicsSignalRO, Kind
-
-
-class QBPM1(Device):
-    """Quadrant Beam Position Monitor"""
-
-    intensity = Cpt(EpicsSignalRO, "-DI-QBPM-01:INTEN", kind=Kind.normal)

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -12,7 +12,7 @@ from ophyd_async.core import StandardReadable
 from dodal.beamlines import i03
 from dodal.common.beamlines import beamline_utils
 from dodal.devices.aperturescatterguard import ApertureScatterguard
-from dodal.devices.qbpm1 import QBPM1
+from dodal.devices.eiger import EigerDetector
 from dodal.devices.smargon import Smargon
 from dodal.devices.zebra import Zebra
 from dodal.log import LOGGER
@@ -65,11 +65,11 @@ def test_instantiating_different_device_with_same_name():
 
 
 def test_instantiate_v1_function_fake_makes_fake():
-    qbpm: QBPM1 = beamline_utils.device_instantiation(
-        QBPM1, "qbpm", "", True, True, None
+    eiger: EigerDetector = beamline_utils.device_instantiation(
+        EigerDetector, "eiger", "", True, True, None
     )
-    assert isinstance(qbpm, Device)
-    assert isinstance(qbpm.intensity, FakeEpicsSignal)
+    assert isinstance(eiger, Device)
+    assert isinstance(eiger.stale_params, FakeEpicsSignal)
 
 
 def test_instantiate_v2_function_fake_makes_fake():


### PR DESCRIPTION
Fixes #690

### Instructions to reviewer on how to test:
1. Confirm tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
