### PR TITLE
759 pressure jump devices collected updates

### DIFF
--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -120,18 +120,19 @@ class AllValvesControl(StandardReadable, Movable):
     async def set_valve(
         self,
         valve: int,
-        value: ValveControlRequest | FastValveControlRequest | ValveOpenSeqRequest,
+        value: ValveControlRequest | FastValveControlRequest,
     ):
-        if valve in self.slow_valves and (
-            isinstance(value, ValveControlRequest)
-            or isinstance(value, ValveOpenSeqRequest)
-        ):
-            await self.valve_control[valve].set(value)
-        elif valve in self.fast_valves and (
-            isinstance(value, FastValveControlRequest)
-            or isinstance(value, ValveOpenSeqRequest)
-        ):
-            await self.fast_valve_control[valve].set(value)
+        if valve in self.slow_valves and (isinstance(value, ValveControlRequest)):
+            if value == ValveControlRequest.OPEN:
+                await self.valve_control[valve].set(ValveOpenSeqRequest.OPEN_SEQ)
+            else:
+                await self.valve_control[valve].set(value)
+
+        elif valve in self.fast_valves and (isinstance(value, FastValveControlRequest)):
+            if value == FastValveControlRequest.OPEN:
+                await self.fast_valve_control[valve].set(ValveOpenSeqRequest.OPEN_SEQ)
+            else:
+                await self.fast_valve_control[valve].set(value)
 
     @AsyncStatus.wrap
     async def set(self, value: AllValvesControlState):

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -12,6 +12,7 @@ from ophyd_async.core import (
 )
 from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 
+OPENSEQ_PULSE_LENGTH = 0.2
 
 class PumpState(str, Enum):
     MANUAL = "Manual"
@@ -125,12 +126,16 @@ class AllValvesControl(StandardReadable, Movable):
         if valve in self.slow_valves and (isinstance(value, ValveControlRequest)):
             if value == ValveControlRequest.OPEN:
                 await self.valve_control[valve].set(ValveOpenSeqRequest.OPEN_SEQ)
+                await asyncio.sleep(OPENSEQ_PULSE_LENGTH)
+                await self.valve_control[valve].set(ValveOpenSeqRequest.INACTIVE)
             else:
                 await self.valve_control[valve].set(value)
 
         elif valve in self.fast_valves and (isinstance(value, FastValveControlRequest)):
             if value == FastValveControlRequest.OPEN:
                 await self.fast_valve_control[valve].set(ValveOpenSeqRequest.OPEN_SEQ)
+                await asyncio.sleep(OPENSEQ_PULSE_LENGTH)
+                await self.fast_valve_control[valve].set(ValveOpenSeqRequest.INACTIVE)
             else:
                 await self.fast_valve_control[valve].set(value)
 

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -118,11 +118,19 @@ class AllValvesControl(StandardReadable, Movable):
         super().__init__(name)
 
     async def set_valve(
-        self, valve: int, value: ValveControlRequest | FastValveControlRequest | ValveOpenSeqRequest
+        self,
+        valve: int,
+        value: ValveControlRequest | FastValveControlRequest | ValveOpenSeqRequest,
     ):
-        if valve in self.slow_valves and isinstance(value, ValveControlRequest) or isinstance(value, ValveOpenSeqRequest):
+        if valve in self.slow_valves and (
+            isinstance(value, ValveControlRequest)
+            or isinstance(value, ValveOpenSeqRequest)
+        ):
             await self.valve_control[valve].set(value)
-        elif valve in self.fast_valves and isinstance(value, FastValveControlRequest) or isinstance(value, ValveOpenSeqRequest):
+        elif valve in self.fast_valves and (
+            isinstance(value, FastValveControlRequest)
+            or isinstance(value, ValveOpenSeqRequest)
+        ):
             await self.fast_valve_control[valve].set(value)
 
     @AsyncStatus.wrap
@@ -144,7 +152,7 @@ class ValveControl(StandardReadable):
 
         super().__init__(name)
 
-    def set(self, value: ValveControlRequest|ValveOpenSeqRequest ) -> AsyncStatus:
+    def set(self, value: ValveControlRequest | ValveOpenSeqRequest) -> AsyncStatus:
         setStatus = None
 
         if isinstance(value, ValveControlRequest):
@@ -163,7 +171,7 @@ class FastValveControl(StandardReadable):
 
         super().__init__(name)
 
