### PR TITLE
Make sure backlight is moved in/out when set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ filterwarnings = [
     "ignore:dep_util is Deprecated. Use functions from setuptools instead.:DeprecationWarning",
     # Ignore deprecation warning from zocalo
     "ignore:.*pkg_resources.*:DeprecationWarning",
+    # Ignore deprecation warning from setuptools_dso (remove when https://github.com/epics-base/setuptools_dso/issues/36 is released)
+    "ignore::DeprecationWarning:wheel",
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"

--- a/src/dodal/devices/backlight.py
+++ b/src/dodal/devices/backlight.py
@@ -18,7 +18,7 @@ class BacklightPosition(str, Enum):
 class Backlight(StandardReadable):
     """Simple device to trigger the pneumatic in/out."""
 
-    TIME_TO_MOVE_S = 1
+    TIME_TO_MOVE_S = 1  # Tested using a stopwatch on the beamline 09/2024
 
     def __init__(self, prefix: str, name: str = "") -> None:
         with self.add_children_as_readables():

--- a/src/dodal/devices/backlight.py
+++ b/src/dodal/devices/backlight.py
@@ -37,7 +37,7 @@ class Backlight(StandardReadable):
         position so it appears to us to instantly move. In fact it does take some time
         to move completely in/out so we sleep here to simulate this.
         """
-        old_position = self.position.get_value()
+        old_position = await self.position.get_value()
         await self.position.set(position)
         if position == BacklightPosition.OUT:
             await self.power.set(BacklightPower.OFF)

--- a/src/dodal/devices/backlight.py
+++ b/src/dodal/devices/backlight.py
@@ -33,7 +33,7 @@ class Backlight(StandardReadable):
         """This setter will turn the backlight on when we move it in to the beam and off
         when we move it out.
 
-        Moving the backlight in/out is a pneumatic axis and we have no redback on it's
+        Moving the backlight in/out is a pneumatic axis and we have no readback on its
         position so it appears to us to instantly move. In fact it does take some time
         to move completely in/out so we sleep here to simulate this.
         """

--- a/src/dodal/devices/backlight.py
+++ b/src/dodal/devices/backlight.py
@@ -1,3 +1,4 @@
+from asyncio import sleep
 from enum import Enum
 
 from ophyd_async.core import AsyncStatus, StandardReadable
@@ -17,6 +18,8 @@ class BacklightPosition(str, Enum):
 class Backlight(StandardReadable):
     """Simple device to trigger the pneumatic in/out."""
 
+    TIME_TO_MOVE_S = 1
+
     def __init__(self, prefix: str, name: str = "") -> None:
         with self.add_children_as_readables():
             self.power = epics_signal_rw(BacklightPower, prefix + "-EA-BLIT-01:TOGGLE")
@@ -28,9 +31,17 @@ class Backlight(StandardReadable):
     @AsyncStatus.wrap
     async def set(self, position: BacklightPosition):
         """This setter will turn the backlight on when we move it in to the beam and off
-        when we move it out."""
+        when we move it out.
+
+        Moving the backlight in/out is a pneumatic axis and we have no redback on it's
+        position so it appears to us to instantly move. In fact it does take some time
+        to move completely in/out so we sleep here to simulate this.
+        """
+        old_position = self.position.get_value()
         await self.position.set(position)
         if position == BacklightPosition.OUT:
             await self.power.set(BacklightPower.OFF)
         else:
             await self.power.set(BacklightPower.ON)
+        if old_position != position:
+            await sleep(self.TIME_TO_MOVE_S)


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/198

### Instructions to reviewer on how to test:
1. Confirm this would make sure we move the backlight out properly

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
