### PR TITLE
Allow moving aperture and scatterguard more independently

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -8,11 +8,7 @@ from dodal.common.beamlines.beamline_utils import (
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.udc_directory_provider import PandASubdirectoryProvider
-from dodal.devices.aperturescatterguard import (
-    ApertureScatterguard,
-    load_positions_from_beamline_parameters,
-    load_tolerances_from_beamline_params,
-)
+from dodal.devices.aperturescatterguard import ApertureConfigData, ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.cryostream import CryoStream
@@ -64,14 +60,14 @@ def aperture_scatterguard(
     object.
     """
     params = get_beamline_parameters()
+    data = ApertureConfigData(params)
     return device_instantiation(
         device_factory=ApertureScatterguard,
         name="aperture_scatterguard",
         prefix="",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
-        loaded_positions=load_positions_from_beamline_parameters(params),
-        tolerances=load_tolerances_from_beamline_params(params),
+        configuration_data=data,
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -1,11 +1,7 @@
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
 from dodal.common.beamlines.beamline_utils import device_instantiation
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.devices.aperturescatterguard import (
-    ApertureScatterguard,
-    load_positions_from_beamline_parameters,
-    load_tolerances_from_beamline_params,
-)
+from dodal.devices.aperturescatterguard import ApertureConfigData, ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.beamstop import BeamStop
@@ -236,8 +232,7 @@ def aperture_scatterguard(
         prefix="",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
-        loaded_positions=load_positions_from_beamline_parameters(params),
-        tolerances=load_tolerances_from_beamline_params(params),
+        configuration_data=ApertureConfigData(params),
     )
 
 

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -189,11 +189,22 @@ class ApertureScatterguard(StandardReadable, Movable):
     @AsyncStatus.wrap
     async def set(self, value: InOutAndPosition):
         in_out, position = value
-        if in_out == ApertureInOut.OUT and not position:
+        if in_out == ApertureInOut.OUT:
             robot_load_y = self._loaded_positions[
                 AperturePosition.ROBOT_LOAD
             ].location.aperture_y
-            return await self._aperture.y.set(robot_load_y)
+            if position:
+                location = self._loaded_positions[position].location
+                out_location = ApertureFiveDimensionalLocation(
+                    location.aperture_x,
+                    robot_load_y,
+                    location.aperture_z,
+                    location.scatterguard_x,
+                    location.scatterguard_y,
+                )
+                return await self._set_raw_unsafe(out_location)
+            else:
+                return await self._aperture.y.set(robot_load_y)
         if position:
             position_detail = self._loaded_positions[position]
             await self._safe_move_within_datacollection_range(position_detail.location)

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -190,22 +190,24 @@ class ApertureScatterguard(StandardReadable, Movable):
     async def set(self, value: InOutAndPosition):
         in_out, position = value
         if in_out == ApertureInOut.OUT:
-            robot_load_y = self._loaded_positions[
+            out_y = self._loaded_positions[
                 AperturePosition.ROBOT_LOAD
             ].location.aperture_y
             if position:
                 location = self._loaded_positions[position].location
                 out_location = ApertureFiveDimensionalLocation(
                     location.aperture_x,
-                    robot_load_y,
+                    out_y,
                     location.aperture_z,
                     location.scatterguard_x,
                     location.scatterguard_y,
                 )
                 return await self._set_raw_unsafe(out_location)
             else:
-                return await self._aperture.y.set(robot_load_y)
-        if position:
+                return await self._aperture.y.set(out_y)
+        elif in_out == ApertureInOut.IN:
+            if not position:
+                raise InvalidApertureMove("Cannot move in without a selected aperture")
             position_detail = self._loaded_positions[position]
             await self._safe_move_within_datacollection_range(position_detail.location)
 

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -374,13 +374,13 @@ async def test_when_move_out_and_none_then_mini_apt_y_moves_to_robot_load_positi
     ap_sg: ApertureScatterguard,
 ):
     await ap_sg.set((ApertureInOut.OUT, None))
-    get_mock_put(ap_sg._aperture.y.user_readback).assert_called_once_with(
+    get_mock_put(ap_sg._aperture.y.user_setpoint).assert_called_once_with(
         31.40, wait=ANY, timeout=ANY
     )
-    get_mock_put(ap_sg._aperture.x.user_readback).assert_not_called()
-    get_mock_put(ap_sg._aperture.z.user_readback).assert_not_called()
-    get_mock_put(ap_sg._scatterguard.x.user_readback).assert_not_called()
-    get_mock_put(ap_sg._scatterguard.y.user_readback).assert_not_called()
+    get_mock_put(ap_sg._aperture.x.user_setpoint).assert_not_called()
+    get_mock_put(ap_sg._aperture.z.user_setpoint).assert_not_called()
+    get_mock_put(ap_sg._scatterguard.x.user_setpoint).assert_not_called()
+    get_mock_put(ap_sg._scatterguard.y.user_setpoint).assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -406,3 +406,10 @@ async def test_when_move_out_and_a_position_then_mini_apt_y_moves_to_robot_load_
     assert (
         await ap_sg._scatterguard.y.user_readback.get_value() == location.scatterguard_y
     )
+
+
+async def test_when_move_in_and_no_aperture_then_raise_exception(
+    ap_sg: ApertureScatterguard,
+):
+    with pytest.raises(InvalidApertureMove):
+        await ap_sg.set((ApertureInOut.IN, None))

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -374,10 +374,35 @@ async def test_when_move_out_and_none_then_mini_apt_y_moves_to_robot_load_positi
     ap_sg: ApertureScatterguard,
 ):
     await ap_sg.set((ApertureInOut.OUT, None))
-    get_mock_put(ap_sg._aperture.y.user_setpoint).assert_called_once_with(
+    get_mock_put(ap_sg._aperture.y.user_readback).assert_called_once_with(
         31.40, wait=ANY, timeout=ANY
     )
-    get_mock_put(ap_sg._aperture.x.user_setpoint).assert_not_called()
-    get_mock_put(ap_sg._aperture.z.user_setpoint).assert_not_called()
-    get_mock_put(ap_sg._scatterguard.x.user_setpoint).assert_not_called()
-    get_mock_put(ap_sg._scatterguard.y.user_setpoint).assert_not_called()
+    get_mock_put(ap_sg._aperture.x.user_readback).assert_not_called()
+    get_mock_put(ap_sg._aperture.z.user_readback).assert_not_called()
+    get_mock_put(ap_sg._scatterguard.x.user_readback).assert_not_called()
+    get_mock_put(ap_sg._scatterguard.y.user_readback).assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "position",
+    [
+        AperturePosition.SMALL,
+        AperturePosition.MEDIUM,
+        AperturePosition.LARGE,
+    ],
+)
+async def test_when_move_out_and_a_position_then_mini_apt_y_moves_to_robot_load_y_and_other_axes_move_to_aperture_position(
+    ap_sg: ApertureScatterguard, position: AperturePosition
+):
+    location = ap_sg._loaded_positions[position].location
+
+    await ap_sg.set((ApertureInOut.OUT, position))
+    assert await ap_sg._aperture.y.user_readback.get_value() == 31.40
+    assert await ap_sg._aperture.x.user_readback.get_value() == location.aperture_x
+    assert await ap_sg._aperture.z.user_readback.get_value() == location.aperture_z
+    assert (
+        await ap_sg._scatterguard.x.user_readback.get_value() == location.scatterguard_x
+    )
+    assert (
+        await ap_sg._scatterguard.y.user_readback.get_value() == location.scatterguard_y
+    )


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/267

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
