### PR TITLE
530 only stream oav on updates

### DIFF
--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -63,8 +63,8 @@ class BartRobot(StandardReadable, Movable):
         self.current_puck = epics_signal_r(float, prefix + "CURRENT_PUCK_RBV")
         self.current_pin = epics_signal_r(float, prefix + "CURRENT_PIN_RBV")
 
-        self.next_sample_id = epics_signal_rw_rbv(float, prefix + "NEXT_ID")
-        self.sample_id = epics_signal_r(float, prefix + "CURRENT_ID_RBV")
+        self.next_sample_id = epics_signal_rw_rbv(int, prefix + "NEXT_ID")
+        self.sample_id = epics_signal_r(int, prefix + "CURRENT_ID_RBV")
 
         self.load = epics_signal_x(prefix + "LOAD.PROC")
         self.program_running = epics_signal_r(bool, prefix + "PROGRAM_RUNNING")

--- a/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
+++ b/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
@@ -197,7 +197,7 @@ async def test_oav_only_forwards_data_when_the_unique_id_updates(
     await oav_forwarder.kickoff()
     await asyncio.sleep(0.01)
     oav_forwarder.redis_client.hset.assert_called_once()
-    set_mock_value(oav_forwarder._sources[source.value].image_uuid, 1)
+    set_mock_value(oav_forwarder.counter, 1)
     await asyncio.sleep(0.01)
     assert oav_forwarder.redis_client.hset.call_count == 2
     second_call = oav_forwarder.redis_client.hset.call_args_list[1][0]

--- a/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
+++ b/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
@@ -1,13 +1,9 @@
 import asyncio
-import io
-import pickle
 from datetime import timedelta
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
-import numpy as np
 import pytest
 from ophyd_async.core import DeviceCollector, set_mock_value
-from PIL import Image
 
 from dodal.devices.oav.oav_to_redis_forwarder import (
     OAVToRedisForwarder,
@@ -22,14 +18,16 @@ def oav_forwarder(RE):
     with DeviceCollector(mock=True):
         oav_forwarder = OAVToRedisForwarder("prefix", "host", "password")
     set_mock_value(
-        oav_forwarder._sources[Source.FULL_SCREEN.value], "test-full-screen-stream-url"
+        oav_forwarder._sources[Source.FULL_SCREEN.value].url,
+        "test-full-screen-stream-url",
     )
-    set_mock_value(oav_forwarder._sources[Source.ROI.value], "test-roi-stream-url")
+    set_mock_value(oav_forwarder._sources[Source.ROI.value].url, "test-roi-stream-url")
+    set_mock_value(oav_forwarder.selected_source, Source.FULL_SCREEN)
     return oav_forwarder
 
 
 @pytest.fixture
-def oav_forwarder_with_valid_response(oav_forwarder):
+def oav_forwarder_with_valid_response(oav_forwarder: OAVToRedisForwarder):
     client_session_patch = patch(
         "dodal.devices.oav.oav_to_redis_forwarder.ClientSession.get", autospec=True
     )
@@ -61,8 +59,13 @@ async def test_when_oav_forwarder_kicked_off_then_connection_open_and_data_strea
 
     await oav_forwarder.kickoff()
 
+    oav_forwarder._get_frame_and_put_to_redis.assert_not_called()
+
     await asyncio.sleep(0.01)
-    oav_forwarder._get_frame_and_put_to_redis.assert_called_once_with(mock_response)
+
+    oav_forwarder._get_frame_and_put_to_redis.assert_called_once_with(
+        "fullscreen-0", mock_response
+    )
 
     await oav_forwarder.complete()
 
@@ -87,7 +90,9 @@ async def test_when_oav_forwarder_kicked_off_then_completed_forwarding_is_stoppe
     assert oav_forwarder.forwarding_task.done()
 
 
-def get_mock_response(jpeg_bytes):
+def get_mock_response(jpeg_bytes: bytes | None = None):
+    if not jpeg_bytes:
+        jpeg_bytes = b"\xff\xd8\x67\xce\xff\xd9"
     mock_response = MagicMock()
     mock_response.content.readline = AsyncMock(return_value=jpeg_bytes[:3])
     mock_response.content.readuntil = AsyncMock(return_value=jpeg_bytes[3:])
@@ -102,38 +107,25 @@ async def test_given_byte_stream_when_get_next_jpeg_called_then_jpeg_bytes_retur
     mock_response.content.readuntil.assert_awaited_once_with(b"\xff\xd9")
 
 
-def _convert_numpy_data_into_jpeg_bytes(np_array):
-    img = Image.fromarray(np_array)
-    img_byte_arr = io.BytesIO()
-    img.save(img_byte_arr, format="jpeg")
-    img_byte_arr.seek(0)
-    return img_byte_arr.read()
-
-
-def _mock_response(numpy_image=None):
-    if numpy_image is None:
-        numpy_image = np.zeros((10, 10, 3), dtype=np.uint8)
-    all_bytes = _convert_numpy_data_into_jpeg_bytes(numpy_image)
-    return get_mock_response(all_bytes)
-
-
 async def test_when_get_frame_and_put_to_redis_called_then_data_put_in_redis_under_sample_id(
     oav_forwarder,
 ):
     SAMPLE_ID = 100
     await oav_forwarder.sample_id.set(SAMPLE_ID)
-    await oav_forwarder._get_frame_and_put_to_redis(_mock_response())
+    await oav_forwarder._get_frame_and_put_to_redis(ANY, get_mock_response())
     redis_call = oav_forwarder.redis_client.hset.call_args[0]
-    assert redis_call[0] == str(SAMPLE_ID)
+    assert redis_call[0] == "murko:100:raw"
 
 
-async def test_when_get_frame_and_put_to_redis_called_then_data_converted_to_image_and_sent_to_redis(
+async def test_when_get_frame_and_put_to_redis_called_then_data_is_jpeg_bytes(
     oav_forwarder,
 ):
-    expected_in_redis = np.zeros((10, 10, 3), dtype=np.uint8)
-    await oav_forwarder._get_frame_and_put_to_redis(_mock_response(expected_in_redis))
+    expected_bytes = b"\xff\xd8\x67\xce\xff\xd9"
+    await oav_forwarder._get_frame_and_put_to_redis(
+        ANY, get_mock_response(expected_bytes)
+    )
     redis_call = oav_forwarder.redis_client.hset.call_args[0]
-    np.testing.assert_array_equal(pickle.loads(redis_call[2]), expected_in_redis)
+    assert redis_call[2] == expected_bytes
 
 
 async def test_when_get_frame_and_put_to_redis_called_then_data_put_in_redis_with_expiry_time(
@@ -141,9 +133,9 @@ async def test_when_get_frame_and_put_to_redis_called_then_data_put_in_redis_wit
 ):
     SAMPLE_ID = 100
     await oav_forwarder.sample_id.set(SAMPLE_ID)
-    await oav_forwarder._get_frame_and_put_to_redis(_mock_response())
+    await oav_forwarder._get_frame_and_put_to_redis(ANY, get_mock_response())
     redis_expire_call = oav_forwarder.redis_client.expire.call_args[0]
-    assert redis_expire_call[0] == str(SAMPLE_ID)
+    assert redis_expire_call[0] == "murko:100:raw"
     assert redis_expire_call[1] == timedelta(days=oav_forwarder.DATA_EXPIRY_DAYS)
 
 


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/530 and https://github.com/DiamondLightSource/mx-bluesky/issues/147

Built on top of https://github.com/DiamondLightSource/dodal/pull/808 so review/merge that first

Additionally this PR:
* Changes the format of data we store in redis to be just the raw JPEG bytes. This was done after discussion with @aragaod to reduce the memory usage of the redis database.
* Adds a timeout of 30s and so will not stream data for longer than this, FYI @aragaod. We can update this timeout later if needed

### Instructions to reviewer on how to test:
1. Confirm tests still pass
2. Confirm device still connects with `dodal connect i04`

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://github.com/DiamondLightSource/dodal/wiki/Device-Standards)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
