### PR TITLE
Make sure to add trailing slash on paths

### DIFF
--- a/src/dodal/devices/detector/detector.py
+++ b/src/dodal/devices/detector/detector.py
@@ -79,7 +79,7 @@ class DetectorParams(BaseModel):
     def _parse_directory(cls, directory: str | Path) -> str:
         path = Path(directory)
         assert path.is_dir()
-        return str(path)
+        return f"{path}/"
 
     def get_beam_position_mm(self, detector_distance: float) -> tuple[float, float]:
         x_beam_mm = self.beam_xy_converter.get_beam_xy_from_det_dist(

--- a/src/dodal/devices/util/lookup_tables.py
+++ b/src/dodal/devices/util/lookup_tables.py
@@ -27,7 +27,7 @@ async def energy_distance_table(lookup_table_path: str) -> np.ndarray:
 
     # Slight cheat to make the file IO async, numpy doesn't do any real IO now, just
     # decodes the text
-    async with aiofiles.open(lookup_table_path, "r") as stream:
+    async with aiofiles.open(lookup_table_path) as stream:
         raw_table = await stream.read()
     return loadtxt(StringIO(raw_table), comments=["#", "Units"])
 

--- a/tests/devices/unit_tests/detector/test_detector.py
+++ b/tests/devices/unit_tests/detector/test_detector.py
@@ -28,7 +28,7 @@ def create_det_params_with_dir_and_prefix(directory: str | Path, prefix="test"):
 def test_if_string_provided_check_is_dir(tmp_path: Path):
     assert not (_dir := str(tmp_path)).endswith("/")
     params = create_det_params_with_dir_and_prefix(_dir)
-    assert params.directory == str(tmp_path)
+    assert params.directory == f"{tmp_path}/"
     file_path = tmp_path / "foo.h5"
     file_path.touch()
     with pytest.raises(ValidationError):
@@ -37,7 +37,7 @@ def test_if_string_provided_check_is_dir(tmp_path: Path):
 
 def test_if_path_provided_check_is_dir(tmp_path: Path):
     params = create_det_params_with_dir_and_prefix(tmp_path)
-    assert params.directory == str(tmp_path)
+    assert params.directory == f"{tmp_path}/"
     file_path = tmp_path / "foo.h5"
     file_path.touch()
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/454

### Instructions to reviewer on how to test:
1. Confirm tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