-    def set(self, value: FastValveControlRequest|ValveOpenSeqRequest) -> AsyncStatus:
+    def set(self, value: FastValveControlRequest | ValveOpenSeqRequest) -> AsyncStatus:
         setStatus = None
 
         if isinstance(value, FastValveControlRequest):

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -20,16 +20,6 @@ class PumpState(str, Enum):
     AUTO_POSITION = "Auto Position"
 
 
-class BusyState(str, Enum):
-    IDLE = "Idle"
-    BUSY = "Busy"
-
-
-class TimerState(str, Enum):
-    TIMEOUT = "TIMEOUT"
-    COUNTDOWN = "COUNTDOWN"
-
-
 class StopState(str, Enum):
     CONTINUE = "CONTINUE"
     STOP = "STOP"
@@ -47,14 +37,6 @@ class ValveControlRequest(str, Enum):
     OPEN = "Open"
     CLOSE = "Close"
     RESET = "Reset"
-
-
-class PumpMotorControlRequest(str, Enum):
-    ENABLE = "Enable"
-    DISABLE = "Disable"
-    RESET = "Reset"
-    FORWARD = "Forward"
-    REVERSE = "Reverse"
 
 
 class PumpMotorDirectionState(str, Enum):
@@ -78,11 +60,6 @@ class FastValveState(str, Enum):
     CLOSED = "Closed"
     CLOSED_ARMED = "Closed Armed"
     NONE = "Unused"
-
-
-class LimitSwitchState(str, Enum):
-    OFF = "Off"
-    ON = "On"
 
 
 @dataclass

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -63,8 +63,6 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
     cell: PressureJumpCell,
 ):
     set_mock_value(cell.pump.pump_position, 100)
