### PR TITLE
Make backlight timing a float

### DIFF
--- a/src/dodal/devices/backlight.py
+++ b/src/dodal/devices/backlight.py
@@ -18,7 +18,7 @@ class BacklightPosition(str, Enum):
 class Backlight(StandardReadable):
     """Simple device to trigger the pneumatic in/out."""
 
-    TIME_TO_MOVE_S = 1  # Tested using a stopwatch on the beamline 09/2024
+    TIME_TO_MOVE_S = 1.0  # Tested using a stopwatch on the beamline 09/2024
 
     def __init__(self, prefix: str, name: str = "") -> None:
         with self.add_children_as_readables():


### PR DESCRIPTION
Needed to help typing in https://github.com/DiamondLightSource/mx-bluesky/pull/560

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
