### PR TITLE
ApertureScatterguard now set using a well defined enum

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -1,5 +1,6 @@
 from ophyd_async.panda import HDFPanda
 
+from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
 from dodal.common.beamlines.beamline_utils import (
     device_instantiation,
     get_directory_provider,
@@ -7,7 +8,11 @@ from dodal.common.beamlines.beamline_utils import (
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.udc_directory_provider import PandASubdirectoryProvider
-from dodal.devices.aperturescatterguard import AperturePositions, ApertureScatterguard
+from dodal.devices.aperturescatterguard import (
+    ApertureScatterguard,
+    load_positions_from_beamline_parameters,
+    load_tolerances_from_beamline_params,
+)
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.cryostream import CryoStream
@@ -53,24 +58,20 @@ set_directory_provider(PandASubdirectoryProvider())
 def aperture_scatterguard(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
-    aperture_positions: AperturePositions | None = None,
 ) -> ApertureScatterguard:
     """Get the i03 aperture and scatterguard device, instantiate it if it hasn't already
     been. If this is called when already instantiated in i03, it will return the existing
-    object. If aperture_positions is specified, it will update them.
+    object.
     """
-
-    def load_positions(a_s: ApertureScatterguard):
-        if aperture_positions is not None:
-            a_s.load_aperture_positions(aperture_positions)
-
+    params = get_beamline_parameters()
     return device_instantiation(
         device_factory=ApertureScatterguard,
         name="aperture_scatterguard",
         prefix="",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
-        post_create=load_positions,
+        loaded_positions=load_positions_from_beamline_parameters(params),
+        tolerances=load_tolerances_from_beamline_params(params),
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -1,6 +1,11 @@
+from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
 from dodal.common.beamlines.beamline_utils import device_instantiation
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.devices.aperturescatterguard import AperturePositions, ApertureScatterguard
+from dodal.devices.aperturescatterguard import (
+    ApertureScatterguard,
+    load_positions_from_beamline_parameters,
+    load_tolerances_from_beamline_params,
+)
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.beamstop import BeamStop
@@ -219,24 +224,20 @@ def backlight(
 def aperture_scatterguard(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
-    aperture_positions: AperturePositions | None = None,
 ) -> ApertureScatterguard:
     """Get the i04 aperture and scatterguard device, instantiate it if it hasn't already
     been. If this is called when already instantiated in i04, it will return the existing
-    object. If aperture_positions is specified, it will update them.
+    object.
     """
-
-    def load_positions(a_s: ApertureScatterguard):
-        if aperture_positions is not None:
-            a_s.load_aperture_positions(aperture_positions)
-
+    params = get_beamline_parameters()
     return device_instantiation(
         device_factory=ApertureScatterguard,
         name="aperture_scatterguard",
         prefix="",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
-        post_create=load_positions,
+        loaded_positions=load_positions_from_beamline_parameters(params),
+        tolerances=load_tolerances_from_beamline_params(params),
     )
 
 

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -164,10 +164,6 @@ class ApertureScatterguard(StandardReadable, Movable):
                 )
             }
 
-    def reload_positions(self):
-        self._loaded_positions = load_positions_from_beamline_parameters()
-        self._tolerences = load_tolerances_from_beamline_params()
-
     def get_position_from_gda_aperture_name(
         self, gda_aperture_name: AperturePositionGDANames
     ) -> AperturePosition:

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -8,9 +8,9 @@ from event_model.documents.event_descriptor import DataKey
 from ophyd_async.core import AsyncStatus, HintedSignal, SignalR, StandardReadable
 from ophyd_async.core.soft_signal_backend import SoftConverter, SoftSignalBackend
 
+from dodal.common.beamlines.beamline_parameters import GDABeamlineParameters
 from dodal.devices.aperture import Aperture
 from dodal.devices.scatterguard import Scatterguard
-from dodal.log import LOGGER
 
 
 class InvalidApertureMove(Exception):
@@ -40,14 +40,10 @@ class ApertureScatterguardTolerances:
 
 @dataclass
 class SingleAperturePosition:
-    # Default values are needed as ophyd_async sim does not respect initial_values of
-    # soft signal backends see https://github.com/bluesky/ophyd-async/issues/266
-    name: str = ""
-    GDA_name: str = ""
-    radius_microns: float | None = None
-    location: ApertureFiveDimensionalLocation = ApertureFiveDimensionalLocation(
-        0, 0, 0, 0, 0
-    )
+    name: str
+    GDA_name: str
+    radius_microns: float | None
+    location: ApertureFiveDimensionalLocation
 
 
 # Use StrEnum once we stop python 3.10 support
@@ -65,7 +61,7 @@ def position_from_params(
     name: str,
     GDA_name: AperturePositionGDANames,
     radius_microns: float | None,
-    params: dict,
+    params: GDABeamlineParameters,
 ) -> SingleAperturePosition:
     return SingleAperturePosition(
         name,
@@ -81,7 +77,9 @@ def position_from_params(
     )
 
 
-def tolerances_from_params(params: dict) -> ApertureScatterguardTolerances:
+def load_tolerances_from_beamline_params(
+    params: GDABeamlineParameters,
+) -> ApertureScatterguardTolerances:
     return ApertureScatterguardTolerances(
         ap_x=params["miniap_x_tolerance"],
         ap_y=params["miniap_y_tolerance"],
@@ -91,68 +89,46 @@ def tolerances_from_params(params: dict) -> ApertureScatterguardTolerances:
     )
 
 
-@dataclass
-class AperturePositions:
-    """Holds the motor positions needed to select a particular aperture size. This class should be instantiated with definitions for its sizes
-    using from_gda_beamline_params"""
+class AperturePosition(Enum):
+    ROBOT_LOAD = 0
+    SMALL = 1
+    MEDIUM = 2
+    LARGE = 3
 
-    LARGE: SingleAperturePosition
-    MEDIUM: SingleAperturePosition
-    SMALL: SingleAperturePosition
-    ROBOT_LOAD: SingleAperturePosition
 
-    tolerances: ApertureScatterguardTolerances
-
-    UNKNOWN = SingleAperturePosition(
-        "Unknown", "UNKNOWN", None, ApertureFiveDimensionalLocation(0, 0, 0, 0, 0)
-    )
-
-    @classmethod
-    def from_gda_beamline_params(cls, params):
-        return cls(
-            LARGE=position_from_params(
-                "Large", AperturePositionGDANames.LARGE_APERTURE, 100, params
-            ),
-            MEDIUM=position_from_params(
-                "Medium", AperturePositionGDANames.MEDIUM_APERTURE, 50, params
-            ),
-            SMALL=position_from_params(
-                "Small", AperturePositionGDANames.SMALL_APERTURE, 20, params
-            ),
-            ROBOT_LOAD=position_from_params(
-                "Robot load", AperturePositionGDANames.ROBOT_LOAD, None, params
-            ),
-            tolerances=tolerances_from_params(params),
-        )
-
-    def get_position_from_gda_aperture_name(
-        self, gda_aperture_name: AperturePositionGDANames
-    ) -> SingleAperturePosition:
-        apertures = [ap for ap in self.as_list() if ap.GDA_name == gda_aperture_name]
-        if not apertures:
-            raise ValueError(
-                f"Tried to convert unknown aperture name {gda_aperture_name} to a SingleAperturePosition"
-            )
-        else:
-            return apertures[0]
-
-    def as_list(self) -> list[SingleAperturePosition]:
-        return [
-            self.LARGE,
-            self.MEDIUM,
-            self.SMALL,
-            self.ROBOT_LOAD,
-        ]
+def load_positions_from_beamline_parameters(
+    params: GDABeamlineParameters,
+) -> dict[AperturePosition, SingleAperturePosition]:
+    return {
+        AperturePosition.ROBOT_LOAD: position_from_params(
+            "Robot load", AperturePositionGDANames.ROBOT_LOAD, None, params
+        ),
+        AperturePosition.SMALL: position_from_params(
+            "Small", AperturePositionGDANames.SMALL_APERTURE, 20, params
+        ),
+        AperturePosition.MEDIUM: position_from_params(
+            "Medium", AperturePositionGDANames.MEDIUM_APERTURE, 50, params
+        ),
+        AperturePosition.LARGE: position_from_params(
+            "Large", AperturePositionGDANames.LARGE_APERTURE, 100, params
+        ),
+    }
 
 
 class ApertureScatterguard(StandardReadable, Movable):
-    def __init__(self, prefix: str = "", name: str = "") -> None:
-        self.aperture = Aperture(prefix + "-MO-MAPT-01:")
-        self.scatterguard = Scatterguard(prefix + "-MO-SCAT-01:")
-        self.aperture_positions: AperturePositions | None = None
-        self.TOLERANCE_STEPS = 3  # Number of MRES steps
+    def __init__(
+        self,
+        loaded_positions: dict[AperturePosition, SingleAperturePosition],
+        tolerances: ApertureScatterguardTolerances,
+        prefix: str = "",
+        name: str = "",
+    ) -> None:
+        self._aperture = Aperture(prefix + "-MO-MAPT-01:")
+        self._scatterguard = Scatterguard(prefix + "-MO-SCAT-01:")
+        self._loaded_positions = loaded_positions
+        self._tolerances = tolerances
         aperture_backend = SoftSignalBackend(
-            SingleAperturePosition, AperturePositions.UNKNOWN
+            SingleAperturePosition, self._loaded_positions[AperturePosition.ROBOT_LOAD]
         )
         aperture_backend.converter = self.ApertureConverter()
         self.selected_aperture = self.SelectedAperture(backend=aperture_backend)
@@ -188,25 +164,32 @@ class ApertureScatterguard(StandardReadable, Movable):
                 )
             }
 
-    def load_aperture_positions(self, positions: AperturePositions):
-        LOGGER.info(f"{self.name} loaded in {positions}")
-        self.aperture_positions = positions
+    def reload_positions(self):
+        self._loaded_positions = load_positions_from_beamline_parameters()
+        self._tolerences = load_tolerances_from_beamline_params()
+
+    def get_position_from_gda_aperture_name(
+        self, gda_aperture_name: AperturePositionGDANames
+    ) -> AperturePosition:
+        for aperture, detail in self._loaded_positions.items():
+            if detail.GDA_name == gda_aperture_name:
+                return aperture
+        raise ValueError(
+            f"Tried to convert unknown aperture name {gda_aperture_name} to a SingleAperturePosition"
+        )
 
     @AsyncStatus.wrap
-    async def set(self, value: SingleAperturePosition):
-        assert isinstance(self.aperture_positions, AperturePositions)
-        if value not in self.aperture_positions.as_list():
-            raise InvalidApertureMove(f"Unknown aperture: {value}")
-
-        await self._safe_move_within_datacollection_range(value.location)
+    async def set(self, value: AperturePosition):
+        position = self._loaded_positions[value]
+        await self._safe_move_within_datacollection_range(position.location)
 
     def _get_motor_list(self):
         return [
-            self.aperture.x,
-            self.aperture.y,
-            self.aperture.z,
-            self.scatterguard.x,
-            self.scatterguard.y,
+            self._aperture.x,
+            self._aperture.y,
+            self._aperture.z,
+            self._scatterguard.x,
+            self._scatterguard.y,
         ]
 
     @AsyncStatus.wrap
@@ -217,11 +200,11 @@ class ApertureScatterguard(StandardReadable, Movable):
         aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = positions
 
         await asyncio.gather(
-            self.aperture.x.set(aperture_x),
-            self.aperture.y.set(aperture_y),
-            self.aperture.z.set(aperture_z),
-            self.scatterguard.x.set(scatterguard_x),
-            self.scatterguard.y.set(scatterguard_y),
+            self._aperture.x.set(aperture_x),
+            self._aperture.y.set(aperture_y),
+            self._aperture.z.set(aperture_z),
+            self._scatterguard.x.set(scatterguard_x),
+            self._scatterguard.y.set(scatterguard_y),
         )
 
     async def get_current_aperture_position(self) -> SingleAperturePosition:
@@ -231,17 +214,18 @@ class ApertureScatterguard(StandardReadable, Movable):
         mini aperture y <= ROBOT_LOAD.location.aperture_y + tolerance.
         If no position is found then raises InvalidApertureMove.
         """
-        assert isinstance(self.aperture_positions, AperturePositions)
-        current_ap_y = await self.aperture.y.user_readback.get_value(cached=False)
-        robot_load_ap_y = self.aperture_positions.ROBOT_LOAD.location.aperture_y
-        if await self.aperture.large.get_value(cached=False) == 1:
-            return self.aperture_positions.LARGE
-        elif await self.aperture.medium.get_value(cached=False) == 1:
-            return self.aperture_positions.MEDIUM
-        elif await self.aperture.small.get_value(cached=False) == 1:
-            return self.aperture_positions.SMALL
-        elif current_ap_y <= robot_load_ap_y + self.aperture_positions.tolerances.ap_y:
-            return self.aperture_positions.ROBOT_LOAD
+        current_ap_y = await self._aperture.y.user_readback.get_value(cached=False)
+        robot_load_ap_y = self._loaded_positions[
+            AperturePosition.ROBOT_LOAD
+        ].location.aperture_y
+        if await self._aperture.large.get_value(cached=False) == 1:
+            return self._loaded_positions[AperturePosition.LARGE]
+        elif await self._aperture.medium.get_value(cached=False) == 1:
+            return self._loaded_positions[AperturePosition.MEDIUM]
+        elif await self._aperture.small.get_value(cached=False) == 1:
+            return self._loaded_positions[AperturePosition.SMALL]
+        elif current_ap_y <= robot_load_ap_y + self._tolerances.ap_y:
+            return self._loaded_positions[AperturePosition.ROBOT_LOAD]
 
         raise InvalidApertureMove("Current aperture/scatterguard state unrecognised")
 
@@ -253,46 +237,46 @@ class ApertureScatterguard(StandardReadable, Movable):
         See https://github.com/DiamondLightSource/hyperion/wiki/Aperture-Scatterguard-Collisions
         for why this is required.
         """
-        assert self.aperture_positions is not None
+        assert self._loaded_positions is not None
         # unpacking the position
         aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = pos
 
-        ap_z_in_position = await self.aperture.z.motor_done_move.get_value()
+        ap_z_in_position = await self._aperture.z.motor_done_move.get_value()
         if not ap_z_in_position:
             raise InvalidApertureMove(
                 "ApertureScatterguard z is still moving. Wait for it to finish "
                 "before triggering another move."
             )
 
-        current_ap_z = await self.aperture.z.user_readback.get_value()
+        current_ap_z = await self._aperture.z.user_readback.get_value()
         diff_on_z = abs(current_ap_z - aperture_z)
-        if diff_on_z > self.aperture_positions.tolerances.ap_z:
+        if diff_on_z > self._tolerances.ap_z:
             raise InvalidApertureMove(
                 "ApertureScatterguard safe move is not yet defined for positions "
                 "outside of LARGE, MEDIUM, SMALL, ROBOT_LOAD. "
-                f"Current aperture z ({current_ap_z}), outside of tolerance ({self.aperture_positions.tolerances.ap_z}) from target ({aperture_z})."
+                f"Current aperture z ({current_ap_z}), outside of tolerance ({self._tolerances.ap_z}) from target ({aperture_z})."
             )
 
-        current_ap_y = await self.aperture.y.user_readback.get_value()
+        current_ap_y = await self._aperture.y.user_readback.get_value()
 
         if aperture_y > current_ap_y:
             await asyncio.gather(
-                self.scatterguard.x.set(scatterguard_x),
-                self.scatterguard.y.set(scatterguard_y),
+                self._scatterguard.x.set(scatterguard_x),
+                self._scatterguard.y.set(scatterguard_y),
             )
             await asyncio.gather(
-                self.aperture.x.set(aperture_x),
-                self.aperture.y.set(aperture_y),
-                self.aperture.z.set(aperture_z),
+                self._aperture.x.set(aperture_x),
+                self._aperture.y.set(aperture_y),
+                self._aperture.z.set(aperture_z),
             )
             return
         await asyncio.gather(
-            self.aperture.x.set(aperture_x),
-            self.aperture.y.set(aperture_y),
-            self.aperture.z.set(aperture_z),
+            self._aperture.x.set(aperture_x),
+            self._aperture.y.set(aperture_y),
+            self._aperture.z.set(aperture_z),
         )
 
         await asyncio.gather(
-            self.scatterguard.x.set(scatterguard_x),
-            self.scatterguard.y.set(scatterguard_y),
+            self._scatterguard.x.set(scatterguard_x),
+            self._scatterguard.y.set(scatterguard_y),
         )

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -174,6 +174,10 @@ class ApertureScatterguard(StandardReadable, Movable):
             f"Tried to convert unknown aperture name {gda_aperture_name} to a SingleAperturePosition"
         )
 
