### PR TITLE
Removed setting the flatfield on zoom level changes

### DIFF
--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -12,7 +12,6 @@ from ophyd import (
     OverlayPlugin,
     ProcessPlugin,
     ROIPlugin,
-    Signal,
     StatusBase,
 )
 
@@ -35,8 +34,6 @@ class ZoomController(Device):
 
     # Level is the string description of the zoom level e.g. "1.0x"
     level = Component(EpicsSignal, "MP:SELECT", string=True)
-    # Used by OAV to work out if we're changing the setpoint
-    _level_sp = Component(Signal)
 
     zrst = Component(EpicsSignal, "MP:SELECT.ZRST")
     onst = Component(EpicsSignal, "MP:SELECT.ONST")
@@ -45,14 +42,6 @@ class ZoomController(Device):
     frst = Component(EpicsSignal, "MP:SELECT.FRST")
     fvst = Component(EpicsSignal, "MP:SELECT.FVST")
     sxst = Component(EpicsSignal, "MP:SELECT.SXST")
-
-    def set_flatfield_on_zoom_level_one(self, value):
-        self.parent: OAV
-        flat_applied = self.parent.proc.port_name.get()
-        no_flat_applied = self.parent.cam.port_name.get()
-        return self.parent.grid_snapshot.input_plugin.set(
-            flat_applied if value == "1.0x" else no_flat_applied
-        )
 
     @property
     def allowed_zoom_levels(self):
@@ -67,10 +56,7 @@ class ZoomController(Device):
         ]
 
     def set(self, level_to_set: str) -> StatusBase:
-        return_status = self._level_sp.set(level_to_set)
-        return_status &= self.level.set(level_to_set)
-        return_status &= self.set_flatfield_on_zoom_level_one(level_to_set)
-        return return_status
+        return self.level.set(level_to_set)
 
 
 class OAV(AreaDetector):

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -1,8 +1,5 @@
-from unittest.mock import MagicMock
-
 import pytest
 from ophyd.sim import instantiate_fake_device
-from ophyd.status import AndStatus, Status
 
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.oav.oav_errors import (
@@ -34,32 +31,6 @@ def oav() -> OAV:
     oav.wait_for_connection()
 
     return oav
-
-
-@pytest.mark.parametrize(
-    "zoom, expected_plugin",
-    [
-        ("1.0x", "proc"),
-        ("7.0x", "CAM"),
-    ],
-)
-def test_when_zoom_level_changed_then_oav_rewired(zoom, expected_plugin, oav: OAV):
-    oav.zoom_controller.set(zoom).wait()
-
-    assert oav.grid_snapshot.input_plugin.get() == expected_plugin
-
-
-def test_when_zoom_level_changed_then_status_waits_for_all_plugins_to_be_updated(
-    oav: OAV,
-):
-    mjpg_status = Status("mjpg - test_when_zoom_level...")
-    oav.grid_snapshot.input_plugin.set = MagicMock(return_value=mjpg_status)
-
-    assert isinstance(full_status := oav.zoom_controller.set("1.0x"), AndStatus)
-    assert mjpg_status in full_status
-
-    mjpg_status.set_finished()
-    full_status.wait()
 
 
 def test_load_microns_per_pixel_entry_not_found(oav: OAV):

--- a/tests/devices/unit_tests/test_oav.py
+++ b/tests/devices/unit_tests/test_oav.py
@@ -2,7 +2,6 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import numpy as np
 import pytest
-from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from ophyd.sim import instantiate_fake_device, make_fake_device
 from ophyd_async.core import set_mock_value
@@ -163,27 +162,6 @@ def test_bottom_right_from_top_left():
         top_left, 15, 20, 0.005, 0.007, 1, 1
     )
     assert bottom_right[0] == 198 and bottom_right[1] == 263
-
-
-def test_when_zoom_1_then_flat_field_applied(fake_oav: OAV, RE: RunEngine):
-    RE(bps.abs_set(fake_oav.zoom_controller, "1.0x"))
-    assert fake_oav.grid_snapshot.input_plugin.get() == "PROC"
-
-
-def test_when_zoom_not_1_then_flat_field_removed(fake_oav: OAV, RE: RunEngine):
-    RE(bps.abs_set(fake_oav.zoom_controller, "10.0x"))
-    assert fake_oav.grid_snapshot.input_plugin.get() == "CAM"
-
-
-def test_when_zoom_is_externally_changed_to_1_then_flat_field_not_changed(
-    fake_oav: OAV,
-):
-    """This test is required to ensure that Hyperion doesn't cause unexpected behaviour
-    e.g. change the flatfield when the zoom level is changed through the synoptic"""
-    fake_oav.grid_snapshot.input_plugin.sim_put("CAM")  # type: ignore
-
-    fake_oav.zoom_controller.level.sim_put("1.0x")  # type: ignore
-    assert fake_oav.grid_snapshot.input_plugin.get() == "CAM"
 
 
 def test_get_beam_position_from_zoom_only_called_once_on_multiple_connects(


### PR DESCRIPTION
Fixes #801 

### Instructions to reviewer on how to test:
1. Confirm all code to do with flat field has been removed

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
