### PR TITLE
Limit i03 beam width to 80um

### DIFF
--- a/src/dodal/beamline_specific_utils/i03.py
+++ b/src/dodal/beamline_specific_utils/i03.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 I03_BEAM_HEIGHT_UM = 20
+I03_BEAM_WIDTH_UM = 80
 
 
 @dataclass
@@ -10,4 +11,7 @@ class BeamSize:
 
 
 def beam_size_from_aperture(aperture_size: float | None):
-    return BeamSize(aperture_size, I03_BEAM_HEIGHT_UM if aperture_size else None)
+    return BeamSize(
+        min(aperture_size, I03_BEAM_WIDTH_UM),
+        I03_BEAM_HEIGHT_UM if aperture_size else None,
+    )

--- a/src/dodal/beamline_specific_utils/i03.py
+++ b/src/dodal/beamline_specific_utils/i03.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-I03_BEAM_HEIGHT_UM = 20
-I03_BEAM_WIDTH_UM = 80
+I03_BEAM_HEIGHT_UM = 20.0
+I03_BEAM_WIDTH_UM = 80.0
 
 
 @dataclass
@@ -12,6 +12,6 @@ class BeamSize:
 
 def beam_size_from_aperture(aperture_size: float | None):
     return BeamSize(
-        min(aperture_size, I03_BEAM_WIDTH_UM),
+        min(aperture_size, I03_BEAM_WIDTH_UM) if aperture_size else None,
         I03_BEAM_HEIGHT_UM if aperture_size else None,
     )

--- a/tests/devices/unit_tests/util/test_beamline_specific_utils.py
+++ b/tests/devices/unit_tests/util/test_beamline_specific_utils.py
@@ -7,9 +7,10 @@ from dodal.beamline_specific_utils.i03 import (
 
 RADII_AND_SIZES = [
     (None, (None, None)),
-    (123, (123, I03_BEAM_HEIGHT_UM)),
+    (123, (80, I03_BEAM_HEIGHT_UM)),
     (23.45, (23.45, I03_BEAM_HEIGHT_UM)),
-    (888, (888, I03_BEAM_HEIGHT_UM)),
+    (50, (50, I03_BEAM_HEIGHT_UM)),
+    (888, (80, I03_BEAM_HEIGHT_UM)),
 ]
 
 


### PR DESCRIPTION
- `beam_size_from_apterture` now limits the returned width to the maximum for the beamline