+    def get_gda_name_for_position(self, position: AperturePosition) -> str:
+        detailed_position = self._loaded_positions[position]
+        return detailed_position.GDA_name
+
     @AsyncStatus.wrap
     async def set(self, value: AperturePosition):
         position = self._loaded_positions[value]

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -280,7 +280,7 @@ def is_any_device_factory(func: Callable) -> bool:
 
 
 def is_v2_device_type(obj: type[Any]) -> bool:
-    return inspect.isclass(obj) and issubclass(obj, OphydV2Device)
+    return inspect.isclass(obj) and isinstance(obj, OphydV2Device)
 
 
 def is_v1_device_type(obj: type[Any]) -> bool:

--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -1,8 +1,5 @@
-from unittest.mock import MagicMock
-
 from dodal.beamlines import i03
 from dodal.common.beamlines import beamline_utils
-from dodal.devices.aperturescatterguard import ApertureScatterguard
 
 
 def test_list():
@@ -15,14 +12,3 @@ def test_list():
         "synchrotron",
         "aperture_scatterguard",
     ]
-
-
-def test_getting_second_aperture_scatterguard_gives_valid_device(RE):
-    beamline_utils.clear_devices()
-    test_positions = MagicMock()
-    ap_sg: ApertureScatterguard = i03.aperture_scatterguard(
-        fake_with_ophyd_sim=True, aperture_positions=test_positions
-    )
-    assert ap_sg.aperture_positions is not None
-    ap_sg = i03.aperture_scatterguard(fake_with_ophyd_sim=True)
-    assert ap_sg.aperture_positions == test_positions

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -11,7 +11,7 @@ from ophyd_async.core import StandardReadable
 
 from dodal.beamlines import i03
 from dodal.common.beamlines import beamline_utils
