### PR TITLE
Add ability to control shutter source

### DIFF
--- a/src/dodal/devices/zebra.py
+++ b/src/dodal/devices/zebra.py
@@ -37,6 +37,11 @@ TTL_SHUTTER = 2
 TTL_XSPRESS3 = 3
 TTL_PANDA = 4
 
+# The AND gate that controls the automatic shutter
+AUTO_SHUTTER_GATE = 2
+# The input that triggers the automatic shutter
+AUTO_SHUTTER_INPUT = 1
+
 
 class ArmSource(str, Enum):
     SOFT = "Soft"

--- a/src/dodal/devices/zebra_controlled_shutter.py
+++ b/src/dodal/devices/zebra_controlled_shutter.py
@@ -7,7 +7,7 @@ from ophyd_async.core import (
     StandardReadable,
     wait_for_value,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_w
+from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw, epics_signal_w
 
 
 class ZebraShutterState(str, Enum):
@@ -24,14 +24,16 @@ class ZebraShutter(StandardReadable, Movable):
     """The shutter on most MX beamlines is controlled by the zebra.
 
     Internally in the zebra there are two AND gates, one for manual control and one for
-    automatic control. A soft input (aliased to control) will switch between
+    automatic control. A soft input (aliased to control_mode) will switch between
     which of these AND gates to use. For the manual gate the shutter is then controlled
-    by a different soft input (aliased to position_setpoint). Both these AND gates then
-    feed into an OR gate, which then feeds to the shutter."""
+    by a different soft input (aliased to _manual_position_setpoint). Both these AND
+    gates then feed into an OR gate, which then feeds to the shutter."""
 
     def __init__(self, prefix: str, name: str):
-        self.position_setpoint = epics_signal_w(ZebraShutterState, prefix + "CTRL2")
-        self.control = epics_signal_w(ZebraShutterControl, prefix + "CTRL1")
+        self._manual_position_setpoint = epics_signal_w(
+            ZebraShutterState, prefix + "CTRL2"
+        )
+        self.control_mode = epics_signal_rw(ZebraShutterControl, prefix + "CTRL1")
 
         with self.add_children_as_readables():
             self.position_readback = epics_signal_r(ZebraShutterState, prefix + "STA")
@@ -39,7 +41,11 @@ class ZebraShutter(StandardReadable, Movable):
 
     @AsyncStatus.wrap
     async def set(self, value: ZebraShutterState):
-        await self.position_setpoint.set(value)
+        if await self.control_mode.get_value() == ZebraShutterControl.AUTO:
+            raise UserWarning(
+                f"Tried to set shutter to {value.value} but the shutter is in auto mode."
+            )
+        await self._manual_position_setpoint.set(value)
         return await wait_for_value(
             signal=self.position_readback,
             match=value,

--- a/tests/devices/unit_tests/test_shutter.py
+++ b/tests/devices/unit_tests/test_shutter.py
@@ -3,6 +3,7 @@ from ophyd_async.core import DeviceCollector, callback_on_mock_put, set_mock_val
 
 from dodal.devices.zebra_controlled_shutter import (
     ZebraShutter,
+    ZebraShutterControl,
     ZebraShutterState,
 )
 
@@ -18,7 +19,7 @@ async def sim_shutter():
     def propagate_status(value: ZebraShutterState, *args, **kwargs):
         set_mock_value(sim_shutter.position_readback, value)
 
-    callback_on_mock_put(sim_shutter.position_setpoint, propagate_status)
+    callback_on_mock_put(sim_shutter._manual_position_setpoint, propagate_status)
     return sim_shutter
 
 
@@ -33,3 +34,9 @@ async def test_set_shutter_open(
     assert (
         shutter_position["value"] is new_state
     ), f"Unexpected value: {shutter_position['value']}"
+
+
+async def test_given_shutter_in_auto_then_when_set_raises(sim_shutter: ZebraShutter):
+    set_mock_value(sim_shutter.control_mode, ZebraShutterControl.AUTO)
+    with pytest.raises(UserWarning):
+        await sim_shutter.set(ZebraShutterState.OPEN)


### PR DESCRIPTION
See https://github.com/DiamondLightSource/mx-bluesky/issues/232

### Instructions to reviewer on how to test:
1. Confirm `dodal connect i03` works

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
