### PR TITLE
Fixes the OAVToRedisForwarder based on beamline tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ filterwarnings = [
     "ignore:dep_util is Deprecated. Use functions from setuptools instead.:DeprecationWarning",
     # Ignore deprecation warning from zocalo
     "ignore:.*pkg_resources.*:DeprecationWarning",
+    # Ignore deprecation warning from setuptools_dso (remove when https://github.com/epics-base/setuptools_dso/issues/36 is released)
+    "ignore::DeprecationWarning:wheel",
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -410,9 +410,11 @@ def oav_to_redis_forwarder(
     """
     return device_instantiation(
         OAVToRedisForwarder,
-        "oav_to_redis",
+        "oav_to_redis_forwarder",
         "",
         wait_for_connection,
         fake_with_ophyd_sim,
-        params=OAVConfigParams(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
+        redis_host=REDIS_HOST,
+        redis_password=REDIS_PASSWORD,
+        redis_db=7,
     )

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -411,7 +411,7 @@ def oav_to_redis_forwarder(
     return device_instantiation(
         OAVToRedisForwarder,
         "oav_to_redis_forwarder",
-        "",
+        "-DI-OAV-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
         redis_host=REDIS_HOST,

--- a/src/dodal/common/beamlines/beamline_parameters.py
+++ b/src/dodal/common/beamlines/beamline_parameters.py
@@ -7,7 +7,7 @@ BEAMLINE_PARAMETER_KEYWORDS = ["FB", "FULL", "deadtime"]
 
 BEAMLINE_PARAMETER_PATHS = {
     "i03": "/dls_sw/i03/software/daq_configuration/domain/beamlineParameters",
-    "i04": "/dls_sw/i04/software/gda_versions/gda_9_29/workspace_git/gda-mx.git/configurations/i04-config/scripts/beamlineParameters",
+    "i04": "/dls_sw/i04/software/gda_versions/gda_9_34/workspace_git/gda-mx.git/configurations/i04-config/scripts/beamlineParameters",
     "s03": "tests/test_data/test_beamline_parameters.txt",
 }
 

--- a/src/dodal/devices/oav/oav_to_redis_forwarder.py
+++ b/src/dodal/devices/oav/oav_to_redis_forwarder.py
@@ -81,7 +81,7 @@ class OAVToRedisForwarder(StandardReadable, Flyable):
         self.uuid_setter(image_uuid := str(uuid.uuid4()))
         img = Image.open(io.BytesIO(jpeg_bytes))
         image_data = pickle.dumps(np.asarray(img))
-        sample_id = await self.sample_id.get_value()
+        sample_id = str(await self.sample_id.get_value())
         await self.redis_client.hset(sample_id, image_uuid, image_data)  # type: ignore
         await self.redis_client.expire(sample_id, timedelta(days=self.DATA_EXPIRY_DAYS))
         LOGGER.debug(f"Sent frame to redis key {sample_id} with uuid {image_uuid}")

--- a/src/dodal/devices/oav/oav_to_redis_forwarder.py
+++ b/src/dodal/devices/oav/oav_to_redis_forwarder.py
@@ -55,7 +55,7 @@ class OAVToRedisForwarder(StandardReadable, Flyable):
             redis_db: int           which redis database to connect to, defaults to 0
             name: str               the name of this device
         """
-        self.stream_url = epics_signal_r(str, f"{prefix}-DI-OAV-01:MJPG:MJPG_URL_RBV")
+        self.stream_url = epics_signal_r(str, f"{prefix}MJPG:MJPG_URL_RBV")
 
         with self.add_children_as_readables():
             self.uuid, self.uuid_setter = soft_signal_r_and_setter(str)
@@ -65,7 +65,7 @@ class OAVToRedisForwarder(StandardReadable, Flyable):
             host=redis_host, password=redis_password, db=redis_db
         )
 
-        self.sample_id = soft_signal_rw(int)
+        self.sample_id = soft_signal_rw(int, initial_value=0)
 
         # The uuid that images are being saved under, this should be monitored for
         # callbacks to correlate the data
@@ -86,7 +86,7 @@ class OAVToRedisForwarder(StandardReadable, Flyable):
         await self.redis_client.expire(sample_id, timedelta(days=self.DATA_EXPIRY_DAYS))
         LOGGER.debug(f"Sent frame to redis key {sample_id} with uuid {image_uuid}")
 
-    async def _open_connection_and_(self, function_to_do: Callable):
+    async def _open_connection_and_do_function(self, function_to_do: Callable):
         stream_url = await self.stream_url.get_value()
         async with ClientSession() as session:
             async with session.get(stream_url) as response:
@@ -103,9 +103,9 @@ class OAVToRedisForwarder(StandardReadable, Flyable):
 
     @AsyncStatus.wrap
     async def kickoff(self):
-        await self._open_connection_and_(self._confirm_mjpg_stream)
+        await self._open_connection_and_do_function(self._confirm_mjpg_stream)
         self.forwarding_task = asyncio.create_task(
-            self._open_connection_and_(self._stream_to_redis)
+            self._open_connection_and_do_function(self._stream_to_redis)
         )
 
     @AsyncStatus.wrap

--- a/tests/devices/system_tests/test_oav_to_redis_system.py
+++ b/tests/devices/system_tests/test_oav_to_redis_system.py
@@ -3,45 +3,55 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from aiohttp.client_exceptions import ClientConnectorError
-from ophyd_async.core import DeviceCollector
+from ophyd_async.core import DeviceCollector, set_mock_value
 
 from dodal.devices.oav.oav_to_redis_forwarder import OAVToRedisForwarder
+
+
+def _oav_to_redis_forwarder(mock):
+    with DeviceCollector(mock=mock):
+        oav_forwarder = OAVToRedisForwarder("BL04I-DI-OAV-01:", "", "")
+    oav_forwarder.redis_client.hset = AsyncMock()
+    oav_forwarder.redis_client.expire = AsyncMock()
+    return oav_forwarder
 
 
 @pytest.fixture
 @patch("dodal.devices.oav.oav_to_redis_forwarder.StrictRedis")
 def oav_to_redis_forwarder(_, RE):
-    with DeviceCollector():
-        oav_forwarder = OAVToRedisForwarder("BL04I", "", "")
-    oav_forwarder.redis_client.hset = AsyncMock()
-    return oav_forwarder
+    return _oav_to_redis_forwarder(False)
 
 
-@pytest.mark.s03  # Doesn't actually depend on s03, just on DLS network. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
+@pytest.fixture
+@patch("dodal.devices.oav.oav_to_redis_forwarder.StrictRedis")
+def mock_oav_to_redis_forwarder(_, RE):
+    return _oav_to_redis_forwarder(True)
+
+
+@pytest.mark.s03  # Doesn't actually depend on s03 but is a system test as it depends on external webpage. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
 async def test_given_stream_url_is_not_a_real_webpage_when_kickoff_then_error(
-    oav_to_redis_forwarder: OAVToRedisForwarder,
+    mock_oav_to_redis_forwarder: OAVToRedisForwarder,
 ):
-    oav_to_redis_forwarder.stream_url = AsyncMock()
-    oav_to_redis_forwarder.stream_url.get_value.return_value = (
-        "http://www.this_is_not_a_valid_webpage.com/"
+    set_mock_value(
+        mock_oav_to_redis_forwarder.stream_url,
+        "http://www.this_is_not_a_valid_webpage.com/",
     )
     with pytest.raises(ClientConnectorError):
-        await oav_to_redis_forwarder.kickoff()
+        await mock_oav_to_redis_forwarder.kickoff()
 
 
-@pytest.mark.s03  # Doesn't actually depend on s03, just on DLS network. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
+@pytest.mark.s03  # Doesn't actually depend on s03 but is a system test as it depends on external webpage. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
 async def test_given_stream_url_is_real_webpage_but_not_mjpg_when_kickoff_then_error(
-    oav_to_redis_forwarder: OAVToRedisForwarder,
+    mock_oav_to_redis_forwarder: OAVToRedisForwarder,
 ):
     URL = "https://www.google.com/"
-    oav_to_redis_forwarder.stream_url = AsyncMock()
-    oav_to_redis_forwarder.stream_url.get_value.return_value = URL
+    set_mock_value(mock_oav_to_redis_forwarder.stream_url, URL)
     with pytest.raises(ValueError) as e:
         await oav_to_redis_forwarder.kickoff()
     assert URL in str(e.value)
 
 
-@pytest.mark.s03  # Doesn't actually depend on s03, just on DLS network. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
+@pytest.mark.s03  # Doesn't actually depend on s03, instead connects to the real beamline. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
 async def test_given_valid_stream_when_kickoff_then_multiple_images_written_to_redis(
     oav_to_redis_forwarder: OAVToRedisForwarder,
 ):

--- a/tests/devices/system_tests/test_oav_to_redis_system.py
+++ b/tests/devices/system_tests/test_oav_to_redis_system.py
@@ -48,4 +48,4 @@ async def test_given_valid_stream_when_kickoff_then_multiple_images_written_to_r
     await oav_to_redis_forwarder.kickoff()
     await asyncio.sleep(0.5)
     await oav_to_redis_forwarder.complete()
-    assert oav_to_redis_forwarder.redis_client.hset.call_count > 1
+    assert oav_to_redis_forwarder.redis_client.hset.call_count > 1  # type:ignore

--- a/tests/devices/system_tests/test_oav_to_redis_system.py
+++ b/tests/devices/system_tests/test_oav_to_redis_system.py
@@ -47,7 +47,7 @@ async def test_given_stream_url_is_real_webpage_but_not_mjpg_when_kickoff_then_e
     URL = "https://www.google.com/"
     set_mock_value(mock_oav_to_redis_forwarder.stream_url, URL)
     with pytest.raises(ValueError) as e:
-        await oav_to_redis_forwarder.kickoff()
+        await mock_oav_to_redis_forwarder.kickoff()
     assert URL in str(e.value)
 
 

--- a/tests/devices/system_tests/test_oav_to_redis_system.py
+++ b/tests/devices/system_tests/test_oav_to_redis_system.py
@@ -1,0 +1,51 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp.client_exceptions import ClientConnectorError
+from ophyd_async.core import DeviceCollector
+
+from dodal.devices.oav.oav_to_redis_forwarder import OAVToRedisForwarder
+
+
+@pytest.fixture
+@patch("dodal.devices.oav.oav_to_redis_forwarder.StrictRedis")
+def oav_to_redis_forwarder(_, RE):
+    with DeviceCollector():
+        oav_forwarder = OAVToRedisForwarder("BL04I", "", "")
+    oav_forwarder.redis_client.hset = AsyncMock()
+    return oav_forwarder
+
+
+@pytest.mark.s03  # Doesn't actually depend on s03, just on DLS network. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
+async def test_given_stream_url_is_not_a_real_webpage_when_kickoff_then_error(
+    oav_to_redis_forwarder: OAVToRedisForwarder,
+):
+    oav_to_redis_forwarder.stream_url = AsyncMock()
+    oav_to_redis_forwarder.stream_url.get_value.return_value = (
+        "http://www.this_is_not_a_valid_webpage.com/"
+    )
+    with pytest.raises(ClientConnectorError):
+        await oav_to_redis_forwarder.kickoff()
+
+
+@pytest.mark.s03  # Doesn't actually depend on s03, just on DLS network. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
+async def test_given_stream_url_is_real_webpage_but_not_mjpg_when_kickoff_then_error(
+    oav_to_redis_forwarder: OAVToRedisForwarder,
+):
+    URL = "https://www.google.com/"
+    oav_to_redis_forwarder.stream_url = AsyncMock()
+    oav_to_redis_forwarder.stream_url.get_value.return_value = URL
+    with pytest.raises(ValueError) as e:
+        await oav_to_redis_forwarder.kickoff()
+    assert URL in str(e.value)
+
+
+@pytest.mark.s03  # Doesn't actually depend on s03, just on DLS network. See https://github.com/DiamondLightSource/mx-bluesky/issues/183
+async def test_given_valid_stream_when_kickoff_then_multiple_images_written_to_redis(
+    oav_to_redis_forwarder: OAVToRedisForwarder,
+):
+    await oav_to_redis_forwarder.kickoff()
+    await asyncio.sleep(0.5)
+    await oav_to_redis_forwarder.complete()
+    assert oav_to_redis_forwarder.redis_client.hset.call_count > 1

--- a/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
+++ b/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
@@ -89,7 +89,7 @@ async def test_when_get_frame_and_put_to_redis_called_then_data_put_in_redis_und
     await oav_forwarder.sample_id.set(SAMPLE_ID)
     await oav_forwarder._get_frame_and_put_to_redis(_mock_response())
     redis_call = oav_forwarder.redis_client.hset.call_args[0]
-    assert redis_call[0] == SAMPLE_ID
+    assert redis_call[0] == str(SAMPLE_ID)
 
 
 async def test_when_get_frame_and_put_to_redis_called_then_data_converted_to_image_and_sent_to_redis(
@@ -108,5 +108,5 @@ async def test_when_get_frame_and_put_to_redis_called_then_data_put_in_redis_wit
     await oav_forwarder.sample_id.set(SAMPLE_ID)
     await oav_forwarder._get_frame_and_put_to_redis(_mock_response())
     redis_expire_call = oav_forwarder.redis_client.expire.call_args[0]
-    assert redis_expire_call[0] == SAMPLE_ID
+    assert redis_expire_call[0] == str(SAMPLE_ID)
     assert redis_expire_call[1] == timedelta(days=oav_forwarder.DATA_EXPIRY_DAYS)


### PR DESCRIPTION
See https://github.com/DiamondLightSource/mx-bluesky/issues/195

### Instructions to reviewer on how to test:
1. Confirm `dodal connect i04` works
2. Confirm new system and unit tests work

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
