### PR TITLE
(DiamondLightSource/mx-bluesky#475) Method to allow access to full zocalo results

### DIFF
--- a/src/dodal/devices/zocalo/__init__.py
+++ b/src/dodal/devices/zocalo/__init__.py
@@ -4,14 +4,14 @@ from dodal.devices.zocalo.zocalo_results import (
     NoZocaloSubscription,
     XrcResult,
     ZocaloResults,
-    get_processing_result,
+    get_full_processing_results,
 )
 
 __all__ = [
     "ZocaloResults",
     "XrcResult",
     "ZocaloTrigger",
-    "get_processing_result",
+    "get_full_processing_results",
     "ZOCALO_READING_PLAN_NAME",
     "NoResultsFromZocalo",
     "NoZocaloSubscription",

--- a/src/dodal/devices/zocalo/zocalo_results.py
+++ b/src/dodal/devices/zocalo/zocalo_results.py
@@ -9,8 +9,8 @@ import bluesky.plan_stubs as bps
 import numpy as np
 import workflows.recipe
 import workflows.transport
-from bluesky import Msg
 from bluesky.protocols import Descriptor, Triggerable
+from bluesky.utils import Msg
 from deepdiff import DeepDiff
 from numpy.typing import NDArray
 from ophyd_async.core import (
@@ -52,7 +52,7 @@ ZOCALO_STAGE_GROUP = "clear zocalo queue"
 
 
 class XrcResult(TypedDict):
-    centre_of_mass: list[int]
+    centre_of_mass: list[float]
     max_voxel: list[int]
     max_count: int
     n_voxels: int
@@ -401,5 +401,5 @@ def get_full_processing_results(
     """A plan that will return the raw zocalo results, ranked in descending order according to the sort key.
     Returns empty list in the event no results found."""
     LOGGER.info("Retrieving raw zocalo processing results")
-    raw_results = yield from bps.rd(zocalo.results, default_value=[])
-    return [_corrected_xrc_result(r) for r in raw_results]
+    raw_results = yield from bps.rd(zocalo.results, default_value=[])  # type: ignore
+    return [_corrected_xrc_result(r) for r in raw_results]  # type: ignore

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -489,4 +489,4 @@ async def test_given_gpu_enabled_when_no_results_found_then_returns_no_results(
         ]
     )
     await zocalo_results.trigger()
-    assert len(await zocalo_results.centres_of_mass.get_value()) == 0
+    assert len(await zocalo_results.centre_of_mass.get_value()) == 0

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -17,7 +17,6 @@ from dodal.devices.zocalo.zocalo_results import (
     ZocaloResults,
     ZocaloSource,
     get_full_processing_results,
-    get_processing_result,
 )
 
 TEST_RESULTS: list[XrcResult] = [
@@ -124,30 +123,10 @@ async def test_put_result_read_results(
     zocalo_device = await mocked_zocalo_device([], run_setup=True)
     await zocalo_device._put_results(TEST_RESULTS, test_recipe_parameters)
     reading = await zocalo_device.read()
-    results: list[XrcResult] = reading["zocalo-results"]["value"]
     centres: list[XrcResult] = reading["zocalo-centres_of_mass"]["value"]
     bboxes: list[XrcResult] = reading["zocalo-bbox_sizes"]["value"]
-    assert results == TEST_RESULTS
     assert np.all(centres == np.array([[1, 2, 3], [2, 3, 4], [4, 5, 6]]))
     assert np.all(bboxes[0] == [2, 2, 1])
-
-
-async def test_rd_top_results(
-    mocked_zocalo_device,
-    RE,
-):
-    zocalo_device = await mocked_zocalo_device([], run_setup=True)
-    await zocalo_device._put_results(TEST_RESULTS, test_recipe_parameters)
-
-    def test_plan():
-        bbox_size = yield from bps.rd(zocalo_device.bbox_sizes)
-        assert len(bbox_size[0]) == 3  # type: ignore
-        assert np.all(bbox_size[0] == np.array([2, 2, 1]))  # type: ignore
-        centres_of_mass = yield from bps.rd(zocalo_device.centres_of_mass)
-        assert len(centres_of_mass[0]) == 3  # type: ignore
-        assert np.all(centres_of_mass[0] == np.array([1, 2, 3]))  # type: ignore
-
-    RE(test_plan())
 
 
 async def test_trigger_and_wait_puts_results(
@@ -167,22 +146,6 @@ async def test_trigger_and_wait_puts_results(
     zocalo_device._put_results.assert_called()
 
 
-async def test_extraction_plan(mocked_zocalo_device, RE) -> None:
-    zocalo_device: ZocaloResults = await mocked_zocalo_device(
-        TEST_RESULTS, run_setup=False
-    )
-
-    def plan():
-        yield from bps.open_run()
-        yield from bps.trigger_and_read([zocalo_device], name=ZOCALO_READING_PLAN_NAME)
-        com, bbox = yield from get_processing_result(zocalo_device)
-        assert np.all(com == np.array([0.5, 1.5, 2.5]))
-        assert np.all(bbox == np.array([2, 2, 1]))
-        yield from bps.close_run()
-
-    RE(plan())
-
-
 async def test_get_full_processing_results(mocked_zocalo_device, RE) -> None:
     zocalo_device: ZocaloResults = await mocked_zocalo_device(
         TEST_RESULTS, run_setup=False
@@ -200,6 +163,8 @@ async def test_get_full_processing_results(mocked_zocalo_device, RE) -> None:
             [[1, 2, 3], [3, 4, 4]],
             [[1, 2, 3], [3, 4, 4]],
         ]
+        for prop in ["max_voxel", "max_count", "n_voxels", "total_count"]:
+            assert [r[prop] for r in full_results] == [r[prop] for r in TEST_RESULTS]  # type: ignore
 
     RE(plan())
 

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -16,6 +16,7 @@ from dodal.devices.zocalo.zocalo_results import (
     XrcResult,
     ZocaloResults,
     ZocaloSource,
+    get_full_processing_results,
     get_processing_result,
 )
 
@@ -178,6 +179,27 @@ async def test_extraction_plan(mocked_zocalo_device, RE) -> None:
         assert np.all(com == np.array([0.5, 1.5, 2.5]))
         assert np.all(bbox == np.array([2, 2, 1]))
         yield from bps.close_run()
+
+    RE(plan())
+
+
+async def test_get_full_processing_results(mocked_zocalo_device, RE) -> None:
+    zocalo_device: ZocaloResults = await mocked_zocalo_device(
+        TEST_RESULTS, run_setup=False
+    )
+
+    def plan():
+        yield from bps.trigger(zocalo_device)
+        full_results = yield from get_full_processing_results(zocalo_device)
+        assert len(full_results) == 3
+        centres_of_mass = [xrc_result["centre_of_mass"] for xrc_result in full_results]
+        bbox = [xrc_result["bounding_box"] for xrc_result in full_results]
+        assert centres_of_mass == [[0.5, 1.5, 2.5], [1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]
+        assert bbox == [
+            [[1, 2, 3], [3, 4, 4]],
+            [[1, 2, 3], [3, 4, 4]],
+            [[1, 2, 3], [3, 4, 4]],
+        ]
 
     RE(plan())
 

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -1,8 +1,10 @@
+from asyncio import get_running_loop
 from functools import partial
 from queue import Empty
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
 import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
@@ -17,6 +19,7 @@ from dodal.devices.zocalo.zocalo_results import (
     ZocaloResults,
     ZocaloSource,
     get_full_processing_results,
+    get_processing_results_from_event,
 )
 
 TEST_RESULTS: list[XrcResult] = [
@@ -116,19 +119,6 @@ async def mocked_zocalo_device(RE: RunEngine, zocalo_results: ZocaloResults):
     return device
 
 
-async def test_put_result_read_results(
-    mocked_zocalo_device,
-    RE,
-) -> None:
-    zocalo_device = await mocked_zocalo_device([], run_setup=True)
-    await zocalo_device._put_results(TEST_RESULTS, test_recipe_parameters)
-    reading = await zocalo_device.read()
-    centres: list[XrcResult] = reading["zocalo-centres_of_mass"]["value"]
-    bboxes: list[XrcResult] = reading["zocalo-bbox_sizes"]["value"]
-    assert np.all(centres == np.array([[1, 2, 3], [2, 3, 4], [4, 5, 6]]))
-    assert np.all(bboxes[0] == [2, 2, 1])
-
-
 async def test_trigger_and_wait_puts_results(
     mocked_zocalo_device,
     RE,
@@ -167,6 +157,25 @@ async def test_get_full_processing_results(mocked_zocalo_device, RE) -> None:
             assert [r[prop] for r in full_results] == [r[prop] for r in TEST_RESULTS]  # type: ignore
 
     RE(plan())
+
+
+async def test_get_processing_results_from_event(mocked_zocalo_device, RE) -> None:
+    zocalo_device: ZocaloResults = await mocked_zocalo_device(
+        TEST_RESULTS, run_setup=False
+    )
+
+    xrc_results_fut = get_running_loop().create_future()
+
+    def handle_zocalo_result(name: str, doc: dict):
+        xrc_results_fut.set_result(get_processing_results_from_event("zocalo", doc))
+
+    @bpp.subs_decorator({"event": handle_zocalo_result})
+    @bpp.run_decorator()
+    def plan():
+        yield from bps.trigger_and_read([zocalo_device])
+
+    RE(plan())
+    assert xrc_results_fut.result() == TEST_RESULTS
 
 
 @patch(


### PR DESCRIPTION
Extends ZocaloResults to get access to everything instead of just the position and bounding box

Fixes DiamondLightSource/mx-bluesky#475

