### PR TITLE
Fix exception calling getpass() when inside container

### DIFF
--- a/src/dodal/devices/zocalo/zocalo_interaction.py
+++ b/src/dodal/devices/zocalo/zocalo_interaction.py
@@ -39,7 +39,12 @@ class ZocaloStartInfo:
 
 
 def _get_zocalo_headers() -> tuple[str, str]:
-    user = os.environ.get("ZOCALO_GO_USER", getpass.getuser())
+    user = os.environ.get("ZOCALO_GO_USER")
+
+    # cannot default as getuser() will throw when called from inside a container
+    if not user:
+        user = getpass.getuser()
+
     hostname = os.environ.get("ZOCALO_GO_HOSTNAME", socket.gethostname())
     return user, hostname
 


### PR DESCRIPTION
The previous fix #725 did not work because getpass() was still called and failed; this ensures it is not called unless necessary.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
