### PR TITLE
Add the horizontal mirror voltages

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -22,7 +22,7 @@ from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import PandAFastGridScan, ZebraFastGridScan
 from dodal.devices.flux import Flux
-from dodal.devices.focusing_mirror import FocusingMirrorWithStripes, VFMMirrorVoltages
+from dodal.devices.focusing_mirror import FocusingMirrorWithStripes, MirrorVoltages
 from dodal.devices.motors import XYZPositioner
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
@@ -121,11 +121,11 @@ def vfm(
 
 
 @skip_device(lambda: BL == "s03")
-def vfm_mirror_voltages(
+def mirror_voltages(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> VFMMirrorVoltages:
+) -> MirrorVoltages:
     return device_instantiation(
-        device_factory=VFMMirrorVoltages,
+        device_factory=MirrorVoltages,
         name="vfm_mirror_voltages",
         prefix="-MO-PSU-01:",
         wait=wait_for_connection,

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -126,7 +126,7 @@ def mirror_voltages(
 ) -> MirrorVoltages:
     return device_instantiation(
         device_factory=MirrorVoltages,
-        name="vfm_mirror_voltages",
+        name="mirror_voltages",
         prefix="-MO-PSU-01:",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,

--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -114,7 +114,7 @@ class MirrorVoltages(StandardReadable):
         )
 
         with self.add_children_as_readables():
-            self.horizontal_voltages = self._channels_in_range(prefix, 0, 13)
+            self.horizontal_voltages = self._channels_in_range(prefix, 0, 14)
             self.vertical_voltages = self._channels_in_range(prefix, 14, 22)
 
         super().__init__(*args, name=name, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def pytest_runtest_teardown():
 
 @pytest.fixture
 def vfm_mirror_voltages(RE: RunEngine):
-    voltages = i03.vfm_mirror_voltages(fake_with_ophyd_sim=True)
+    voltages = i03.mirror_voltages(fake_with_ophyd_sim=True)
     voltages.voltage_lookup_table_path = "tests/test_data/test_mirror_focus.json"
     yield voltages
     beamline_utils.clear_devices()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ from ophyd_async.core import (
     PathProvider,
 )
 
-from dodal.beamlines import i03
 from dodal.common.beamlines import beamline_utils
 from dodal.common.visit import (
     DirectoryServiceClient,
@@ -90,14 +89,6 @@ def pytest_runtest_setup(item):
 def pytest_runtest_teardown():
     if "dodal.beamlines.beamline_utils" in sys.modules:
         sys.modules["dodal.beamlines.beamline_utils"].clear_devices()
-
-
-@pytest.fixture
-def vfm_mirror_voltages(RE: RunEngine):
-    voltages = i03.mirror_voltages(fake_with_ophyd_sim=True)
-    voltages.voltage_lookup_table_path = "tests/test_data/test_mirror_focus.json"
-    yield voltages
-    beamline_utils.clear_devices()
 
 
 s03_epics_server_port = getenv("S03_EPICS_CA_SERVER_PORT")

--- a/tests/devices/unit_tests/test_focusing_mirror.py
+++ b/tests/devices/unit_tests/test_focusing_mirror.py
@@ -245,7 +245,7 @@ def test_mirror_set_voltage_returns_immediately_if_voltage_already_demanded(
 def test_mirror_populates_voltage_channels(RE):
     with DeviceCollector(mock=True):
         mirror_voltages = MirrorVoltages("", "", daq_configuration_path="")
-    assert len(mirror_voltages.horizontal_voltages) == 13
+    assert len(mirror_voltages.horizontal_voltages) == 14
     assert len(mirror_voltages.vertical_voltages) == 8
     assert isinstance(mirror_voltages.horizontal_voltages[0], SingleMirrorVoltage)
 

--- a/tests/devices/unit_tests/test_focusing_mirror.py
+++ b/tests/devices/unit_tests/test_focusing_mirror.py
@@ -10,129 +10,128 @@ import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
-from ophyd_async.core import callback_on_mock_put, get_mock_put, set_mock_value
+from ophyd_async.core import (
+    DeviceCollector,
+    callback_on_mock_put,
+    get_mock_put,
+    set_mock_value,
+)
 
 from dodal.devices.focusing_mirror import (
     FocusingMirrorWithStripes,
     MirrorStripe,
     MirrorVoltageDemand,
-    MirrorVoltageDevice,
-    VFMMirrorVoltages,
+    MirrorVoltages,
+    SingleMirrorVoltage,
 )
 from dodal.log import LOGGER
 
 
-@pytest.fixture
-def vfm_mirror_voltages_not_ok(vfm_mirror_voltages) -> VFMMirrorVoltages:
-    set_mock_value(
-        vfm_mirror_voltages.voltage_channels[0]._demand_accepted,
-        MirrorVoltageDemand.FAIL,
-    )
-    return vfm_mirror_voltages
-
-
-@pytest.fixture
-def vfm_mirror_voltages_with_set(vfm_mirror_voltages) -> VFMMirrorVoltages:
-    return vfm_mirror_voltages_with_set_to_value(
-        vfm_mirror_voltages, MirrorVoltageDemand.OK
-    )
-
-
-@pytest.fixture
-def vfm_mirror_voltages_with_set_multiple_spins(
-    vfm_mirror_voltages,
-) -> VFMMirrorVoltages:
-    return vfm_mirror_voltages_with_set_to_value(
-        vfm_mirror_voltages, MirrorVoltageDemand.OK, 3
-    )
-
-
-@pytest.fixture
-def vfm_mirror_voltages_with_set_accepted_fail(
-    vfm_mirror_voltages,
-) -> VFMMirrorVoltages:
-    return vfm_mirror_voltages_with_set_to_value(
-        vfm_mirror_voltages, MirrorVoltageDemand.FAIL
-    )
-
-
-def vfm_mirror_voltages_with_set_to_value(
-    vfm_mirror_voltages, new_value: MirrorVoltageDemand, spins: int = 0
-) -> VFMMirrorVoltages:
+def mirror_voltage_with_set_to_value(
+    mirror_voltage: SingleMirrorVoltage, new_value: MirrorVoltageDemand, spins: int = 0
+) -> SingleMirrorVoltage:
     async def set_demand_accepted_after_delay():
         await asyncio.sleep(0.1)
         nonlocal spins
         if spins > 0:
             set_mock_value(
-                vfm_mirror_voltages.voltage_channels[0]._demand_accepted,
+                mirror_voltage._demand_accepted,
                 MirrorVoltageDemand.SLEW,
             )
             spins -= 1
             asyncio.create_task(set_demand_accepted_after_delay())
         else:
             set_mock_value(
-                vfm_mirror_voltages.voltage_channels[0]._demand_accepted,
+                mirror_voltage._demand_accepted,
                 new_value,
             )
         LOGGER.debug("DEMAND ACCEPTED OK")
 
     def not_ok_then_other_value(*args, **kwargs):
         set_mock_value(
-            vfm_mirror_voltages.voltage_channels[0]._demand_accepted,
+            mirror_voltage._demand_accepted,
             MirrorVoltageDemand.SLEW,
         )
         asyncio.create_task(set_demand_accepted_after_delay())
         return DEFAULT
 
-    callback_on_mock_put(
-        vfm_mirror_voltages.voltage_channels[0]._setpoint_v, not_ok_then_other_value
-    )
+    callback_on_mock_put(mirror_voltage._setpoint_v, not_ok_then_other_value)
     set_mock_value(
-        vfm_mirror_voltages.voltage_channels[0]._demand_accepted,
+        mirror_voltage._demand_accepted,
         MirrorVoltageDemand.OK,
     )
-    return vfm_mirror_voltages
+    return mirror_voltage
 
 
 @pytest.fixture
-def vfm_mirror_voltages_with_set_timing_out(vfm_mirror_voltages) -> VFMMirrorVoltages:
+def mirror_voltage():
+    with DeviceCollector(mock=True):
+        mirror_voltage = SingleMirrorVoltage()
+    return mirror_voltage
+
+
+@pytest.fixture
+def mirror_voltage_with_set(
+    mirror_voltage: SingleMirrorVoltage,
+) -> SingleMirrorVoltage:
+    return mirror_voltage_with_set_to_value(mirror_voltage, MirrorVoltageDemand.OK)
+
+
+@pytest.fixture
+def mirror_voltage_not_ok(mirror_voltage: SingleMirrorVoltage) -> SingleMirrorVoltage:
+    set_mock_value(mirror_voltage._demand_accepted, MirrorVoltageDemand.FAIL)
+    return mirror_voltage
+
+
+@pytest.fixture
+def mirror_voltage_with_set_multiple_spins(
+    mirror_voltage: SingleMirrorVoltage,
+) -> SingleMirrorVoltage:
+    return mirror_voltage_with_set_to_value(mirror_voltage, MirrorVoltageDemand.OK, 3)
+
+
+@pytest.fixture
+def mirror_voltage_with_set_accepted_fail(
+    mirror_voltage: SingleMirrorVoltage,
+) -> SingleMirrorVoltage:
+    return mirror_voltage_with_set_to_value(mirror_voltage, MirrorVoltageDemand.FAIL)
+
+
+@pytest.fixture
+def mirror_voltage_with_set_timing_out(
+    mirror_voltage: SingleMirrorVoltage,
+) -> SingleMirrorVoltage:
     def not_ok(*args, **kwargs):
         set_mock_value(
-            vfm_mirror_voltages.voltage_channels[0]._demand_accepted,
+            mirror_voltage._demand_accepted,
             MirrorVoltageDemand.SLEW,
         )
         return DEFAULT
 
-    get_mock_put(
-        vfm_mirror_voltages.voltage_channels[0]._setpoint_v
-    ).side_effect = not_ok
+    get_mock_put(mirror_voltage._setpoint_v).side_effect = not_ok
     set_mock_value(
-        vfm_mirror_voltages.voltage_channels[0]._demand_accepted,
+        mirror_voltage._demand_accepted,
         MirrorVoltageDemand.OK,
     )
-    return vfm_mirror_voltages
+    return mirror_voltage
 
 
 def test_mirror_set_voltage_sets_and_waits_happy_path(
     RE: RunEngine,
-    vfm_mirror_voltages_with_set: VFMMirrorVoltages,
+    mirror_voltage_with_set: SingleMirrorVoltage,
 ):
     def completed():
         pass
 
-    mock_put = get_mock_put(
-        vfm_mirror_voltages_with_set.voltage_channels[0]._setpoint_v
-    )
+    mock_put = get_mock_put(mirror_voltage_with_set._setpoint_v)
     mock_put.return_value = completed()
     set_mock_value(
-        vfm_mirror_voltages_with_set.voltage_channels[0]._demand_accepted,
+        mirror_voltage_with_set._demand_accepted,
         MirrorVoltageDemand.OK,
     )
 
     def plan():
-        yield from bps.abs_set(
-            vfm_mirror_voltages_with_set.voltage_channels[0], 100, wait=True
-        )
+        yield from bps.abs_set(mirror_voltage_with_set, 100, wait=True)
 
     RE(plan())
 
@@ -141,25 +140,21 @@ def test_mirror_set_voltage_sets_and_waits_happy_path(
 
 def test_mirror_set_voltage_sets_and_waits_happy_path_spin_while_waiting_for_slew(
     RE: RunEngine,
-    vfm_mirror_voltages_with_set_multiple_spins: VFMMirrorVoltages,
+    mirror_voltage_with_set_multiple_spins: SingleMirrorVoltage,
 ):
     def completed():
         pass
 
-    mock_put = get_mock_put(
-        vfm_mirror_voltages_with_set_multiple_spins.voltage_channels[0]._setpoint_v
-    )
+    mock_put = get_mock_put(mirror_voltage_with_set_multiple_spins._setpoint_v)
     mock_put.return_value = completed()
     set_mock_value(
-        vfm_mirror_voltages_with_set_multiple_spins.voltage_channels[
-            0
-        ]._demand_accepted,
+        mirror_voltage_with_set_multiple_spins._demand_accepted,
         MirrorVoltageDemand.OK,
     )
 
     def plan():
         yield from bps.abs_set(
-            vfm_mirror_voltages_with_set_multiple_spins.voltage_channels[0],
+            mirror_voltage_with_set_multiple_spins,
             100,
             wait=True,
         )
@@ -171,13 +166,11 @@ def test_mirror_set_voltage_sets_and_waits_happy_path_spin_while_waiting_for_sle
 
 def test_mirror_set_voltage_set_rejected_when_not_ok(
     RE: RunEngine,
-    vfm_mirror_voltages_not_ok: VFMMirrorVoltages,
+    mirror_voltage_not_ok: SingleMirrorVoltage,
 ):
     def plan():
         with pytest.raises(FailedStatus) as e:
-            yield from bps.abs_set(
-                vfm_mirror_voltages_not_ok.voltage_channels[0], 100, wait=True
-            )
+            yield from bps.abs_set(mirror_voltage_not_ok, 100, wait=True)
 
         assert isinstance(e.value.args[0].exception(), AssertionError)
 
@@ -186,18 +179,16 @@ def test_mirror_set_voltage_set_rejected_when_not_ok(
 
 def test_mirror_set_voltage_sets_and_waits_set_fail(
     RE: RunEngine,
-    vfm_mirror_voltages_with_set: VFMMirrorVoltages,
+    mirror_voltage_with_set: SingleMirrorVoltage,
 ):
     def failed(*args, **kwargs):
         raise AssertionError("Test Failure")
 
-    vfm_mirror_voltages_with_set.voltage_channels[0]._setpoint_v.set = failed
+    mirror_voltage_with_set._setpoint_v.set = failed
 
     def plan():
         with pytest.raises(FailedStatus) as e:
-            yield from bps.abs_set(
-                vfm_mirror_voltages_with_set.voltage_channels[0], 100, wait=True
-            )
+            yield from bps.abs_set(mirror_voltage_with_set, 100, wait=True)
 
         assert isinstance(e.value.args[0].exception(), AssertionError)
 
@@ -205,12 +196,12 @@ def test_mirror_set_voltage_sets_and_waits_set_fail(
 
 
 def test_mirror_set_voltage_sets_and_waits_demand_accepted_fail(
-    RE: RunEngine, vfm_mirror_voltages_with_set_accepted_fail
+    RE: RunEngine, mirror_voltage_with_set_accepted_fail: SingleMirrorVoltage
 ):
     def plan():
         with pytest.raises(FailedStatus) as e:
             yield from bps.abs_set(
-                vfm_mirror_voltages_with_set_accepted_fail.voltage_channels[0],
+                mirror_voltage_with_set_accepted_fail,
                 100,
                 wait=True,
             )
@@ -223,12 +214,12 @@ def test_mirror_set_voltage_sets_and_waits_demand_accepted_fail(
 @patch("dodal.devices.focusing_mirror.DEFAULT_SETTLE_TIME_S", 3)
 def test_mirror_set_voltage_sets_and_waits_settle_timeout_expires(
     RE: RunEngine,
-    vfm_mirror_voltages_with_set_timing_out: VFMMirrorVoltages,
+    mirror_voltage_with_set_timing_out: SingleMirrorVoltage,
 ):
     def plan():
         with pytest.raises(Exception) as excinfo:
             yield from bps.abs_set(
-                vfm_mirror_voltages_with_set_timing_out.voltage_channels[0],
+                mirror_voltage_with_set_timing_out,
                 100,
                 wait=True,
             )
@@ -239,32 +230,30 @@ def test_mirror_set_voltage_sets_and_waits_settle_timeout_expires(
 
 def test_mirror_set_voltage_returns_immediately_if_voltage_already_demanded(
     RE: RunEngine,
-    vfm_mirror_voltages_with_set: VFMMirrorVoltages,
+    mirror_voltage_with_set: SingleMirrorVoltage,
 ):
-    set_mock_value(vfm_mirror_voltages_with_set.voltage_channels[0]._setpoint_v, 100)
+    set_mock_value(mirror_voltage_with_set._setpoint_v, 100)
 
     def plan():
-        yield from bps.abs_set(
-            vfm_mirror_voltages_with_set.voltage_channels[0], 100, wait=True
-        )
+        yield from bps.abs_set(mirror_voltage_with_set, 100, wait=True)
 
     RE(plan())
 
-    get_mock_put(
-        vfm_mirror_voltages_with_set.voltage_channels[0]._setpoint_v
-    ).assert_not_called()
+    get_mock_put(mirror_voltage_with_set._setpoint_v).assert_not_called()
 
 
-def test_mirror_populates_voltage_channels(
-    vfm_mirror_voltages_with_set: VFMMirrorVoltages,
+def test_mirror_populates_voltage_channels(RE):
+    with DeviceCollector(mock=True):
+        mirror_voltages = MirrorVoltages("", "", daq_configuration_path="")
+    assert len(mirror_voltages.horizontal_voltages) == 13
+    assert len(mirror_voltages.vertical_voltages) == 8
+    assert isinstance(mirror_voltages.horizontal_voltages[0], SingleMirrorVoltage)
+
+
+async def test_given_striped_focussing_mirror_then_energy_to_stripe_returns_expected(
+    RE,
 ):
-    channels = vfm_mirror_voltages_with_set.voltage_channels
-    assert len(channels) == 8
-    assert isinstance(channels[0], MirrorVoltageDevice)
-
-
-async def test_given_striped_focussing_mirror_then_energy_to_stripe_returns_expected():
-    device = FocusingMirrorWithStripes(prefix="-OP-VFM-01:", name="mirror")
-    await device.connect(mock=True)
+    with DeviceCollector(mock=True):
+        device = FocusingMirrorWithStripes(prefix="-OP-VFM-01:", name="mirror")
     assert device.energy_to_stripe(1) == MirrorStripe.BARE
     assert device.energy_to_stripe(14) == MirrorStripe.RHODIUM


### PR DESCRIPTION
See https://github.com/DiamondLightSource/mx-bluesky/issues/521

Also refactors the tests a bit to make it clearer what is under test

### Instructions to reviewer on how to test:
1. Confirm `dodal connect i03` passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
