### PR TITLE
Convert PMAC Programrunner to a Flyable

### DIFF
--- a/src/dodal/devices/fast_grid_scan.py
+++ b/src/dodal/devices/fast_grid_scan.py
@@ -3,6 +3,7 @@ from typing import Generic, TypeVar
 
 import numpy as np
 from bluesky.plan_stubs import mv
+from bluesky.protocols import Flyable
 from numpy import ndarray
 from ophyd_async.core import (
     AsyncStatus,
@@ -193,7 +194,7 @@ class ExpectedImages(SignalR[int]):
         return first_grid + second_grid
 
 
-class FastGridScanCommon(StandardReadable, ABC, Generic[ParamType]):
+class FastGridScanCommon(StandardReadable, Flyable, ABC, Generic[ParamType]):
     """Device for a general fast grid scan
 
     When the motion program is started, the goniometer will move in a snake-like grid trajectory,

--- a/src/dodal/devices/i24/pmac.py
+++ b/src/dodal/devices/i24/pmac.py
@@ -140,6 +140,7 @@ class ProgramRunner(SignalRW, Flyable):
         self.prog_num = prog_num_sig
 
         self.collection_time = collection_time_sig
+        self.KICKOFF_TIMEOUT = timeout
 
         super().__init__(backend, timeout, name)
 
@@ -152,13 +153,12 @@ class ProgramRunner(SignalRW, Flyable):
         """Kick off the collection by sending a program number to the pmac_string and \
             wait for the scan status PV to go to 1.
         """
-        # prog_num = await self.prog_num.get_value()
         prog_num_str = await self._get_prog_number_string()
         await self.signal.set(prog_num_str, wait=True)
         await wait_for_value(
             self.status,
             ScanState.RUNNING,
-            timeout=DEFAULT_TIMEOUT,
+            timeout=self.KICKOFF_TIMEOUT,
         )
 
     @AsyncStatus.wrap

--- a/src/dodal/devices/i24/pmac.py
+++ b/src/dodal/devices/i24/pmac.py
@@ -228,7 +228,7 @@ class PMAC(StandardReadable):
         # A couple of soft signals for running a collection: program number to send to
         # the PMAC_STRING and expected collection time.
         self.program_number = soft_signal_rw(str)
-        self.collection_time = soft_signal_rw(float)
+        self.collection_time = soft_signal_rw(float, units="s")
 
         self.run_program = ProgramRunner(
             self.pmac_string,

--- a/src/dodal/devices/i24/pmac.py
+++ b/src/dodal/devices/i24/pmac.py
@@ -227,7 +227,7 @@ class PMAC(StandardReadable):
         # A couple of soft signals for running a collection: program number to send to
         # the PMAC_STRING and expected collection time.
         self.program_number = soft_signal_rw(int)
-        self.collection_time = soft_signal_rw(float, units="s")
+        self.collection_time = soft_signal_rw(float, initial_value=600.0, units="s")
 
         self.run_program = ProgramRunner(
             self.pmac_string,

--- a/tests/devices/unit_tests/i24/test_pmac.py
+++ b/tests/devices/unit_tests/i24/test_pmac.py
@@ -11,7 +11,6 @@ from dodal.devices.i24.pmac import (
     PMAC,
     EncReset,
     LaserSettings,
-    ProgramNumber,
 )
 from dodal.devices.util.test_utils import patch_motor
 
@@ -83,7 +82,7 @@ async def test_run_program(fake_pmac: PMAC, RE):
         lambda *args, **kwargs: asyncio.create_task(go_high_then_low()),  # type: ignore
     )
 
-    set_mock_value(fake_pmac.program_number, ProgramNumber.ELEVEN)
+    set_mock_value(fake_pmac.program_number, 11)
     set_mock_value(fake_pmac.collection_time, 2.0)
     await fake_pmac.run_program.kickoff()
     await fake_pmac.run_program.complete()

--- a/tests/devices/unit_tests/i24/test_pmac.py
+++ b/tests/devices/unit_tests/i24/test_pmac.py
@@ -66,18 +66,21 @@ async def test_set_pmac_string_for_enc_reset(fake_pmac: PMAC, RE):
     assert await fake_pmac.pmac_string.get_value() == "m708=100 m709=150"
 
 
-async def test_run_proogram(fake_pmac: PMAC, RE):
+async def test_run_program(fake_pmac: PMAC, RE):
     async def go_high_then_low():
         set_mock_value(fake_pmac.scanstatus, 1)
         await asyncio.sleep(0.01)
         set_mock_value(fake_pmac.scanstatus, 0)
 
-    prog_num = 10
     callback_on_mock_put(
         fake_pmac.pmac_string,
         lambda *args, **kwargs: asyncio.create_task(go_high_then_low()),  # type: ignore
     )
-    RE(bps.abs_set(fake_pmac.run_program, prog_num, timeout=1, wait=True))
+
+    # RE(bps.kickoff(fake_pmac.run_program, program_num=10))
+    prog_num = 10
+    await fake_pmac.run_program.kickoff(program_num=prog_num)
+    await fake_pmac.run_program.complete(complete_time=2.0)
 
     assert await fake_pmac.pmac_string.get_value() == f"&2b{prog_num}r"
 

--- a/tests/devices/unit_tests/i24/test_pmac.py
+++ b/tests/devices/unit_tests/i24/test_pmac.py
@@ -83,9 +83,8 @@ async def test_run_program(fake_pmac: PMAC, RE):
         lambda *args, **kwargs: asyncio.create_task(go_high_then_low()),  # type: ignore
     )
 
-    # RE(bps.kickoff(fake_pmac.run_program, program_num=10))
     set_mock_value(fake_pmac.program_number, ProgramNumber.ELEVEN)
-    # RE(bps.kickoff(fake_pmac.run_program, wait=True))
+    set_mock_value(fake_pmac.collection_time, 2.0)
     await fake_pmac.run_program.kickoff()
     await fake_pmac.run_program.complete()
 

--- a/tests/devices/unit_tests/i24/test_pmac.py
+++ b/tests/devices/unit_tests/i24/test_pmac.py
@@ -6,7 +6,13 @@ import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import callback_on_mock_put, get_mock_put, set_mock_value
 
-from dodal.devices.i24.pmac import HOME_STR, PMAC, EncReset, LaserSettings
+from dodal.devices.i24.pmac import (
+    HOME_STR,
+    PMAC,
+    EncReset,
+    LaserSettings,
+    ProgramNumber,
+)
 from dodal.devices.util.test_utils import patch_motor
 
 
@@ -78,11 +84,12 @@ async def test_run_program(fake_pmac: PMAC, RE):
     )
 
     # RE(bps.kickoff(fake_pmac.run_program, program_num=10))
-    prog_num = 10
-    await fake_pmac.run_program.kickoff(program_num=prog_num)
-    await fake_pmac.run_program.complete(complete_time=2.0)
+    set_mock_value(fake_pmac.program_number, ProgramNumber.ELEVEN)
+    # RE(bps.kickoff(fake_pmac.run_program, wait=True))
+    await fake_pmac.run_program.kickoff()
+    await fake_pmac.run_program.complete()
 
-    assert await fake_pmac.pmac_string.get_value() == f"&2b{prog_num}r"
+    assert await fake_pmac.pmac_string.get_value() == "&2b11r"
 
 
 @patch("dodal.devices.i24.pmac.sleep")


### PR DESCRIPTION
Fixes #788 

Converts the ProgramRunner used to run the scan on the I24 PMAC device to a flyable, with a `kickoff` and a `complete` method/

### Instructions to reviewer on how to test:
1. The kickoff/complete methods make sense
2. Tests pass

