### PR TITLE
remove skip device

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -234,7 +234,6 @@ def slits_3(
     )
 
 
-@skip_device()
 def slits_4(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,


### PR DESCRIPTION
Fixes #587

### Instructions to reviewer on how to test:
1. run `dodal connect i22`
2. Expect all the slits, including 4 to connect

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
