### PR TITLE
Warn rather than fail if the webcam fails

### DIFF
--- a/src/dodal/devices/webcam.py
+++ b/src/dodal/devices/webcam.py
@@ -1,11 +1,23 @@
+from collections.abc import ByteString
+from io import BytesIO
 from pathlib import Path
 
 import aiofiles
 from aiohttp import ClientSession
 from bluesky.protocols import Triggerable
 from ophyd_async.core import AsyncStatus, HintedSignal, StandardReadable, soft_signal_rw
+from PIL import Image
 
 from dodal.log import LOGGER
+
+PLACEHOLDER_IMAGE_SIZE = (1024, 768)
+IMAGE_FORMAT = "png"
+
+
+def create_placeholder_image() -> ByteString:
+    image = Image.new("RGB", PLACEHOLDER_IMAGE_SIZE)
+    image.save(buffer := BytesIO(), format=IMAGE_FORMAT)
+    return buffer.getbuffer()
 
 
 class Webcam(StandardReadable, Triggerable):
@@ -18,19 +30,33 @@ class Webcam(StandardReadable, Triggerable):
         self.add_readables([self.last_saved_path], wrapper=HintedSignal)
         super().__init__(name=name)
 
-    async def _write_image(self, file_path: str):
+    async def _write_image(self, file_path: str, image: ByteString):
+        async with aiofiles.open(file_path, "wb") as file:
+            await file.write(image)
+
+    async def _get_and_write_image(self, file_path: str):
         async with ClientSession() as session:
             async with session.get(self.url) as response:
-                response.raise_for_status()
-                LOGGER.info(f"Saving webcam image from {self.url} to {file_path}")
-                async with aiofiles.open(file_path, "wb") as file:
-                    await file.write(await response.read())
+                if not response.ok:
+                    LOGGER.warning(
+                        f"Webcam responded with {response.status}: {response.reason}. Attempting to read anyway."
+                    )
+                try:
+                    data = await response.read()
+                    LOGGER.info(f"Saving webcam image from {self.url} to {file_path}")
+                except Exception as e:
+                    LOGGER.warning(
+                        f"Failed to read data from {self.url} ({e}). Using placeholder image."
+                    )
+                    data = create_placeholder_image()
+
+                await self._write_image(file_path, data)
 
     @AsyncStatus.wrap
     async def trigger(self) -> None:
         filename = await self.filename.get_value()
         directory = await self.directory.get_value()
 
-        file_path = Path(f"{directory}/{filename}.png").as_posix()
-        await self._write_image(file_path)
+        file_path = Path(f"{directory}/{filename}.{IMAGE_FORMAT}").as_posix()
+        await self._get_and_write_image(file_path)
         await self.last_saved_path.set(file_path)


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/488

### Instructions to reviewer on how to test:
1. Confirm new tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