-from dodal.devices.aperturescatterguard import ApertureScatterguard
+from dodal.devices.beamstop import BeamStop
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.smargon import Smargon
 from dodal.devices.zebra import Zebra
@@ -38,7 +38,7 @@ def setup():
 
 
 def test_instantiate_function_makes_supplied_device():
-    device_types = [Zebra, ApertureScatterguard, Smargon]
+    device_types = [Zebra, BeamStop, Smargon]
     for device in device_types:
         dev = beamline_utils.device_instantiation(
             device, device.__name__, "", False, True, None

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -14,67 +14,23 @@ from ophyd_async.core import (
 
 from dodal.devices.aperturescatterguard import (
     ApertureFiveDimensionalLocation,
+    AperturePosition,
     AperturePositionGDANames,
-    AperturePositions,
     ApertureScatterguard,
+    ApertureScatterguardTolerances,
     InvalidApertureMove,
     SingleAperturePosition,
+    load_positions_from_beamline_parameters,
+    load_tolerances_from_beamline_params,
 )
 from dodal.devices.util.test_utils import patch_motor
 
 ApSgAndLog = tuple[ApertureScatterguard, MagicMock]
 
 
-def get_all_motors(ap_sg: ApertureScatterguard):
-    return [
-        ap_sg.aperture.x,
-        ap_sg.aperture.y,
-        ap_sg.aperture.z,
-        ap_sg.scatterguard.x,
-        ap_sg.scatterguard.y,
-    ]
-
-
 @pytest.fixture
-async def ap_sg_and_call_log(RE: RunEngine, aperture_positions: AperturePositions):
-    call_log = MagicMock()
-    async with DeviceCollector(mock=True):
-        ap_sg = ApertureScatterguard(name="test_ap_sg")
-    ap_sg.load_aperture_positions(aperture_positions)
-    with ExitStack() as motor_patch_stack:
-        for motor in get_all_motors(ap_sg):
-            motor_patch_stack.enter_context(patch_motor(motor))
-            call_log.attach_mock(get_mock_put(motor.user_setpoint), "setpoint")
-        yield ap_sg, call_log
-
-
-@pytest.fixture
-async def ap_sg(ap_sg_and_call_log: ApSgAndLog):
-    ap_sg, _ = ap_sg_and_call_log
-    return ap_sg
-
-
-@pytest.fixture
-async def aperture_in_medium_pos_w_call_log(
-    ap_sg_and_call_log: ApSgAndLog,
-    aperture_positions: AperturePositions,
-):
-    ap_sg, call_log = ap_sg_and_call_log
-    await ap_sg._set_raw_unsafe(aperture_positions.MEDIUM.location)
-
-    set_mock_value(ap_sg.aperture.medium, 1)
-    yield ap_sg, call_log
-
-
-@pytest.fixture
-async def aperture_in_medium_pos(aperture_in_medium_pos_w_call_log: ApSgAndLog):
-    ap_sg, _ = aperture_in_medium_pos_w_call_log
-    return ap_sg
-
-
-@pytest.fixture
-def aperture_positions():
-    aperture_positions = AperturePositions.from_gda_beamline_params(
+def aperture_positions() -> dict[AperturePosition, SingleAperturePosition]:
+    return load_positions_from_beamline_parameters(
         {
             "miniap_x_LARGE_APERTURE": 2.389,
             "miniap_y_LARGE_APERTURE": 40.986,
@@ -96,14 +52,75 @@ def aperture_positions():
             "miniap_z_ROBOT_LOAD": 15.8,
             "sg_x_ROBOT_LOAD": 5.25,
             "sg_y_ROBOT_LOAD": 4.43,
+        }  # type:ignore
+    )
+
+
+@pytest.fixture
+def aperture_tolerances():
+    return load_tolerances_from_beamline_params(
+        {
             "miniap_x_tolerance": 0.004,
             "miniap_y_tolerance": 0.1,
             "miniap_z_tolerance": 0.1,
             "sg_x_tolerance": 0.1,
             "sg_y_tolerance": 0.1,
-        }
+        }  # type:ignore
     )
-    return aperture_positions
+
+
+def get_all_motors(ap_sg: ApertureScatterguard):
+    return [
+        ap_sg._aperture.x,
+        ap_sg._aperture.y,
+        ap_sg._aperture.z,
+        ap_sg._scatterguard.x,
+        ap_sg._scatterguard.y,
+    ]
+
+
+@pytest.fixture
+async def ap_sg_and_call_log(
+    RE: RunEngine,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_tolerances: ApertureScatterguardTolerances,
+):
+    call_log = MagicMock()
+    async with DeviceCollector(mock=True):
+        ap_sg = ApertureScatterguard(
+            name="test_ap_sg",
+            loaded_positions=aperture_positions,
+            tolerances=aperture_tolerances,
+        )
+    with ExitStack() as motor_patch_stack:
+        for motor in get_all_motors(ap_sg):
+            motor_patch_stack.enter_context(patch_motor(motor))
+            call_log.attach_mock(get_mock_put(motor.user_setpoint), "setpoint")
+        yield ap_sg, call_log
+
+
+@pytest.fixture
+async def ap_sg(ap_sg_and_call_log: ApSgAndLog):
+    ap_sg, _ = ap_sg_and_call_log
+    return ap_sg
+
+
+@pytest.fixture
+async def aperture_in_medium_pos_w_call_log(
+    ap_sg_and_call_log: ApSgAndLog,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+):
+    ap_sg, call_log = ap_sg_and_call_log
+    await ap_sg._set_raw_unsafe(aperture_positions[AperturePosition.MEDIUM].location)
+
+    set_mock_value(ap_sg._aperture.medium, 1)
+    yield ap_sg, call_log
+
+
+@pytest.fixture
+async def aperture_in_medium_pos(aperture_in_medium_pos_w_call_log: ApSgAndLog):
+    ap_sg, _ = aperture_in_medium_pos_w_call_log
+    return ap_sg
 
 
 def _assert_patched_ap_sg_has_call(
@@ -122,26 +139,16 @@ def _assert_patched_ap_sg_has_call(
         )
 
 
-async def test_aperture_scatterguard_rejects_unknown_position(aperture_in_medium_pos):
-    position_to_reject = ApertureFiveDimensionalLocation(0, 0, 0, 0, 0)
-
-    with pytest.raises(InvalidApertureMove):
-        await aperture_in_medium_pos.set(
-            SingleAperturePosition("test", "GDA_NAME", 10, position_to_reject)
-        )
-
-
 def _call_list(calls: Sequence[float]):
     return [call.setpoint(v, wait=True, timeout=ANY) for v in calls]
 
 
 async def test_aperture_scatterguard_select_bottom_moves_sg_down_then_assembly_up(
-    aperture_positions: AperturePositions,
     aperture_in_medium_pos_w_call_log: ApSgAndLog,
 ):
     ap_sg, call_log = aperture_in_medium_pos_w_call_log
 
-    await ap_sg.set(aperture_positions.SMALL)
+    await ap_sg.set(AperturePosition.SMALL)
 
     call_log.assert_has_calls(_call_list((5.3375, -3.55, 2.43, 48.974, 15.8)))
 
@@ -156,11 +163,11 @@ async def test_aperture_unsafe_move(
 
 
 async def test_aperture_scatterguard_select_top_moves_assembly_down_then_sg_up(
-    aperture_positions: AperturePositions, aperture_in_medium_pos: ApertureScatterguard
+    aperture_in_medium_pos: ApertureScatterguard,
 ):
     ap_sg = aperture_in_medium_pos
 
-    await ap_sg.set(aperture_positions.LARGE)
+    await ap_sg.set(AperturePosition.LARGE)
 
     _assert_patched_ap_sg_has_call(ap_sg, (2.389, 40.986, 15.8, 5.25, 4.43))
 
@@ -168,9 +175,9 @@ async def test_aperture_scatterguard_select_top_moves_assembly_down_then_sg_up(
 async def test_aperture_scatterguard_throws_error_if_outside_tolerance(
     ap_sg: ApertureScatterguard,
 ):
-    set_mock_value(ap_sg.aperture.z.deadband, 0.001)
-    set_mock_value(ap_sg.aperture.z.user_readback, 1)
-    set_mock_value(ap_sg.aperture.z.motor_done_move, 1)
+    set_mock_value(ap_sg._aperture.z.deadband, 0.001)
+    set_mock_value(ap_sg._aperture.z.user_readback, 1)
+    set_mock_value(ap_sg._aperture.z.motor_done_move, 1)
 
     with pytest.raises(InvalidApertureMove):
         pos = ApertureFiveDimensionalLocation(0, 0, 1.1, 0, 0)
@@ -180,9 +187,9 @@ async def test_aperture_scatterguard_throws_error_if_outside_tolerance(
 async def test_aperture_scatterguard_returns_status_if_within_tolerance(
     ap_sg: ApertureScatterguard,
 ):
-    set_mock_value(ap_sg.aperture.z.deadband, 0.001)
-    set_mock_value(ap_sg.aperture.z.user_readback, 1)
-    set_mock_value(ap_sg.aperture.z.motor_done_move, 1)
+    set_mock_value(ap_sg._aperture.z.deadband, 0.001)
+    set_mock_value(ap_sg._aperture.z.user_readback, 1)
+    set_mock_value(ap_sg._aperture.z.motor_done_move, 1)
 
     pos = ApertureFiveDimensionalLocation(0, 0, 1, 0, 0)
     await ap_sg._safe_move_within_datacollection_range(pos)
@@ -200,103 +207,119 @@ def set_underlying_motors(
 
 
 async def test_aperture_positions_large(
-    ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
+    ap_sg: ApertureScatterguard, aperture_positions
 ):
-    set_mock_value(ap_sg.aperture.large, 1)
-    assert await ap_sg.get_current_aperture_position() == aperture_positions.LARGE
+    set_mock_value(ap_sg._aperture.large, 1)
+    assert (
+        await ap_sg.get_current_aperture_position()
+        == aperture_positions[AperturePosition.LARGE]
+    )
 
 
 async def test_aperture_positions_medium(
-    ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
+    ap_sg: ApertureScatterguard, aperture_positions
 ):
-    set_mock_value(ap_sg.aperture.medium, 1)
-    assert await ap_sg.get_current_aperture_position() == aperture_positions.MEDIUM
+    set_mock_value(ap_sg._aperture.medium, 1)
+    assert (
+        await ap_sg.get_current_aperture_position()
+        == aperture_positions[AperturePosition.MEDIUM]
+    )
 
 
 async def test_aperture_positions_small(
-    ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
+    ap_sg: ApertureScatterguard, aperture_positions
 ):
-    set_mock_value(ap_sg.aperture.small, 1)
-    assert await ap_sg.get_current_aperture_position() == aperture_positions.SMALL
+    set_mock_value(ap_sg._aperture.small, 1)
+    assert (
+        await ap_sg.get_current_aperture_position()
+        == aperture_positions[AperturePosition.SMALL]
+    )
 
 
 async def test_aperture_positions_robot_load(
-    ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
+    ap_sg: ApertureScatterguard,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
 ):
-    set_mock_value(ap_sg.aperture.large, 0)
-    set_mock_value(ap_sg.aperture.medium, 0)
-    set_mock_value(ap_sg.aperture.small, 0)
-    await ap_sg.aperture.y.set(aperture_positions.ROBOT_LOAD.location.aperture_y)
-    assert await ap_sg.get_current_aperture_position() == aperture_positions.ROBOT_LOAD
+    set_mock_value(ap_sg._aperture.large, 0)
+    set_mock_value(ap_sg._aperture.medium, 0)
+    set_mock_value(ap_sg._aperture.small, 0)
+    robot_load = aperture_positions[AperturePosition.ROBOT_LOAD]
+    await ap_sg._aperture.y.set(robot_load.location.aperture_y)
+    assert await ap_sg.get_current_aperture_position() == robot_load
 
 
 async def test_aperture_positions_robot_load_within_tolerance(
-    ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
+    ap_sg: ApertureScatterguard,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
 ):
-    robot_load_ap_y = aperture_positions.ROBOT_LOAD.location.aperture_y
-    tolerance = aperture_positions.tolerances.ap_y
-    set_mock_value(ap_sg.aperture.large, 0)
-    set_mock_value(ap_sg.aperture.medium, 0)
-    set_mock_value(ap_sg.aperture.small, 0)
-    await ap_sg.aperture.y.set(robot_load_ap_y + tolerance)
-    assert await ap_sg.get_current_aperture_position() == aperture_positions.ROBOT_LOAD
+    robot_load = aperture_positions[AperturePosition.ROBOT_LOAD]
+    robot_load_ap_y = robot_load.location.aperture_y
+    tolerance = ap_sg._tolerances.ap_y
+    set_mock_value(ap_sg._aperture.large, 0)
+    set_mock_value(ap_sg._aperture.medium, 0)
+    set_mock_value(ap_sg._aperture.small, 0)
+    await ap_sg._aperture.y.set(robot_load_ap_y + tolerance)
+    assert await ap_sg.get_current_aperture_position() == robot_load
 
 
 async def test_aperture_positions_robot_load_outside_tolerance(
-    ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
+    ap_sg: ApertureScatterguard,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
 ):
-    robot_load_ap_y = aperture_positions.ROBOT_LOAD.location.aperture_y
-    tolerance = aperture_positions.tolerances.ap_y + 0.01
-    set_mock_value(ap_sg.aperture.large, 0)
-    set_mock_value(ap_sg.aperture.medium, 0)
-    set_mock_value(ap_sg.aperture.small, 0)
-    await ap_sg.aperture.y.set(robot_load_ap_y + tolerance)
+    robot_load = aperture_positions[AperturePosition.ROBOT_LOAD]
+    robot_load_ap_y = robot_load.location.aperture_y
+    tolerance = ap_sg._tolerances.ap_y + 0.01
+    set_mock_value(ap_sg._aperture.large, 0)
+    set_mock_value(ap_sg._aperture.medium, 0)
+    set_mock_value(ap_sg._aperture.small, 0)
+    await ap_sg._aperture.y.set(robot_load_ap_y + tolerance)
     with pytest.raises(InvalidApertureMove):
         await ap_sg.get_current_aperture_position()
 
 
 async def test_aperture_positions_robot_load_unsafe(
-    ap_sg: ApertureScatterguard, aperture_positions: AperturePositions
+    ap_sg: ApertureScatterguard,
 ):
-    set_mock_value(ap_sg.aperture.large, 0)
-    set_mock_value(ap_sg.aperture.medium, 0)
-    set_mock_value(ap_sg.aperture.small, 0)
-    await ap_sg.aperture.y.set(50.0)
+    set_mock_value(ap_sg._aperture.large, 0)
+    set_mock_value(ap_sg._aperture.medium, 0)
+    set_mock_value(ap_sg._aperture.small, 0)
+    await ap_sg._aperture.y.set(50.0)
     with pytest.raises(InvalidApertureMove):
         await ap_sg.get_current_aperture_position()
 
 
 async def test_given_aperture_not_set_through_device_but_motors_in_position_when_device_read_then_position_returned(
-    aperture_in_medium_pos: ApertureScatterguard, aperture_positions: AperturePositions
+    aperture_in_medium_pos: ApertureScatterguard,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
 ):
     selected_aperture = await aperture_in_medium_pos.read()
     assert isinstance(selected_aperture, dict)
     assert selected_aperture["test_ap_sg-selected_aperture"]["value"] == asdict(
-        aperture_positions.MEDIUM
+        aperture_positions[AperturePosition.MEDIUM]
     )
 
 
 async def test_when_aperture_set_and_device_read_then_position_returned(
-    aperture_in_medium_pos: ApertureScatterguard, aperture_positions: AperturePositions
+    aperture_in_medium_pos: ApertureScatterguard,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
 ):
-    await aperture_in_medium_pos.set(aperture_positions.MEDIUM)
+    await aperture_in_medium_pos.set(AperturePosition.MEDIUM)
     selected_aperture = await aperture_in_medium_pos.read()
     assert selected_aperture["test_ap_sg-selected_aperture"]["value"] == asdict(
-        aperture_positions.MEDIUM
+        aperture_positions[AperturePosition.MEDIUM]
     )
 
 
 async def test_ap_sg_in_runengine(
     aperture_in_medium_pos: ApertureScatterguard,
     RE: RunEngine,
+    aperture_positions: dict[AperturePosition, SingleAperturePosition],
 ):
     ap_sg = aperture_in_medium_pos
-    ap = ap_sg.aperture
-    sg = ap_sg.scatterguard
-    assert ap_sg.aperture_positions
-    test_position = ap_sg.aperture_positions.SMALL
-    test_loc = test_position.location
-    RE(bps.abs_set(ap_sg, test_position, wait=True))
+    ap = ap_sg._aperture
+    sg = ap_sg._scatterguard
+    test_loc = aperture_positions[AperturePosition.SMALL].location
+    RE(bps.abs_set(ap_sg, AperturePosition.SMALL, wait=True))
     assert await ap.x.user_readback.get_value() == test_loc.aperture_x
     assert await ap.y.user_readback.get_value() == test_loc.aperture_y
     assert await ap.z.user_readback.get_value() == test_loc.aperture_z
@@ -313,33 +336,32 @@ async def test_ap_sg_descriptor(
 
 
 def test_get_position_from_gda_aperture_name(
-    RE: RunEngine, aperture_positions: AperturePositions
+    RE: RunEngine,
+    ap_sg: ApertureScatterguard,
 ):
     assert (
-        aperture_positions.get_position_from_gda_aperture_name(
+        ap_sg.get_position_from_gda_aperture_name(
             AperturePositionGDANames.LARGE_APERTURE
         )
-        == aperture_positions.LARGE
+        == AperturePosition.LARGE
     )
     assert (
-        aperture_positions.get_position_from_gda_aperture_name(
+        ap_sg.get_position_from_gda_aperture_name(
             AperturePositionGDANames.MEDIUM_APERTURE
         )
-        == aperture_positions.MEDIUM
+        == AperturePosition.MEDIUM
     )
     assert (
-        aperture_positions.get_position_from_gda_aperture_name(
+        ap_sg.get_position_from_gda_aperture_name(
             AperturePositionGDANames.SMALL_APERTURE
         )
-        == aperture_positions.SMALL
+        == AperturePosition.SMALL
     )
     assert (
-        aperture_positions.get_position_from_gda_aperture_name(
-            AperturePositionGDANames.ROBOT_LOAD
-        )
-        == aperture_positions.ROBOT_LOAD
+        ap_sg.get_position_from_gda_aperture_name(AperturePositionGDANames.ROBOT_LOAD)
+        == AperturePosition.ROBOT_LOAD
     )
     with pytest.raises(ValueError):
-        aperture_positions.get_position_from_gda_aperture_name(
+        ap_sg.get_position_from_gda_aperture_name(
             "VERY TINY APERTURE"  # type: ignore
         )

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -329,14 +329,12 @@ async def test_ap_sg_in_runengine(
 
 async def test_ap_sg_descriptor(
     aperture_in_medium_pos: ApertureScatterguard,
-    RE: RunEngine,
 ):
     description = await aperture_in_medium_pos.describe()
     assert description
 
 
 def test_get_position_from_gda_aperture_name(
-    RE: RunEngine,
     ap_sg: ApertureScatterguard,
 ):
     assert (
@@ -365,3 +363,7 @@ def test_get_position_from_gda_aperture_name(
         ap_sg.get_position_from_gda_aperture_name(
             "VERY TINY APERTURE"  # type: ignore
         )
+
+
+def test_ap_sg_returns_GDA_name_correctly(ap_sg: ApertureScatterguard):
+    assert ap_sg.get_gda_name_for_position(AperturePosition.SMALL) == "SMALL_APERTURE"


### PR DESCRIPTION
Fixes #740

### Instructions to reviewer on how to test:
1. Confirm interface to `ApertureScatterguard` is cleaner
1. Confirm tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