-    # set_mock_value(cell.pump.pump_forward_limit, LimitSwitchState.OFF)
-    # set_mock_value(cell.pump.pump_backward_limit, LimitSwitchState.ON)
     set_mock_value(
         cell.pump.pump_motor_direction,
         PumpMotorDirectionState.FORWARD,

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -122,7 +122,8 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
     )
 
     set_mock_value(
-        cell.all_valves_control.fast_valve_control[6].close, FastValveControlRequest.ARM
+        cell.all_valves_control.fast_valve_control[6].close,
+        FastValveControlRequest.RESET,
     )
 
     set_mock_value(
@@ -131,21 +132,27 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
 
     # Set new values
     await cell.all_valves_control.set_valve(1, ValveControlRequest.OPEN)
-    await cell.all_valves_control.set_valve(1, ValveOpenSeqRequest.OPEN_SEQ)
-    await cell.all_valves_control.set_valve(6, FastValveControlRequest.CLOSE)
-    await cell.all_valves_control.set_valve(6, ValveOpenSeqRequest.OPEN_SEQ)
+    await cell.all_valves_control.set_valve(1, ValveControlRequest.CLOSE)
+    await cell.all_valves_control.set_valve(6, FastValveControlRequest.ARM)
+    await cell.all_valves_control.set_valve(6, FastValveControlRequest.OPEN)
+
+    # cell.all_valves_control.valve_control[1].close.set(ValveControlRequest.OPEN)
+    # cell.all_valves_control.valve_control[1].open.set(ValveOpenSeqRequest.OPEN_SEQ)
+    # cell.all_valves_control.valve_control[6].close.set(ValveOpenSeqRequest.OPEN_SEQ)
+    # cell.all_valves_control.valve_control[6].open.set(ValveOpenSeqRequest.OPEN_SEQ)
+
 
     # Check slow valves have been set to the new value
     await assert_reading(
         cell.all_valves_control.valve_control[1],
         {
-            "pjump-all_valves_control-valve_control-1-close": {
-                "value": ValveControlRequest.OPEN,
+            "pjump-all_valves_control-valve_control-1-open": {
+                "value": ValveOpenSeqRequest.OPEN_SEQ,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-all_valves_control-valve_control-1-open": {
-                "value": ValveOpenSeqRequest.OPEN_SEQ,
+            "pjump-all_valves_control-valve_control-1-close": {
+                "value": ValveControlRequest.CLOSE,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
@@ -157,7 +164,7 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
         cell.all_valves_control.fast_valve_control[6],
         {
             "pjump-all_valves_control-fast_valve_control-6-close": {
-                "value": FastValveControlRequest.CLOSE,
+                "value": FastValveControlRequest.ARM,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -109,6 +109,7 @@ async def test_reading_pjumpcell_includes_config_fields_valves(
         },
     )
 
+
 async def test_pjumpcell_set_valve_sets_valve_fields(
     cell: PressureJumpCell,
 ):
@@ -119,7 +120,6 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
     set_mock_value(
         cell.all_valves_control.valve_control[1].open, ValveOpenSeqRequest.INACTIVE
     )
-
 
     set_mock_value(
         cell.all_valves_control.fast_valve_control[6].close, FastValveControlRequest.ARM
@@ -149,11 +149,12 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-        })
+        },
+    )
 
     # Check fast valves have been set to the new value
     await assert_reading(
-        cell.all_valves_control.valve_control[6],
+        cell.all_valves_control.fast_valve_control[6],
         {
             "pjump-all_valves_control-fast_valve_control-6-close": {
                 "value": FastValveControlRequest.CLOSE,
@@ -165,7 +166,8 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-        })
+        },
+    )
 
 
 async def test_reading_pjumpcell_includes_read_fields_pump(
@@ -236,7 +238,7 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducers-1-beckhoff_voltage": {
+            "pjump-pressure_transducers-1-slow_beckhoff_voltage_readout": {
                 "value": 2.51,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -261,7 +263,7 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducers-2-beckhoff_voltage": {
+            "pjump-pressure_transducers-2-slow_beckhoff_voltage_readout": {
                 "value": 2.52,
                 "timestamp": ANY,
                 "alarm_severity": 0,
@@ -286,7 +288,7 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },
-            "pjump-pressure_transducers-3-beckhoff_voltage": {
+            "pjump-pressure_transducers-3-slow_beckhoff_voltage_readout": {
                 "value": 2.53,
                 "timestamp": ANY,
                 "alarm_severity": 0,

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -4,9 +4,12 @@ import pytest
 from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
 
 from dodal.devices.pressure_jump_cell import (
+    FastValveControlRequest,
     FastValveState,
     PressureJumpCell,
     PumpMotorDirectionState,
+    ValveControlRequest,
+    ValveOpenSeqRequest,
     ValveState,
 )
 
@@ -52,6 +55,70 @@ async def test_reading_pjumpcell_includes_read_fields_valves(
             },
             "pjump-all_valves_control-fast_valve_states-6": {
                 "value": FastValveState.OPEN_ARMED,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+        },
+    )
+
+
+async def test_reading_pjumpcell_includes_config_fields_valves(
+    cell: PressureJumpCell,
+):
+    set_mock_value(
+        cell.all_valves_control.valve_control[1].close, ValveControlRequest.CLOSE
+    )
+    set_mock_value(
+        cell.all_valves_control.valve_control[3].close, ValveControlRequest.OPEN
+    )
+    set_mock_value(
+        cell.all_valves_control.valve_control[1].open, ValveOpenSeqRequest.INACTIVE
+    )
+    set_mock_value(
+        cell.all_valves_control.valve_control[3].open, ValveOpenSeqRequest.OPEN_SEQ
+    )
+
+    set_mock_value(
+        cell.all_valves_control.fast_valve_control[5].close,
+        FastValveControlRequest.DISARM,
+    )
+    set_mock_value(
+        cell.all_valves_control.fast_valve_control[6].close, FastValveControlRequest.ARM
+    )
+    set_mock_value(
+        cell.all_valves_control.fast_valve_control[5].open,
+        ValveOpenSeqRequest.INACTIVE,
+    )
+    set_mock_value(
+        cell.all_valves_control.fast_valve_control[6].open, ValveOpenSeqRequest.OPEN_SEQ
+    )
+
+    await assert_reading(
+        cell.all_valves_control.valve_control[1],
+        {
+            "pjump-all_valves_control-valve_control-1-close": {
+                "value": ValveControlRequest.CLOSE,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-all_valves_control-valve_control-1-open": {
+                "value": ValveOpenSeqRequest.INACTIVE,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+        },
+    )
+
+    await assert_reading(
+        cell.all_valves_control.fast_valve_control[6],
+        {
+            "pjump-all_valves_control-fast_valve_control-6-close": {
+                "value": FastValveControlRequest.ARM,
+                "timestamp": ANY,
+                "alarm_severity": 0,
+            },
+            "pjump-all_valves_control-fast_valve_control-6-open": {
+                "value": ValveOpenSeqRequest.OPEN_SEQ,
                 "timestamp": ANY,
                 "alarm_severity": 0,
             },


### PR DESCRIPTION
Fixes #759 

The OPENSEQ PVs expect their value to be momentarily be set to 1 to trigger the valve opening `ValveOpenSeqRequest.OPEN_SEQ`. Via a synoptic screen this is achieved via a pushbutton control that is 1 when it is being held down and 0 when released, what is the equivalent way of doing this in dodal? can it be in the driver or is it down to the plan?

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
