### PR TITLE
Refactor ApertureScatterguard to return individual signals

### DIFF
--- a/src/dodal/beamline_specific_utils/i03.py
+++ b/src/dodal/beamline_specific_utils/i03.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-from dodal.devices.aperturescatterguard import ApertureValue
-
 I03_BEAM_HEIGHT_UM = 20
 
 
@@ -11,6 +9,5 @@ class BeamSize:
     y_um: float | None
 
 
-def beam_size_from_aperture(position: ApertureValue):
-    aperture_size = position.radius
+def beam_size_from_aperture(aperture_size: float | None):
     return BeamSize(aperture_size, I03_BEAM_HEIGHT_UM if aperture_size else None)

--- a/src/dodal/beamline_specific_utils/i03.py
+++ b/src/dodal/beamline_specific_utils/i03.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from dodal.devices.aperturescatterguard import SingleAperturePosition
+from dodal.devices.aperturescatterguard import ApertureValue
 
 I03_BEAM_HEIGHT_UM = 20
 
@@ -11,6 +11,6 @@ class BeamSize:
     y_um: float | None
 
 
-def beam_size_from_aperture(position: SingleAperturePosition):
-    aperture_size = position.radius_microns
+def beam_size_from_aperture(position: ApertureValue):
+    aperture_size = position.radius
     return BeamSize(aperture_size, I03_BEAM_HEIGHT_UM if aperture_size else None)

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -10,8 +10,8 @@ from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beam
 from dodal.common.udc_directory_provider import PandASubdirectoryProvider
 from dodal.devices.aperturescatterguard import (
     ApertureScatterguard,
+    ApertureValue,
     load_positions_from_beamline_parameters,
-    load_tolerances_from_beamline_params,
 )
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
@@ -71,7 +71,7 @@ def aperture_scatterguard(
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
         loaded_positions=load_positions_from_beamline_parameters(params),
-        tolerances=load_tolerances_from_beamline_params(params),
+        tolerances=ApertureValue.tolerances_from_gda_params(params),
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -9,8 +9,8 @@ from dodal.common.beamlines.beamline_utils import (
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.udc_directory_provider import PandASubdirectoryProvider
 from dodal.devices.aperturescatterguard import (
+    AperturePosition,
     ApertureScatterguard,
-    ApertureValue,
     load_positions_from_beamline_parameters,
 )
 from dodal.devices.attenuator import Attenuator
@@ -71,7 +71,7 @@ def aperture_scatterguard(
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
         loaded_positions=load_positions_from_beamline_parameters(params),
-        tolerances=ApertureValue.tolerances_from_gda_params(params),
+        tolerances=AperturePosition.tolerances_from_gda_params(params),
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -3,8 +3,8 @@ from dodal.common.beamlines.beamline_utils import device_instantiation
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.devices.aperturescatterguard import (
     ApertureScatterguard,
+    ApertureValue,
     load_positions_from_beamline_parameters,
-    load_tolerances_from_beamline_params,
 )
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
@@ -236,7 +236,7 @@ def aperture_scatterguard(
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
         loaded_positions=load_positions_from_beamline_parameters(params),
-        tolerances=load_tolerances_from_beamline_params(params),
+        tolerances=ApertureValue.tolerances_from_gda_params(params),
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -2,8 +2,8 @@ from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
 from dodal.common.beamlines.beamline_utils import device_instantiation
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.devices.aperturescatterguard import (
+    AperturePosition,
     ApertureScatterguard,
-    ApertureValue,
     load_positions_from_beamline_parameters,
 )
 from dodal.devices.attenuator import Attenuator
@@ -236,7 +236,7 @@ def aperture_scatterguard(
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
         loaded_positions=load_positions_from_beamline_parameters(params),
-        tolerances=ApertureValue.tolerances_from_gda_params(params),
+        tolerances=AperturePosition.tolerances_from_gda_params(params),
     )
 
 

--- a/src/dodal/common/beamlines/beamline_parameters.py
+++ b/src/dodal/common/beamlines/beamline_parameters.py
@@ -15,6 +15,9 @@ BEAMLINE_PARAMETER_PATHS = {
 class GDABeamlineParameters:
     params: dict[str, Any]
 
+    def __init__(self, params: dict[str, Any]):
+        self.params = params
+
     def __repr__(self) -> str:
         return repr(self.params)
 
@@ -23,7 +26,6 @@ class GDABeamlineParameters:
 
     @classmethod
     def from_lines(cls, file_name: str, config_lines: list[str]):
-        ob = cls()
         config_lines_nocomments = [line.split("#", 1)[0] for line in config_lines]
         config_lines_sep_key_and_value = [
             # XXX removes all whitespace instead of just trim
@@ -46,8 +48,7 @@ class GDABeamlineParameters:
             except Exception as e:
                 LOGGER.warning(f"Unable to parse {file_name} line {i}: {e}")
 
-        ob.params = dict(config_pairs)
-        return ob
+        return cls(params=dict(config_pairs))
 
     @classmethod
     def from_file(cls, path: str):

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -118,6 +118,7 @@ class ApertureScatterguard(StandardReadable, Movable):
             ],
             wrapper=HintedSignal,
         )
+        super().__init__(name)
 
     def get_position_from_gda_aperture_name(
         self, gda_aperture_name: str

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import asyncio
-from collections import namedtuple
-from dataclasses import asdict, dataclass
 from enum import Enum
 
-from bluesky.protocols import Movable, Reading
-from event_model.documents.event_descriptor import DataKey
-from ophyd_async.core import AsyncStatus, HintedSignal, SignalR, StandardReadable
-from ophyd_async.core.soft_signal_backend import SoftConverter, SoftSignalBackend
+from bluesky.protocols import Movable
+from ophyd_async.core import (
+    AsyncStatus,
+    HintedSignal,
+    StandardReadable,
+    soft_signal_rw,
+)
+from pydantic import BaseModel, Field
 
 from dodal.common.beamlines.beamline_parameters import GDABeamlineParameters
 from dodal.devices.aperture import Aperture
@@ -17,100 +21,75 @@ class InvalidApertureMove(Exception):
     pass
 
 
-ApertureFiveDimensionalLocation = namedtuple(
-    "ApertureFiveDimensionalLocation",
-    [
-        "aperture_x",
-        "aperture_y",
-        "aperture_z",
-        "scatterguard_x",
-        "scatterguard_y",
-    ],
-)
+class ApertureValue(BaseModel):
+    aperture_x: float
+    aperture_y: float
+    aperture_z: float
+    scatterguard_x: float
+    scatterguard_y: float
+    radius: float | None = Field(json_schema_extra={"units": "µm"}, default=None)
+
+    def values(self) -> tuple[float, float, float, float, float]:
+        return (
+            self.aperture_x,
+            self.aperture_y,
+            self.aperture_z,
+            self.scatterguard_x,
+            self.scatterguard_y,
+        )
+
+    @staticmethod
+    def tolerances_from_gda_params(
+        params: GDABeamlineParameters,
+    ) -> ApertureValue:
+        return ApertureValue(
+            aperture_x=params["miniap_x_tolerance"],
+            aperture_y=params["miniap_y_tolerance"],
+            aperture_z=params["miniap_z_tolerance"],
+            scatterguard_x=params["sg_x_tolerance"],
+            scatterguard_y=params["sg_y_tolerance"],
+        )
+
+    @staticmethod
+    def position_from_gda_params(
+        name: AperturePosition,
+        radius: float | None,
+        params: GDABeamlineParameters,
+    ) -> ApertureValue:
+        return ApertureValue(
+            aperture_x=params[f"miniap_x_{name.value}"],
+            aperture_y=params[f"miniap_y_{name.value}"],
+            aperture_z=params[f"miniap_z_{name.value}"],
+            scatterguard_x=params[f"sg_x_{name.value}"],
+            scatterguard_y=params[f"sg_y_{name.value}"],
+            radius=radius,
+        )
 
 
-@dataclass
-class ApertureScatterguardTolerances:
-    ap_x: float
-    ap_y: float
-    ap_z: float
-    sg_x: float
-    sg_y: float
+class AperturePosition(str, Enum):
+    """Maps from a short usable name to the value name in the GDA Beamline parameters"""
 
-
-@dataclass
-class SingleAperturePosition:
-    name: str
-    GDA_name: str
-    radius_microns: float | None
-    location: ApertureFiveDimensionalLocation
-
-
-# Use StrEnum once we stop python 3.10 support
-class AperturePositionGDANames(str, Enum):
-    LARGE_APERTURE = "LARGE_APERTURE"
-    MEDIUM_APERTURE = "MEDIUM_APERTURE"
-    SMALL_APERTURE = "SMALL_APERTURE"
     ROBOT_LOAD = "ROBOT_LOAD"
-
-    def __str__(self):
-        return str(self.value)
-
-
-def position_from_params(
-    name: str,
-    GDA_name: AperturePositionGDANames,
-    radius_microns: float | None,
-    params: GDABeamlineParameters,
-) -> SingleAperturePosition:
-    return SingleAperturePosition(
-        name,
-        GDA_name,
-        radius_microns,
-        ApertureFiveDimensionalLocation(
-            params[f"miniap_x_{GDA_name}"],
-            params[f"miniap_y_{GDA_name}"],
-            params[f"miniap_z_{GDA_name}"],
-            params[f"sg_x_{GDA_name}"],
-            params[f"sg_y_{GDA_name}"],
-        ),
-    )
-
-
-def load_tolerances_from_beamline_params(
-    params: GDABeamlineParameters,
-) -> ApertureScatterguardTolerances:
-    return ApertureScatterguardTolerances(
-        ap_x=params["miniap_x_tolerance"],
-        ap_y=params["miniap_y_tolerance"],
-        ap_z=params["miniap_z_tolerance"],
-        sg_x=params["sg_x_tolerance"],
-        sg_y=params["sg_y_tolerance"],
-    )
-
-
-class AperturePosition(Enum):
-    ROBOT_LOAD = 0
-    SMALL = 1
-    MEDIUM = 2
-    LARGE = 3
+    SMALL = "SMALL_APERTURE"
+    MEDIUM = "MEDIUM_APERTURE"
+    LARGE = "LARGE_APERTURE"
 
 
 def load_positions_from_beamline_parameters(
     params: GDABeamlineParameters,
-) -> dict[AperturePosition, SingleAperturePosition]:
+) -> dict[AperturePosition, ApertureValue]:
     return {
-        AperturePosition.ROBOT_LOAD: position_from_params(
-            "Robot load", AperturePositionGDANames.ROBOT_LOAD, None, params
+        AperturePosition.ROBOT_LOAD: ApertureValue.position_from_gda_params(
+            AperturePosition.ROBOT_LOAD, None, params
         ),
-        AperturePosition.SMALL: position_from_params(
-            "Small", AperturePositionGDANames.SMALL_APERTURE, 20, params
+        AperturePosition.SMALL: ApertureValue.position_from_gda_params(
+            AperturePosition.SMALL, 20, params
         ),
-        AperturePosition.MEDIUM: position_from_params(
-            "Medium", AperturePositionGDANames.MEDIUM_APERTURE, 50, params
+        AperturePosition.MEDIUM: ApertureValue.position_from_gda_params(
+            AperturePosition.MEDIUM, 50, params
         ),
-        AperturePosition.LARGE: position_from_params(
-            "Large", AperturePositionGDANames.LARGE_APERTURE, 100, params
+        AperturePosition.LARGE: ApertureValue.position_from_gda_params(
+            AperturePosition.LARGE, 100, params
         ),
     }
 
@@ -118,120 +97,78 @@ def load_positions_from_beamline_parameters(
 class ApertureScatterguard(StandardReadable, Movable):
     def __init__(
         self,
-        loaded_positions: dict[AperturePosition, SingleAperturePosition],
-        tolerances: ApertureScatterguardTolerances,
+        loaded_positions: dict[AperturePosition, ApertureValue],
+        tolerances: ApertureValue,
         prefix: str = "",
         name: str = "",
     ) -> None:
-        self._aperture = Aperture(prefix + "-MO-MAPT-01:")
-        self._scatterguard = Scatterguard(prefix + "-MO-SCAT-01:")
+        self.aperture = Aperture(prefix + "-MO-MAPT-01:")
+        self.scatterguard = Scatterguard(prefix + "-MO-SCAT-01:")
+        self.radius = soft_signal_rw(float, units="µm")
         self._loaded_positions = loaded_positions
         self._tolerances = tolerances
-        aperture_backend = SoftSignalBackend(
-            SingleAperturePosition, self._loaded_positions[AperturePosition.ROBOT_LOAD]
+        self.add_readables(
+            [
+                self.aperture.x.user_readback,
+                self.aperture.y.user_readback,
+                self.aperture.z.user_readback,
+                self.scatterguard.x.user_readback,
+                self.scatterguard.y.user_readback,
+                self.radius,
+            ],
+            wrapper=HintedSignal,
         )
-        aperture_backend.converter = self.ApertureConverter()
-        self.selected_aperture = self.SelectedAperture(backend=aperture_backend)
-        self.add_readables([self.selected_aperture], wrapper=HintedSignal)
-        super().__init__(name)
-
-    class ApertureConverter(SoftConverter):
-        # Ophyd-async #311 should add a default converter for dataclasses to do this
-        def reading(
-            self, value: SingleAperturePosition, timestamp: float, severity: int
-        ) -> Reading:
-            return Reading(
-                value=asdict(value),
-                timestamp=timestamp,
-                alarm_severity=-1 if severity > 2 else severity,
-            )
-
-    class SelectedAperture(SignalR):
-        async def read(self, *args, **kwargs):
-            assert isinstance(self.parent, ApertureScatterguard)
-            assert self._backend
-            await self._backend.put(await self.parent.get_current_aperture_position())
-            return {self.name: await self._backend.get_reading()}
-
-        async def describe(self) -> dict[str, DataKey]:
-            return {
-                self._name: DataKey(
-                    dtype="array",
-                    shape=[
-                        -1,
-                    ],  # TODO describe properly - see https://github.com/DiamondLightSource/dodal/issues/253,
-                    source=self._backend.source(self._name),  # type: ignore
-                )
-            }
 
     def get_position_from_gda_aperture_name(
-        self, gda_aperture_name: AperturePositionGDANames
+        self, gda_aperture_name: str
     ) -> AperturePosition:
-        for aperture, detail in self._loaded_positions.items():
-            if detail.GDA_name == gda_aperture_name:
-                return aperture
-        raise ValueError(
-            f"Tried to convert unknown aperture name {gda_aperture_name} to a SingleAperturePosition"
-        )
-
-    def get_gda_name_for_position(self, position: AperturePosition) -> str:
-        detailed_position = self._loaded_positions[position]
-        return detailed_position.GDA_name
+        return AperturePosition(gda_aperture_name)
 
     @AsyncStatus.wrap
     async def set(self, value: AperturePosition):
         position = self._loaded_positions[value]
-        await self._safe_move_within_datacollection_range(position.location)
-
-    def _get_motor_list(self):
-        return [
-            self._aperture.x,
-            self._aperture.y,
-            self._aperture.z,
-            self._scatterguard.x,
-            self._scatterguard.y,
-        ]
+        await self._safe_move_within_datacollection_range(position)
 
     @AsyncStatus.wrap
-    async def _set_raw_unsafe(self, positions: ApertureFiveDimensionalLocation):
+    async def _set_raw_unsafe(self, positions: ApertureValue):
         """Accept the risks and move in an unsafe way. Collisions possible."""
+        if positions.radius is not None:
+            await self.radius.set(positions.radius)
 
         # unpacking the position
-        aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = positions
-
-        await asyncio.gather(
-            self._aperture.x.set(aperture_x),
-            self._aperture.y.set(aperture_y),
-            self._aperture.z.set(aperture_z),
-            self._scatterguard.x.set(scatterguard_x),
-            self._scatterguard.y.set(scatterguard_y),
+        aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = (
+            positions.values()
         )
 
-    async def get_current_aperture_position(self) -> SingleAperturePosition:
+        await asyncio.gather(
+            self.aperture.x.set(aperture_x),
+            self.aperture.y.set(aperture_y),
+            self.aperture.z.set(aperture_z),
+            self.scatterguard.x.set(scatterguard_x),
+            self.scatterguard.y.set(scatterguard_y),
+        )
+
+    async def get_current_aperture_position(self) -> ApertureValue:
         """
         Returns the current aperture position using readback values
         for SMALL, MEDIUM, LARGE. ROBOT_LOAD position defined when
         mini aperture y <= ROBOT_LOAD.location.aperture_y + tolerance.
         If no position is found then raises InvalidApertureMove.
         """
-        current_ap_y = await self._aperture.y.user_readback.get_value(cached=False)
-        robot_load_ap_y = self._loaded_positions[
-            AperturePosition.ROBOT_LOAD
-        ].location.aperture_y
-        if await self._aperture.large.get_value(cached=False) == 1:
+        current_ap_y = await self.aperture.y.user_readback.get_value(cached=False)
+        robot_load_ap_y = self._loaded_positions[AperturePosition.ROBOT_LOAD].aperture_y
+        if await self.aperture.large.get_value(cached=False) == 1:
             return self._loaded_positions[AperturePosition.LARGE]
-        elif await self._aperture.medium.get_value(cached=False) == 1:
+        elif await self.aperture.medium.get_value(cached=False) == 1:
             return self._loaded_positions[AperturePosition.MEDIUM]
-        elif await self._aperture.small.get_value(cached=False) == 1:
+        elif await self.aperture.small.get_value(cached=False) == 1:
             return self._loaded_positions[AperturePosition.SMALL]
-        elif current_ap_y <= robot_load_ap_y + self._tolerances.ap_y:
+        elif current_ap_y <= robot_load_ap_y + self._tolerances.aperture_y:
             return self._loaded_positions[AperturePosition.ROBOT_LOAD]
 
         raise InvalidApertureMove("Current aperture/scatterguard state unrecognised")
 
-    async def _safe_move_within_datacollection_range(
-        self, pos: ApertureFiveDimensionalLocation
-    ):
+    async def _safe_move_within_datacollection_range(self, position: ApertureValue):
         """
         Move the aperture and scatterguard combo safely to a new position.
         See https://github.com/DiamondLightSource/hyperion/wiki/Aperture-Scatterguard-Collisions
@@ -239,44 +176,48 @@ class ApertureScatterguard(StandardReadable, Movable):
         """
         assert self._loaded_positions is not None
         # unpacking the position
-        aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = pos
+        aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = (
+            position.values()
+        )
 
-        ap_z_in_position = await self._aperture.z.motor_done_move.get_value()
+        ap_z_in_position = await self.aperture.z.motor_done_move.get_value()
         if not ap_z_in_position:
             raise InvalidApertureMove(
                 "ApertureScatterguard z is still moving. Wait for it to finish "
                 "before triggering another move."
             )
 
-        current_ap_z = await self._aperture.z.user_readback.get_value()
+        current_ap_z = await self.aperture.z.user_readback.get_value()
         diff_on_z = abs(current_ap_z - aperture_z)
-        if diff_on_z > self._tolerances.ap_z:
+        if diff_on_z > self._tolerances.aperture_z:
             raise InvalidApertureMove(
                 "ApertureScatterguard safe move is not yet defined for positions "
                 "outside of LARGE, MEDIUM, SMALL, ROBOT_LOAD. "
-                f"Current aperture z ({current_ap_z}), outside of tolerance ({self._tolerances.ap_z}) from target ({aperture_z})."
+                f"Current aperture z ({current_ap_z}), outside of tolerance ({self._tolerances.aperture_z}) from target ({aperture_z})."
             )
 
-        current_ap_y = await self._aperture.y.user_readback.get_value()
+        current_ap_y = await self.aperture.y.user_readback.get_value()
+        if position.radius is not None:
+            await self.radius.set(position.radius)
 
         if aperture_y > current_ap_y:
             await asyncio.gather(
-                self._scatterguard.x.set(scatterguard_x),
-                self._scatterguard.y.set(scatterguard_y),
+                self.scatterguard.x.set(scatterguard_x),
+                self.scatterguard.y.set(scatterguard_y),
             )
             await asyncio.gather(
-                self._aperture.x.set(aperture_x),
-                self._aperture.y.set(aperture_y),
-                self._aperture.z.set(aperture_z),
+                self.aperture.x.set(aperture_x),
+                self.aperture.y.set(aperture_y),
+                self.aperture.z.set(aperture_z),
             )
             return
         await asyncio.gather(
-            self._aperture.x.set(aperture_x),
-            self._aperture.y.set(aperture_y),
-            self._aperture.z.set(aperture_z),
+            self.aperture.x.set(aperture_x),
+            self.aperture.y.set(aperture_y),
+            self.aperture.z.set(aperture_z),
         )
 
         await asyncio.gather(
-            self._scatterguard.x.set(scatterguard_x),
-            self._scatterguard.y.set(scatterguard_y),
+            self.scatterguard.x.set(scatterguard_x),
+            self.scatterguard.y.set(scatterguard_y),
         )

--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -116,8 +116,10 @@ class ApertureScatterguard(StandardReadable, Movable):
                 self.scatterguard.y.user_readback,
                 self.radius,
             ],
-            wrapper=HintedSignal,
         )
+        with self.add_children_as_readables(HintedSignal):
+            self.selected_aperture = soft_signal_rw(AperturePosition)
+
         super().__init__(name)
 
     def get_position_from_gda_aperture_name(
@@ -126,30 +128,30 @@ class ApertureScatterguard(StandardReadable, Movable):
         return AperturePosition(gda_aperture_name)
 
     @AsyncStatus.wrap
-    async def set(self, value: AperturePosition):
-        position = self._loaded_positions[value]
-        await self._safe_move_within_datacollection_range(position)
+    async def set(self, position: AperturePosition):
+        value = self._loaded_positions[position]
+        await self._safe_move_within_datacollection_range(value, position)
 
     @AsyncStatus.wrap
-    async def _set_raw_unsafe(self, positions: ApertureValue):
+    async def _set_raw_unsafe(self, value: ApertureValue):
         """Accept the risks and move in an unsafe way. Collisions possible."""
-        if positions.radius is not None:
-            await self.radius.set(positions.radius)
-
-        # unpacking the position
-        aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = (
-            positions.values()
-        )
+        if value.radius is not None:
+            await self.radius.set(value.radius)
 
         await asyncio.gather(
-            self.aperture.x.set(aperture_x),
-            self.aperture.y.set(aperture_y),
-            self.aperture.z.set(aperture_z),
-            self.scatterguard.x.set(scatterguard_x),
-            self.scatterguard.y.set(scatterguard_y),
+            self.aperture.x.set(value.aperture_x),
+            self.aperture.y.set(value.aperture_y),
+            self.aperture.z.set(value.aperture_z),
+            self.scatterguard.x.set(value.scatterguard_x),
+            self.scatterguard.y.set(value.scatterguard_y),
         )
+        try:
+            position = await self.get_current_aperture_position()
+            self.selected_aperture.set(position)
+        except InvalidApertureMove:
+            self.selected_aperture.set(None)  # type: ignore
 
-    async def get_current_aperture_position(self) -> ApertureValue:
+    async def get_current_aperture_position(self) -> AperturePosition:
         """
         Returns the current aperture position using readback values
         for SMALL, MEDIUM, LARGE. ROBOT_LOAD position defined when
@@ -159,27 +161,25 @@ class ApertureScatterguard(StandardReadable, Movable):
         current_ap_y = await self.aperture.y.user_readback.get_value(cached=False)
         robot_load_ap_y = self._loaded_positions[AperturePosition.ROBOT_LOAD].aperture_y
         if await self.aperture.large.get_value(cached=False) == 1:
-            return self._loaded_positions[AperturePosition.LARGE]
+            return AperturePosition.LARGE
         elif await self.aperture.medium.get_value(cached=False) == 1:
-            return self._loaded_positions[AperturePosition.MEDIUM]
+            return AperturePosition.MEDIUM
         elif await self.aperture.small.get_value(cached=False) == 1:
-            return self._loaded_positions[AperturePosition.SMALL]
+            return AperturePosition.SMALL
         elif current_ap_y <= robot_load_ap_y + self._tolerances.aperture_y:
-            return self._loaded_positions[AperturePosition.ROBOT_LOAD]
+            return AperturePosition.ROBOT_LOAD
 
         raise InvalidApertureMove("Current aperture/scatterguard state unrecognised")
 
-    async def _safe_move_within_datacollection_range(self, position: ApertureValue):
+    async def _safe_move_within_datacollection_range(
+        self, value: ApertureValue, position: AperturePosition
+    ):
         """
         Move the aperture and scatterguard combo safely to a new position.
         See https://github.com/DiamondLightSource/hyperion/wiki/Aperture-Scatterguard-Collisions
         for why this is required.
         """
         assert self._loaded_positions is not None
-        # unpacking the position
-        aperture_x, aperture_y, aperture_z, scatterguard_x, scatterguard_y = (
-            position.values()
-        )
 
         ap_z_in_position = await self.aperture.z.motor_done_move.get_value()
         if not ap_z_in_position:
@@ -189,36 +189,37 @@ class ApertureScatterguard(StandardReadable, Movable):
             )
 
         current_ap_z = await self.aperture.z.user_readback.get_value()
-        diff_on_z = abs(current_ap_z - aperture_z)
+        diff_on_z = abs(current_ap_z - value.aperture_z)
         if diff_on_z > self._tolerances.aperture_z:
             raise InvalidApertureMove(
                 "ApertureScatterguard safe move is not yet defined for positions "
                 "outside of LARGE, MEDIUM, SMALL, ROBOT_LOAD. "
-                f"Current aperture z ({current_ap_z}), outside of tolerance ({self._tolerances.aperture_z}) from target ({aperture_z})."
+                f"Current aperture z ({current_ap_z}), outside of tolerance ({self._tolerances.aperture_z}) from target ({value.aperture_z})."
             )
 
         current_ap_y = await self.aperture.y.user_readback.get_value()
-        if position.radius is not None:
-            await self.radius.set(position.radius)
+        if value.radius is not None:
+            await self.radius.set(value.radius)
 
-        if aperture_y > current_ap_y:
+        if value.aperture_y > current_ap_y:
             await asyncio.gather(
-                self.scatterguard.x.set(scatterguard_x),
-                self.scatterguard.y.set(scatterguard_y),
+                self.scatterguard.x.set(value.scatterguard_x),
+                self.scatterguard.y.set(value.scatterguard_y),
             )
             await asyncio.gather(
-                self.aperture.x.set(aperture_x),
-                self.aperture.y.set(aperture_y),
-                self.aperture.z.set(aperture_z),
+                self.aperture.x.set(value.aperture_x),
+                self.aperture.y.set(value.aperture_y),
+                self.aperture.z.set(value.aperture_z),
             )
             return
         await asyncio.gather(
-            self.aperture.x.set(aperture_x),
-            self.aperture.y.set(aperture_y),
-            self.aperture.z.set(aperture_z),
+            self.aperture.x.set(value.aperture_x),
+            self.aperture.y.set(value.aperture_y),
+            self.aperture.z.set(value.aperture_z),
         )
 
         await asyncio.gather(
-            self.scatterguard.x.set(scatterguard_x),
-            self.scatterguard.y.set(scatterguard_y),
+            self.scatterguard.x.set(value.scatterguard_x),
+            self.scatterguard.y.set(value.scatterguard_y),
         )
+        await self.selected_aperture.set(position)

--- a/tests/devices/system_tests/test_aperturescatterguard_system.py
+++ b/tests/devices/system_tests/test_aperturescatterguard_system.py
@@ -26,7 +26,7 @@ BEAMLINE_PARAMETER_KEYWORDS = ["FB", "FULL", "deadtime"]
 async def ap_sg():
     params = GDABeamlineParameters.from_file(I03_BEAMLINE_PARAMETER_PATH)
     positions = load_positions_from_beamline_parameters(params)
-    tolerances = ApertureValue.tolerances_from_gda_params(params)
+    tolerances = AperturePosition.tolerances_from_gda_params(params)
 
     async with DeviceCollector():
         ap_sg = ApertureScatterguard(
@@ -41,25 +41,25 @@ async def ap_sg():
 @pytest.fixture
 def move_to_large(ap_sg: ApertureScatterguard):
     assert ap_sg._loaded_positions is not None
-    yield from bps.abs_set(ap_sg, AperturePosition.LARGE)
+    yield from bps.abs_set(ap_sg, ApertureValue.LARGE)
 
 
 @pytest.fixture
 def move_to_medium(ap_sg: ApertureScatterguard):
     assert ap_sg._loaded_positions is not None
-    yield from bps.abs_set(ap_sg, AperturePosition.MEDIUM)
+    yield from bps.abs_set(ap_sg, ApertureValue.MEDIUM)
 
 
 @pytest.fixture
 def move_to_small(ap_sg: ApertureScatterguard):
     assert ap_sg._loaded_positions is not None
-    yield from bps.abs_set(ap_sg, AperturePosition.SMALL)
+    yield from bps.abs_set(ap_sg, ApertureValue.SMALL)
 
 
 @pytest.fixture
 def move_to_robotload(ap_sg: ApertureScatterguard):
     assert ap_sg._loaded_positions is not None
-    yield from bps.abs_set(ap_sg, AperturePosition.ROBOT_LOAD)
+    yield from bps.abs_set(ap_sg, ApertureValue.ROBOT_LOAD)
 
 
 @pytest.mark.s03
@@ -77,7 +77,7 @@ async def test_aperturescatterguard_move_in_plan(
     RE,
 ):
     assert ap_sg._loaded_positions is not None
-    large = ap_sg._loaded_positions[AperturePosition.LARGE]
+    large = ap_sg._loaded_positions[ApertureValue.LARGE]
 
     await ap_sg.aperture.z.set(large.aperture_z)
 
@@ -138,10 +138,10 @@ async def test_aperturescatterguard_moves_in_correct_order(
     cb = MonitorCallback()
     assert ap_sg._loaded_positions
     positions = {
-        "L": ap_sg._loaded_positions[AperturePosition.LARGE],
-        "M": ap_sg._loaded_positions[AperturePosition.MEDIUM],
-        "S": ap_sg._loaded_positions[AperturePosition.SMALL],
-        "R": ap_sg._loaded_positions[AperturePosition.ROBOT_LOAD],
+        "L": ap_sg._loaded_positions[ApertureValue.LARGE],
+        "M": ap_sg._loaded_positions[ApertureValue.MEDIUM],
+        "S": ap_sg._loaded_positions[ApertureValue.SMALL],
+        "R": ap_sg._loaded_positions[ApertureValue.ROBOT_LOAD],
     }
     pos1 = positions[pos_name_1]
     pos2 = positions[pos_name_2]

--- a/tests/devices/system_tests/test_aperturescatterguard_system.py
+++ b/tests/devices/system_tests/test_aperturescatterguard_system.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any, cast
-
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.callbacks import CallbackBase
@@ -9,12 +7,13 @@ from bluesky.run_engine import RunEngine
 from event_model import Event
 from ophyd_async.core import DeviceCollector
 
+from dodal.common.beamlines.beamline_parameters import GDABeamlineParameters
 from dodal.devices.aperturescatterguard import (
     AperturePosition,
     ApertureScatterguard,
+    ApertureValue,
     InvalidApertureMove,
     load_positions_from_beamline_parameters,
-    load_tolerances_from_beamline_params,
 )
 
 I03_BEAMLINE_PARAMETER_PATH = (
@@ -23,48 +22,11 @@ I03_BEAMLINE_PARAMETER_PATH = (
 BEAMLINE_PARAMETER_KEYWORDS = ["FB", "FULL", "deadtime"]
 
 
-class GDABeamlineParameters:
-    params: dict[str, Any]
-
-    def __repr__(self) -> str:
-        return repr(self.params)
-
-    def __getitem__(self, item: str):
-        return self.params[item]
-
-    @classmethod
-    def from_file(cls, path: str):
-        ob = cls()
-        with open(path) as f:
-            config_lines = f.readlines()
-        config_lines_nocomments = [line.split("#", 1)[0] for line in config_lines]
-        config_lines_sep_key_and_value = [
-            line.translate(str.maketrans("", "", " \n\t\r")).split("=")
-            for line in config_lines_nocomments
-        ]
-        config_pairs: list[tuple[str, Any]] = [
-            cast(tuple[str, Any], param)
-            for param in config_lines_sep_key_and_value
-            if len(param) == 2
-        ]
-        for i, (_, value) in enumerate(config_pairs):
-            if value == "Yes":
-                config_pairs[i] = (config_pairs[i][0], True)
-            elif value == "No":
-                config_pairs[i] = (config_pairs[i][0], False)
-            elif value in BEAMLINE_PARAMETER_KEYWORDS:
-                pass
-            else:
-                config_pairs[i] = (config_pairs[i][0], float(config_pairs[i][1]))
-        ob.params = dict(config_pairs)
-        return ob
-
-
 @pytest.fixture
 async def ap_sg():
     params = GDABeamlineParameters.from_file(I03_BEAMLINE_PARAMETER_PATH)
-    positions = load_positions_from_beamline_parameters(params)  # type:ignore
-    tolerances = load_tolerances_from_beamline_params(params)  # type:ignore
+    positions = load_positions_from_beamline_parameters(params)
+    tolerances = ApertureValue.tolerances_from_gda_params(params)
 
     async with DeviceCollector():
         ap_sg = ApertureScatterguard(
@@ -117,7 +79,7 @@ async def test_aperturescatterguard_move_in_plan(
     assert ap_sg._loaded_positions is not None
     large = ap_sg._loaded_positions[AperturePosition.LARGE]
 
-    await ap_sg._aperture.z.set(large.location[2])
+    await ap_sg.aperture.z.set(large.aperture_z)
 
     RE(move_to_large)
     RE(move_to_medium)
@@ -129,7 +91,7 @@ async def test_aperturescatterguard_move_in_plan(
 async def test_move_fails_when_not_in_good_starting_pos(
     ap_sg: ApertureScatterguard, move_to_large, RE
 ):
-    await ap_sg._aperture.z.set(0)
+    await ap_sg.aperture.z.set(0)
 
     with pytest.raises(InvalidApertureMove):
         RE(move_to_large)
@@ -186,12 +148,12 @@ async def test_aperturescatterguard_moves_in_correct_order(
     RE = RunEngine({})
     RE.subscribe(cb)
 
-    await ap_sg._aperture.z.set(pos1.location[2])
+    await ap_sg.aperture.z.set(pos1.aperture_z)
 
     def monitor_and_moves():
         yield from bps.open_run()
-        yield from bps.monitor(ap_sg._aperture.y.motor_done_move, name="ap_y")
-        yield from bps.monitor(ap_sg._scatterguard.y.motor_done_move, name="sg_y")
+        yield from bps.monitor(ap_sg.aperture.y.motor_done_move, name="ap_y")
+        yield from bps.monitor(ap_sg.scatterguard.y.motor_done_move, name="sg_y")
         yield from bps.mv(ap_sg, pos1)
         yield from bps.mv(ap_sg, pos2)
         yield from bps.close_run()

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -208,14 +208,14 @@ async def test_aperture_scatterguard_throws_error_if_outside_tolerance(
     set_mock_value(ap_sg.aperture.z.motor_done_move, 1)
 
     with pytest.raises(InvalidApertureMove):
-        pos = ApertureValue(
+        val = ApertureValue(
             aperture_x=0,
             aperture_y=0,
             aperture_z=1.1,
             scatterguard_x=0,
             scatterguard_y=0,
         )
-        await ap_sg._safe_move_within_datacollection_range(pos)
+        await ap_sg._safe_move_within_datacollection_range(val, AperturePosition.LARGE)
 
 
 async def test_aperture_scatterguard_returns_status_if_within_tolerance(
@@ -225,10 +225,10 @@ async def test_aperture_scatterguard_returns_status_if_within_tolerance(
     set_mock_value(ap_sg.aperture.z.user_readback, 1)
     set_mock_value(ap_sg.aperture.z.motor_done_move, 1)
 
-    pos = ApertureValue(
+    val = ApertureValue(
         aperture_x=0, aperture_y=0, aperture_z=1, scatterguard_x=0, scatterguard_y=0
     )
-    await ap_sg._safe_move_within_datacollection_range(pos)
+    await ap_sg._safe_move_within_datacollection_range(val, AperturePosition.LARGE)
 
 
 def set_underlying_motors(ap_sg: ApertureScatterguard, position: ApertureValue):
@@ -240,34 +240,19 @@ def set_underlying_motors(ap_sg: ApertureScatterguard, position: ApertureValue):
         motor.set(pos)
 
 
-async def test_aperture_positions_large(
-    ap_sg: ApertureScatterguard, aperture_positions
-):
+async def test_aperture_positions_large(ap_sg: ApertureScatterguard):
     set_mock_value(ap_sg.aperture.large, 1)
-    assert (
-        await ap_sg.get_current_aperture_position()
-        == aperture_positions[AperturePosition.LARGE]
-    )
+    assert await ap_sg.get_current_aperture_position() == AperturePosition.LARGE
 
 
-async def test_aperture_positions_medium(
-    ap_sg: ApertureScatterguard, aperture_positions
-):
+async def test_aperture_positions_medium(ap_sg: ApertureScatterguard):
     set_mock_value(ap_sg.aperture.medium, 1)
-    assert (
-        await ap_sg.get_current_aperture_position()
-        == aperture_positions[AperturePosition.MEDIUM]
-    )
+    assert await ap_sg.get_current_aperture_position() == AperturePosition.MEDIUM
 
 
-async def test_aperture_positions_small(
-    ap_sg: ApertureScatterguard, aperture_positions
-):
+async def test_aperture_positions_small(ap_sg: ApertureScatterguard):
     set_mock_value(ap_sg.aperture.small, 1)
-    assert (
-        await ap_sg.get_current_aperture_position()
-        == aperture_positions[AperturePosition.SMALL]
-    )
+    assert await ap_sg.get_current_aperture_position() == AperturePosition.SMALL
 
 
 async def test_aperture_positions_robot_load(
@@ -279,7 +264,7 @@ async def test_aperture_positions_robot_load(
     set_mock_value(ap_sg.aperture.small, 0)
     robot_load = aperture_positions[AperturePosition.ROBOT_LOAD]
     await ap_sg.aperture.y.set(robot_load.aperture_y)
-    assert await ap_sg.get_current_aperture_position() == robot_load
+    assert await ap_sg.get_current_aperture_position() == AperturePosition.ROBOT_LOAD
 
 
 async def test_aperture_positions_robot_load_within_tolerance(
@@ -293,7 +278,7 @@ async def test_aperture_positions_robot_load_within_tolerance(
     set_mock_value(ap_sg.aperture.medium, 0)
     set_mock_value(ap_sg.aperture.small, 0)
     await ap_sg.aperture.y.set(robot_load_ap_y + tolerance)
-    assert await ap_sg.get_current_aperture_position() == robot_load
+    assert await ap_sg.get_current_aperture_position() == AperturePosition.ROBOT_LOAD
 
 
 async def test_aperture_positions_robot_load_outside_tolerance(

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from contextlib import ExitStack
-from dataclasses import asdict
+from typing import Any
 from unittest.mock import ANY, MagicMock, call
 
 import bluesky.plan_stubs as bps
@@ -12,16 +12,13 @@ from ophyd_async.core import (
     set_mock_value,
 )
 
+from dodal.common.beamlines.beamline_parameters import GDABeamlineParameters
 from dodal.devices.aperturescatterguard import (
-    ApertureFiveDimensionalLocation,
     AperturePosition,
-    AperturePositionGDANames,
     ApertureScatterguard,
-    ApertureScatterguardTolerances,
+    ApertureValue,
     InvalidApertureMove,
-    SingleAperturePosition,
     load_positions_from_beamline_parameters,
-    load_tolerances_from_beamline_params,
 )
 from dodal.devices.util.test_utils import patch_motor
 
@@ -29,61 +26,65 @@ ApSgAndLog = tuple[ApertureScatterguard, MagicMock]
 
 
 @pytest.fixture
-def aperture_positions() -> dict[AperturePosition, SingleAperturePosition]:
+def aperture_positions() -> dict[AperturePosition, ApertureValue]:
     return load_positions_from_beamline_parameters(
-        {
-            "miniap_x_LARGE_APERTURE": 2.389,
-            "miniap_y_LARGE_APERTURE": 40.986,
-            "miniap_z_LARGE_APERTURE": 15.8,
-            "sg_x_LARGE_APERTURE": 5.25,
-            "sg_y_LARGE_APERTURE": 4.43,
-            "miniap_x_MEDIUM_APERTURE": 2.384,
-            "miniap_y_MEDIUM_APERTURE": 44.967,
-            "miniap_z_MEDIUM_APERTURE": 15.8,
-            "sg_x_MEDIUM_APERTURE": 5.285,
-            "sg_y_MEDIUM_APERTURE": 0.46,
-            "miniap_x_SMALL_APERTURE": 2.430,
-            "miniap_y_SMALL_APERTURE": 48.974,
-            "miniap_z_SMALL_APERTURE": 15.8,
-            "sg_x_SMALL_APERTURE": 5.3375,
-            "sg_y_SMALL_APERTURE": -3.55,
-            "miniap_x_ROBOT_LOAD": 2.386,
-            "miniap_y_ROBOT_LOAD": 31.40,
-            "miniap_z_ROBOT_LOAD": 15.8,
-            "sg_x_ROBOT_LOAD": 5.25,
-            "sg_y_ROBOT_LOAD": 4.43,
-        }  # type:ignore
+        GDABeamlineParameters(
+            params={
+                "miniap_x_LARGE_APERTURE": 2.389,
+                "miniap_y_LARGE_APERTURE": 40.986,
+                "miniap_z_LARGE_APERTURE": 15.8,
+                "sg_x_LARGE_APERTURE": 5.25,
+                "sg_y_LARGE_APERTURE": 4.43,
+                "miniap_x_MEDIUM_APERTURE": 2.384,
+                "miniap_y_MEDIUM_APERTURE": 44.967,
+                "miniap_z_MEDIUM_APERTURE": 15.8,
+                "sg_x_MEDIUM_APERTURE": 5.285,
+                "sg_y_MEDIUM_APERTURE": 0.46,
+                "miniap_x_SMALL_APERTURE": 2.430,
+                "miniap_y_SMALL_APERTURE": 48.974,
+                "miniap_z_SMALL_APERTURE": 15.8,
+                "sg_x_SMALL_APERTURE": 5.3375,
+                "sg_y_SMALL_APERTURE": -3.55,
+                "miniap_x_ROBOT_LOAD": 2.386,
+                "miniap_y_ROBOT_LOAD": 31.40,
+                "miniap_z_ROBOT_LOAD": 15.8,
+                "sg_x_ROBOT_LOAD": 5.25,
+                "sg_y_ROBOT_LOAD": 4.43,
+            }
+        )
     )
 
 
 @pytest.fixture
 def aperture_tolerances():
-    return load_tolerances_from_beamline_params(
-        {
-            "miniap_x_tolerance": 0.004,
-            "miniap_y_tolerance": 0.1,
-            "miniap_z_tolerance": 0.1,
-            "sg_x_tolerance": 0.1,
-            "sg_y_tolerance": 0.1,
-        }  # type:ignore
+    return ApertureValue.tolerances_from_gda_params(
+        GDABeamlineParameters(
+            {
+                "miniap_x_tolerance": 0.004,
+                "miniap_y_tolerance": 0.1,
+                "miniap_z_tolerance": 0.1,
+                "sg_x_tolerance": 0.1,
+                "sg_y_tolerance": 0.1,
+            }
+        )
     )
 
 
 def get_all_motors(ap_sg: ApertureScatterguard):
     return [
-        ap_sg._aperture.x,
-        ap_sg._aperture.y,
-        ap_sg._aperture.z,
-        ap_sg._scatterguard.x,
-        ap_sg._scatterguard.y,
+        ap_sg.aperture.x,
+        ap_sg.aperture.y,
+        ap_sg.aperture.z,
+        ap_sg.scatterguard.x,
+        ap_sg.scatterguard.y,
     ]
 
 
 @pytest.fixture
 async def ap_sg_and_call_log(
     RE: RunEngine,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
-    aperture_tolerances: ApertureScatterguardTolerances,
+    aperture_positions: dict[AperturePosition, ApertureValue],
+    aperture_tolerances: ApertureValue,
 ):
     call_log = MagicMock()
     async with DeviceCollector(mock=True):
@@ -108,12 +109,12 @@ async def ap_sg(ap_sg_and_call_log: ApSgAndLog):
 @pytest.fixture
 async def aperture_in_medium_pos_w_call_log(
     ap_sg_and_call_log: ApSgAndLog,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_positions: dict[AperturePosition, ApertureValue],
 ):
     ap_sg, call_log = ap_sg_and_call_log
-    await ap_sg._set_raw_unsafe(aperture_positions[AperturePosition.MEDIUM].location)
+    await ap_sg._set_raw_unsafe(aperture_positions[AperturePosition.MEDIUM])
 
-    set_mock_value(ap_sg._aperture.medium, 1)
+    set_mock_value(ap_sg.aperture.medium, 1)
     yield ap_sg, call_log
 
 
@@ -125,18 +126,28 @@ async def aperture_in_medium_pos(aperture_in_medium_pos_w_call_log: ApSgAndLog):
 
 def _assert_patched_ap_sg_has_call(
     ap_sg: ApertureScatterguard,
-    position: (
-        ApertureFiveDimensionalLocation | tuple[float, float, float, float, float]
-    ),
+    position: ApertureValue,
 ):
     for motor, pos in zip(
         get_all_motors(ap_sg),
-        position,
+        position.values(),
         strict=False,
     ):
         get_mock_put(motor.user_setpoint).assert_called_with(
             pos, wait=True, timeout=ANY
         )
+
+
+def _assert_value_in_reading(
+    reading: dict[str, Any], value: ApertureValue, device_name="ap_sg"
+):
+    if value.radius is not None:
+        assert reading[f"{device_name}-radius"]["value"] == value.radius
+    assert reading[f"{device_name}-aperture-x"]["value"] == value.aperture_x
+    assert reading[f"{device_name}-aperture-y"]["value"] == value.aperture_y
+    assert reading[f"{device_name}-aperture-z"]["value"] == value.aperture_z
+    assert reading[f"{device_name}-scatterguard-x"]["value"] == value.scatterguard_x
+    assert reading[f"{device_name}-scatterguard-y"]["value"] == value.scatterguard_y
 
 
 def _call_list(calls: Sequence[float]):
@@ -156,10 +167,17 @@ async def test_aperture_scatterguard_select_bottom_moves_sg_down_then_assembly_u
 async def test_aperture_unsafe_move(
     aperture_in_medium_pos: ApertureScatterguard,
 ):
-    (a, b, c, d, e) = (0.2, 3.4, 5.6, 7.8, 9.0)
+    pos = ApertureValue(
+        aperture_x=0.2,
+        aperture_y=3.4,
+        aperture_z=5.6,
+        scatterguard_x=7.8,
+        scatterguard_y=9.0,
+        radius=None,
+    )
     ap_sg = aperture_in_medium_pos
-    await ap_sg._set_raw_unsafe((a, b, c, d, e))  # type: ignore
-    _assert_patched_ap_sg_has_call(ap_sg, (a, b, c, d, e))
+    await ap_sg._set_raw_unsafe(pos)
+    _assert_patched_ap_sg_has_call(ap_sg, pos)
 
 
 async def test_aperture_scatterguard_select_top_moves_assembly_down_then_sg_up(
@@ -169,38 +187,54 @@ async def test_aperture_scatterguard_select_top_moves_assembly_down_then_sg_up(
 
     await ap_sg.set(AperturePosition.LARGE)
 
-    _assert_patched_ap_sg_has_call(ap_sg, (2.389, 40.986, 15.8, 5.25, 4.43))
+    _assert_patched_ap_sg_has_call(
+        ap_sg,
+        ApertureValue(
+            aperture_x=2.389,
+            aperture_y=40.986,
+            aperture_z=15.8,
+            scatterguard_x=5.25,
+            scatterguard_y=4.43,
+            radius=100,
+        ),
+    )
 
 
 async def test_aperture_scatterguard_throws_error_if_outside_tolerance(
     ap_sg: ApertureScatterguard,
 ):
-    set_mock_value(ap_sg._aperture.z.deadband, 0.001)
-    set_mock_value(ap_sg._aperture.z.user_readback, 1)
-    set_mock_value(ap_sg._aperture.z.motor_done_move, 1)
+    set_mock_value(ap_sg.aperture.z.deadband, 0.001)
+    set_mock_value(ap_sg.aperture.z.user_readback, 1)
+    set_mock_value(ap_sg.aperture.z.motor_done_move, 1)
 
     with pytest.raises(InvalidApertureMove):
-        pos = ApertureFiveDimensionalLocation(0, 0, 1.1, 0, 0)
+        pos = ApertureValue(
+            aperture_x=0,
+            aperture_y=0,
+            aperture_z=1.1,
+            scatterguard_x=0,
+            scatterguard_y=0,
+        )
         await ap_sg._safe_move_within_datacollection_range(pos)
 
 
 async def test_aperture_scatterguard_returns_status_if_within_tolerance(
     ap_sg: ApertureScatterguard,
 ):
-    set_mock_value(ap_sg._aperture.z.deadband, 0.001)
-    set_mock_value(ap_sg._aperture.z.user_readback, 1)
-    set_mock_value(ap_sg._aperture.z.motor_done_move, 1)
+    set_mock_value(ap_sg.aperture.z.deadband, 0.001)
+    set_mock_value(ap_sg.aperture.z.user_readback, 1)
+    set_mock_value(ap_sg.aperture.z.motor_done_move, 1)
 
-    pos = ApertureFiveDimensionalLocation(0, 0, 1, 0, 0)
+    pos = ApertureValue(
+        aperture_x=0, aperture_y=0, aperture_z=1, scatterguard_x=0, scatterguard_y=0
+    )
     await ap_sg._safe_move_within_datacollection_range(pos)
 
 
-def set_underlying_motors(
-    ap_sg: ApertureScatterguard, position: ApertureFiveDimensionalLocation
-):
+def set_underlying_motors(ap_sg: ApertureScatterguard, position: ApertureValue):
     for motor, pos in zip(
         get_all_motors(ap_sg),
-        position,
+        position.values(),
         strict=False,
     ):
         motor.set(pos)
@@ -209,7 +243,7 @@ def set_underlying_motors(
 async def test_aperture_positions_large(
     ap_sg: ApertureScatterguard, aperture_positions
 ):
-    set_mock_value(ap_sg._aperture.large, 1)
+    set_mock_value(ap_sg.aperture.large, 1)
     assert (
         await ap_sg.get_current_aperture_position()
         == aperture_positions[AperturePosition.LARGE]
@@ -219,7 +253,7 @@ async def test_aperture_positions_large(
 async def test_aperture_positions_medium(
     ap_sg: ApertureScatterguard, aperture_positions
 ):
-    set_mock_value(ap_sg._aperture.medium, 1)
+    set_mock_value(ap_sg.aperture.medium, 1)
     assert (
         await ap_sg.get_current_aperture_position()
         == aperture_positions[AperturePosition.MEDIUM]
@@ -229,7 +263,7 @@ async def test_aperture_positions_medium(
 async def test_aperture_positions_small(
     ap_sg: ApertureScatterguard, aperture_positions
 ):
-    set_mock_value(ap_sg._aperture.small, 1)
+    set_mock_value(ap_sg.aperture.small, 1)
     assert (
         await ap_sg.get_current_aperture_position()
         == aperture_positions[AperturePosition.SMALL]
@@ -238,41 +272,41 @@ async def test_aperture_positions_small(
 
 async def test_aperture_positions_robot_load(
     ap_sg: ApertureScatterguard,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_positions: dict[AperturePosition, ApertureValue],
 ):
-    set_mock_value(ap_sg._aperture.large, 0)
-    set_mock_value(ap_sg._aperture.medium, 0)
-    set_mock_value(ap_sg._aperture.small, 0)
+    set_mock_value(ap_sg.aperture.large, 0)
+    set_mock_value(ap_sg.aperture.medium, 0)
+    set_mock_value(ap_sg.aperture.small, 0)
     robot_load = aperture_positions[AperturePosition.ROBOT_LOAD]
-    await ap_sg._aperture.y.set(robot_load.location.aperture_y)
+    await ap_sg.aperture.y.set(robot_load.aperture_y)
     assert await ap_sg.get_current_aperture_position() == robot_load
 
 
 async def test_aperture_positions_robot_load_within_tolerance(
     ap_sg: ApertureScatterguard,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_positions: dict[AperturePosition, ApertureValue],
 ):
     robot_load = aperture_positions[AperturePosition.ROBOT_LOAD]
-    robot_load_ap_y = robot_load.location.aperture_y
-    tolerance = ap_sg._tolerances.ap_y
-    set_mock_value(ap_sg._aperture.large, 0)
-    set_mock_value(ap_sg._aperture.medium, 0)
-    set_mock_value(ap_sg._aperture.small, 0)
-    await ap_sg._aperture.y.set(robot_load_ap_y + tolerance)
+    robot_load_ap_y = robot_load.aperture_y
+    tolerance = ap_sg._tolerances.aperture_y
+    set_mock_value(ap_sg.aperture.large, 0)
+    set_mock_value(ap_sg.aperture.medium, 0)
+    set_mock_value(ap_sg.aperture.small, 0)
+    await ap_sg.aperture.y.set(robot_load_ap_y + tolerance)
     assert await ap_sg.get_current_aperture_position() == robot_load
 
 
 async def test_aperture_positions_robot_load_outside_tolerance(
     ap_sg: ApertureScatterguard,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_positions: dict[AperturePosition, ApertureValue],
 ):
     robot_load = aperture_positions[AperturePosition.ROBOT_LOAD]
-    robot_load_ap_y = robot_load.location.aperture_y
-    tolerance = ap_sg._tolerances.ap_y + 0.01
-    set_mock_value(ap_sg._aperture.large, 0)
-    set_mock_value(ap_sg._aperture.medium, 0)
-    set_mock_value(ap_sg._aperture.small, 0)
-    await ap_sg._aperture.y.set(robot_load_ap_y + tolerance)
+    robot_load_ap_y = robot_load.aperture_y
+    tolerance = ap_sg._tolerances.aperture_y + 0.01
+    set_mock_value(ap_sg.aperture.large, 0)
+    set_mock_value(ap_sg.aperture.medium, 0)
+    set_mock_value(ap_sg.aperture.small, 0)
+    await ap_sg.aperture.y.set(robot_load_ap_y + tolerance)
     with pytest.raises(InvalidApertureMove):
         await ap_sg.get_current_aperture_position()
 
@@ -280,46 +314,41 @@ async def test_aperture_positions_robot_load_outside_tolerance(
 async def test_aperture_positions_robot_load_unsafe(
     ap_sg: ApertureScatterguard,
 ):
-    set_mock_value(ap_sg._aperture.large, 0)
-    set_mock_value(ap_sg._aperture.medium, 0)
-    set_mock_value(ap_sg._aperture.small, 0)
-    await ap_sg._aperture.y.set(50.0)
+    set_mock_value(ap_sg.aperture.large, 0)
+    set_mock_value(ap_sg.aperture.medium, 0)
+    set_mock_value(ap_sg.aperture.small, 0)
+    await ap_sg.aperture.y.set(50.0)
     with pytest.raises(InvalidApertureMove):
         await ap_sg.get_current_aperture_position()
 
 
 async def test_given_aperture_not_set_through_device_but_motors_in_position_when_device_read_then_position_returned(
     aperture_in_medium_pos: ApertureScatterguard,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_positions: dict[AperturePosition, ApertureValue],
 ):
-    selected_aperture = await aperture_in_medium_pos.read()
-    assert isinstance(selected_aperture, dict)
-    assert selected_aperture["test_ap_sg-selected_aperture"]["value"] == asdict(
-        aperture_positions[AperturePosition.MEDIUM]
-    )
+    reading = await aperture_in_medium_pos.read()
+    assert isinstance(reading, dict)
+    _assert_value_in_reading(reading, aperture_positions[AperturePosition.MEDIUM])
 
 
 async def test_when_aperture_set_and_device_read_then_position_returned(
     aperture_in_medium_pos: ApertureScatterguard,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_positions: dict[AperturePosition, ApertureValue],
 ):
     await aperture_in_medium_pos.set(AperturePosition.MEDIUM)
-    selected_aperture = await aperture_in_medium_pos.read()
-    assert selected_aperture["test_ap_sg-selected_aperture"]["value"] == asdict(
-        aperture_positions[AperturePosition.MEDIUM]
-    )
+    reading = await aperture_in_medium_pos.read()
+    _assert_value_in_reading(reading, aperture_positions[AperturePosition.MEDIUM])
 
 
 async def test_ap_sg_in_runengine(
     aperture_in_medium_pos: ApertureScatterguard,
     RE: RunEngine,
-    aperture_positions: dict[AperturePosition, SingleAperturePosition],
+    aperture_positions: dict[AperturePosition, ApertureValue],
 ):
-    ap_sg = aperture_in_medium_pos
-    ap = ap_sg._aperture
-    sg = ap_sg._scatterguard
-    test_loc = aperture_positions[AperturePosition.SMALL].location
-    RE(bps.abs_set(ap_sg, AperturePosition.SMALL, wait=True))
+    ap = aperture_in_medium_pos.aperture
+    sg = aperture_in_medium_pos.scatterguard
+    test_loc = aperture_positions[AperturePosition.SMALL]
+    RE(bps.abs_set(aperture_in_medium_pos, AperturePosition.SMALL, wait=True))
     assert await ap.x.user_readback.get_value() == test_loc.aperture_x
     assert await ap.y.user_readback.get_value() == test_loc.aperture_y
     assert await ap.z.user_readback.get_value() == test_loc.aperture_z
@@ -338,32 +367,22 @@ def test_get_position_from_gda_aperture_name(
     ap_sg: ApertureScatterguard,
 ):
     assert (
-        ap_sg.get_position_from_gda_aperture_name(
-            AperturePositionGDANames.LARGE_APERTURE
-        )
+        ap_sg.get_position_from_gda_aperture_name(AperturePosition.LARGE.value)
         == AperturePosition.LARGE
     )
     assert (
-        ap_sg.get_position_from_gda_aperture_name(
-            AperturePositionGDANames.MEDIUM_APERTURE
-        )
+        ap_sg.get_position_from_gda_aperture_name(AperturePosition.MEDIUM.value)
         == AperturePosition.MEDIUM
     )
     assert (
-        ap_sg.get_position_from_gda_aperture_name(
-            AperturePositionGDANames.SMALL_APERTURE
-        )
+        ap_sg.get_position_from_gda_aperture_name(AperturePosition.SMALL.value)
         == AperturePosition.SMALL
     )
     assert (
-        ap_sg.get_position_from_gda_aperture_name(AperturePositionGDANames.ROBOT_LOAD)
+        ap_sg.get_position_from_gda_aperture_name(AperturePosition.ROBOT_LOAD.value)
         == AperturePosition.ROBOT_LOAD
     )
     with pytest.raises(ValueError):
         ap_sg.get_position_from_gda_aperture_name(
             "VERY TINY APERTURE"  # type: ignore
         )
-
-
-def test_ap_sg_returns_GDA_name_correctly(ap_sg: ApertureScatterguard):
-    assert ap_sg.get_gda_name_for_position(AperturePosition.SMALL) == "SMALL_APERTURE"

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -139,7 +139,7 @@ def _assert_patched_ap_sg_has_call(
 
 
 def _assert_value_in_reading(
-    reading: dict[str, Any], value: ApertureValue, device_name="ap_sg"
+    reading: dict[str, Any], value: ApertureValue, device_name: str
 ):
     if value.radius is not None:
         assert reading[f"{device_name}-radius"]["value"] == value.radius
@@ -328,7 +328,11 @@ async def test_given_aperture_not_set_through_device_but_motors_in_position_when
 ):
     reading = await aperture_in_medium_pos.read()
     assert isinstance(reading, dict)
-    _assert_value_in_reading(reading, aperture_positions[AperturePosition.MEDIUM])
+    _assert_value_in_reading(
+        reading,
+        aperture_positions[AperturePosition.MEDIUM],
+        aperture_in_medium_pos.name,
+    )
 
 
 async def test_when_aperture_set_and_device_read_then_position_returned(
@@ -337,7 +341,11 @@ async def test_when_aperture_set_and_device_read_then_position_returned(
 ):
     await aperture_in_medium_pos.set(AperturePosition.MEDIUM)
     reading = await aperture_in_medium_pos.read()
-    _assert_value_in_reading(reading, aperture_positions[AperturePosition.MEDIUM])
+    _assert_value_in_reading(
+        reading,
+        aperture_positions[AperturePosition.MEDIUM],
+        aperture_in_medium_pos.name,
+    )
 
 
 async def test_ap_sg_in_runengine(

--- a/tests/devices/unit_tests/util/test_beamline_specific_utils.py
+++ b/tests/devices/unit_tests/util/test_beamline_specific_utils.py
@@ -4,10 +4,7 @@ from dodal.beamline_specific_utils.i03 import (
     I03_BEAM_HEIGHT_UM,
     beam_size_from_aperture,
 )
-from dodal.devices.aperturescatterguard import (
-    ApertureFiveDimensionalLocation,
-    SingleAperturePosition,
-)
+from dodal.devices.aperturescatterguard import ApertureValue
 
 RADII_AND_SIZES = [
     (None, (None, None)),
@@ -17,14 +14,17 @@ RADII_AND_SIZES = [
 ]
 
 
-def get_single_ap(radius):
-    return SingleAperturePosition(
-        "", "", radius, ApertureFiveDimensionalLocation(0, 0, 0, 0, 0)
-    )
-
-
 @pytest.mark.parametrize(["aperture_radius", "beam_size"], RADII_AND_SIZES)
 def test_beam_size_from_aperture(aperture_radius, beam_size):
-    beamsize = beam_size_from_aperture(get_single_ap(aperture_radius))
+    beamsize = beam_size_from_aperture(
+        ApertureValue(
+            aperture_x=0,
+            aperture_y=0,
+            aperture_z=0,
+            scatterguard_x=0,
+            scatterguard_y=0,
+            radius=aperture_radius,
+        )
+    )
     assert beamsize.x_um == beam_size[0]
     assert beamsize.y_um == beam_size[1]

--- a/tests/devices/unit_tests/util/test_beamline_specific_utils.py
+++ b/tests/devices/unit_tests/util/test_beamline_specific_utils.py
@@ -4,7 +4,6 @@ from dodal.beamline_specific_utils.i03 import (
     I03_BEAM_HEIGHT_UM,
     beam_size_from_aperture,
 )
-from dodal.devices.aperturescatterguard import ApertureValue
 
 RADII_AND_SIZES = [
     (None, (None, None)),
@@ -17,14 +16,7 @@ RADII_AND_SIZES = [
 @pytest.mark.parametrize(["aperture_radius", "beam_size"], RADII_AND_SIZES)
 def test_beam_size_from_aperture(aperture_radius, beam_size):
     beamsize = beam_size_from_aperture(
-        ApertureValue(
-            aperture_x=0,
-            aperture_y=0,
-            aperture_z=0,
-            scatterguard_x=0,
-            scatterguard_y=0,
-            radius=aperture_radius,
-        )
+        aperture_radius,
     )
     assert beamsize.x_um == beam_size[0]
     assert beamsize.y_um == beam_size[1]


### PR DESCRIPTION
Fixes an issue discovered as part of #679, https://github.com/bluesky/ophyd-async/issues/550#issuecomment-2324227988 : SoftConverter is no longer exported from ophyd_async as of 0.5.0, and @coretl @danielballan think that https://github.com/bluesky/ophyd-async/issues/310 should not include being able to pass arbitrary objects, only those that are tableable [tabulable? tabulatable?]. This change therefore adjusts how the ApertureScatterguard returns its signals to be nested under its child devices but as invidual signals.

### Instructions to reviewer on how to test:
1. Ensure that the ApertureScatterguard can still connect and be read
2. The documents for the signals contained inside the device should only use primitive float types.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
