### PR TITLE
Isolated device factory

### DIFF
--- a/docs/explanations/decisions/0003-make-devices-factory.md
+++ b/docs/explanations/decisions/0003-make-devices-factory.md
@@ -1,0 +1,28 @@
+# 3. Add device factory decorator with lazy connect support
+
+Date: 2024-04-26
+
+## Status
+
+Accepted
+
+## Context
+
+Device instances should be capable of being created without necessarily connecting, so long as they are connected prior to being utilised to collect data. The current method puts requirements on the init method of device classes, and does not expose all options for connecting to ophyd-async devices.
+
+## Decision
+
+DAQ members led us to this proposal:
+
+- ophyd-async: make Device.connect(mock, timeout, force=False) idempotent
+- ophyd-async: make ensure_connected(\*devices) plan stub
+- dodal: make device_factory() decorator that may construct, name, cache and connect a device
+- dodal: make get_device_factories() that returns all device factories
+- blueapi: call get_device_factories(), instantiate and connect Devices appropriately, log those that fail
+- blueapi: when plan is called, run ensure_connected on all plan args and defaults that are Devices
+
+We can then iterate on this if the parallel connect causes a broadcast storm. We could also in future add a monitor to a heartbeat PV per device in Device.connect so that it would reconnect next time it was called.
+
+## Consequences
+
+Beamlines will be converted to use the decorator, and default arguments to plans should be replaced with a non-eagerly connecting call to the initializer controlling device.

--- a/docs/explanations/decisions/0003-make-devices-factory.md
+++ b/docs/explanations/decisions/0003-make-devices-factory.md
@@ -17,8 +17,8 @@ DAQ members led us to this proposal:
 - ophyd-async: make Device.connect(mock, timeout, force=False) idempotent
 - ophyd-async: make ensure_connected(\*devices) plan stub
 - dodal: make device_factory() decorator that may construct, name, cache and connect a device
-- dodal: make get_device_factories() that returns all device factories
-- blueapi: call get_device_factories(), instantiate and connect Devices appropriately, log those that fail
+- dodal: collect_factories() returns all device factories
+- blueapi: call collect_factories(), instantiate and connect Devices appropriately, log those that fail
 - blueapi: when plan is called, run ensure_connected on all plan args and defaults that are Devices
 
 We can then iterate on this if the parallel connect causes a broadcast storm. We could also in future add a monitor to a heartbeat PV per device in Device.connect so that it would reconnect next time it was called.

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -10,6 +10,7 @@ from dodal.common.beamlines.beamline_utils import (
     set_path_provider,
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.beamlines.device_helpers import HDF5_PREFIX
 from dodal.common.visit import RemoteDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.i22.dcm import CrystalMetadata, DoubleCrystalMonochromator
@@ -57,7 +58,7 @@ def saxs() -> PilatusDetector:
         prefix=f"{PREFIX.beamline_prefix}-EA-PILAT-01:",
         path_provider=get_path_provider(),
         drv_suffix="CAM:",
-        hdf_suffix="HDF5:",
+        hdf_suffix=HDF5_PREFIX,
         metadata_holder=metadata_holder,
     )
 
@@ -82,7 +83,7 @@ def waxs() -> PilatusDetector:
         prefix=f"{PREFIX.beamline_prefix}-EA-PILAT-03:",
         path_provider=get_path_provider(),
         drv_suffix="CAM:",
-        hdf_suffix="HDF5:",
+        hdf_suffix=HDF5_PREFIX,
         metadata_holder=metadata_holder,
     )
 
@@ -108,14 +109,14 @@ def it() -> TetrammDetector:
 @device_factory()
 def vfm() -> FocusingMirror:
     return FocusingMirror(
-        f"{PREFIX.beamline_prefix}-OP-KBM-01:VFM:",
+        prefix=f"{PREFIX.beamline_prefix}-OP-KBM-01:VFM:",
     )
 
 
 @device_factory()
 def hfm() -> FocusingMirror:
     return FocusingMirror(
-        f"{PREFIX.beamline_prefix}|-OP-KBM-01:HFM:",
+        prefix=f"{PREFIX.beamline_prefix}|-OP-KBM-01:HFM:",
     )
 
 
@@ -144,7 +145,7 @@ def dcm() -> DoubleCrystalMonochromator:
 @device_factory()
 def undulator() -> Undulator:
     return Undulator(
-        f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
+        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
         id_gap_lookup_table_path="/dls_sw/i22/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
         poles=80,
         length=2.0,
@@ -153,38 +154,38 @@ def undulator() -> Undulator:
 
 @device_factory()
 def slits_1() -> Slits:
-    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-01:")
+    return Slits(prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-01:")
 
 
 @device_factory()
 def slits_2() -> Slits:
-    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-02:")
+    return Slits(prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-02:")
 
 
 @device_factory()
 def slits_3() -> Slits:
-    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-03:")
+    return Slits(prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-03:")
 
 
 @device_factory()
 def slits_4() -> Slits:
-    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-04:")
+    return Slits(prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-04:")
 
 
 @device_factory()
 def slits_5() -> Slits:
-    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-05:")
+    return Slits(prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-05:")
 
 
 @device_factory()
 def slits_6() -> Slits:
-    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-06:")
+    return Slits(prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-06:")
 
 
 @device_factory()
 def fswitch() -> FSwitch:
     return FSwitch(
-        f"{PREFIX.beamline_prefix}-MO-FSWT-01:",
+        prefix=f"{PREFIX.beamline_prefix}-MO-FSWT-01:",
         lens_geometry="paraboloid",
         cylindrical=True,
         lens_material="Beryllium",
@@ -196,7 +197,7 @@ def fswitch() -> FSwitch:
 @device_factory()
 def panda1() -> HDFPanda:
     return HDFPanda(
-        f"{PREFIX.beamline_prefix}-EA-PANDA-01:",
+        prefix=f"{PREFIX.beamline_prefix}-EA-PANDA-01:",
         path_provider=get_path_provider(),
     )
 
@@ -204,7 +205,7 @@ def panda1() -> HDFPanda:
 @device_factory(skip=True)
 def panda2() -> HDFPanda:
     return HDFPanda(
-        f"{PREFIX.beamline_prefix}-EA-PANDA-02:",
+        prefix=f"{PREFIX.beamline_prefix}-EA-PANDA-02:",
         path_provider=get_path_provider(),
     )
 
@@ -212,7 +213,7 @@ def panda2() -> HDFPanda:
 @device_factory(skip=True)
 def panda3() -> HDFPanda:
     return HDFPanda(
-        f"{PREFIX.beamline_prefix}-EA-PANDA-03:",
+        prefix=f"{PREFIX.beamline_prefix}-EA-PANDA-03:",
         path_provider=get_path_provider(),
     )
 
@@ -220,7 +221,7 @@ def panda3() -> HDFPanda:
 @device_factory(skip=True)
 def panda4() -> HDFPanda:
     return HDFPanda(
-        f"{PREFIX.beamline_prefix}-EA-PANDA-04:",
+        prefix=f"{PREFIX.beamline_prefix}-EA-PANDA-04:",
         path_provider=get_path_provider(),
     )
 
@@ -234,9 +235,9 @@ def oav() -> AravisDetector:
         distance=(-1.0, "m"),
     )
     return NXSasOAV(
-        prefix="",
+        prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:",
         drv_suffix="DET:",
-        hdf_suffix="HDF5:",
+        hdf_suffix=HDF5_PREFIX,
         path_provider=get_path_provider(),
         metadata_holder=metadata_holder,
     )
@@ -244,4 +245,4 @@ def oav() -> AravisDetector:
 
 @device_factory()
 def linkam() -> Linkam3:
-    return Linkam3(f"{PREFIX.beamline_prefix}-EA-TEMPC-05")
+    return Linkam3(prefix=f"{PREFIX.beamline_prefix}-EA-TEMPC-05")

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -92,7 +92,6 @@ def i0() -> TetrammDetector:
     return TetrammDetector(
         prefix=f"{PREFIX.beamline_prefix}-EA-XBPM-02:",
         path_provider=get_path_provider(),
-        name="",
         type="Cividec Diamond XBPM",
     )
 
@@ -102,7 +101,6 @@ def it() -> TetrammDetector:
     return TetrammDetector(
         prefix=f"{PREFIX.beamline_prefix}-EA-TTRM-02:",
         path_provider=get_path_provider(),
-        name="",
         type="PIN Diode",
     )
 
@@ -110,16 +108,14 @@ def it() -> TetrammDetector:
 @device_factory()
 def vfm() -> FocusingMirror:
     return FocusingMirror(
-        "",
-        prefix=f"{PREFIX.beamline_prefix}-OP-KBM-01:VFM:",
+        f"{PREFIX.beamline_prefix}-OP-KBM-01:VFM:",
     )
 
 
 @device_factory()
 def hfm() -> FocusingMirror:
     return FocusingMirror(
-        "",
-        prefix=f"{PREFIX.beamline_prefix}|-OP-KBM-01:HFM:",
+        f"{PREFIX.beamline_prefix}|-OP-KBM-01:HFM:",
     )
 
 
@@ -248,4 +244,4 @@ def oav() -> AravisDetector:
 
 @device_factory()
 def linkam() -> Linkam3:
-    return Linkam3(f"{PREFIX.beamline_prefix}-EA-TEMPC-05", "")
+    return Linkam3(f"{PREFIX.beamline_prefix}-EA-TEMPC-05")

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -5,12 +5,11 @@ from ophyd_async.epics.adpilatus import PilatusDetector
 from ophyd_async.fastcs.panda import HDFPanda
 
 from dodal.common.beamlines.beamline_utils import (
-    device_instantiation,
+    device_factory,
     get_path_provider,
     set_path_provider,
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.beamlines.device_helpers import numbered_slits
 from dodal.common.visit import RemoteDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.i22.dcm import CrystalMetadata, DoubleCrystalMonochromator
@@ -22,9 +21,10 @@ from dodal.devices.synchrotron import Synchrotron
 from dodal.devices.tetramm import TetrammDetector
 from dodal.devices.undulator import Undulator
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import BeamlinePrefix, get_beamline_name, skip_device
+from dodal.utils import BeamlinePrefix, get_beamline_name
 
 BL = get_beamline_name("i22")
+PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
 
@@ -42,243 +42,153 @@ set_path_provider(
 )
 
 
-def saxs(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> PilatusDetector:
-    return device_instantiation(
-        NXSasPilatus,
-        "saxs",
-        "-EA-PILAT-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory()
+def saxs() -> PilatusDetector:
+    metadata_holder = NXSasMetadataHolder(
+        x_pixel_size=(1.72e-1, "mm"),
+        y_pixel_size=(1.72e-1, "mm"),
+        description="Dectris Pilatus3 2M",
+        type="Photon Counting Hybrid Pixel",
+        sensor_material="silicon",
+        sensor_thickness=(0.45, "mm"),
+        distance=(4711.833684146172, "mm"),
+    )
+    return NXSasPilatus(
+        prefix=f"{PREFIX.beamline_prefix}-EA-PILAT-01:",
+        path_provider=get_path_provider(),
         drv_suffix="CAM:",
         hdf_suffix="HDF5:",
-        metadata_holder=NXSasMetadataHolder(
-            x_pixel_size=(1.72e-1, "mm"),
-            y_pixel_size=(1.72e-1, "mm"),
-            description="Dectris Pilatus3 2M",
-            type="Photon Counting Hybrid Pixel",
-            sensor_material="silicon",
-            sensor_thickness=(0.45, "mm"),
-            distance=(4711.833684146172, "mm"),
-        ),
+        metadata_holder=metadata_holder,
+    )
+
+
+@device_factory()
+def synchrotron() -> Synchrotron:
+    return Synchrotron()
+
+
+@device_factory()
+def waxs() -> PilatusDetector:
+    metadata_holder = NXSasMetadataHolder(
+        x_pixel_size=(1.72e-1, "mm"),
+        y_pixel_size=(1.72e-1, "mm"),
+        description="Dectris Pilatus3 2M",
+        type="Photon Counting Hybrid Pixel",
+        sensor_material="silicon",
+        sensor_thickness=(0.45, "mm"),
+        distance=(175.4199417092314, "mm"),
+    )
+    return NXSasPilatus(
+        prefix=f"{PREFIX.beamline_prefix}-EA-PILAT-03:",
         path_provider=get_path_provider(),
-    )
-
-
-def synchrotron(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Synchrotron:
-    return device_instantiation(
-        Synchrotron,
-        "synchrotron",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
-
-
-def waxs(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> PilatusDetector:
-    return device_instantiation(
-        NXSasPilatus,
-        "waxs",
-        "-EA-PILAT-03:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
         drv_suffix="CAM:",
         hdf_suffix="HDF5:",
-        metadata_holder=NXSasMetadataHolder(
-            x_pixel_size=(1.72e-1, "mm"),
-            y_pixel_size=(1.72e-1, "mm"),
-            description="Dectris Pilatus3 2M",
-            type="Photon Counting Hybrid Pixel",
-            sensor_material="silicon",
-            sensor_thickness=(0.45, "mm"),
-            distance=(175.4199417092314, "mm"),
-        ),
-        path_provider=get_path_provider(),
+        metadata_holder=metadata_holder,
     )
 
 
-def i0(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> TetrammDetector:
-    return device_instantiation(
-        TetrammDetector,
-        "i0",
-        "-EA-XBPM-02:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory()
+def i0() -> TetrammDetector:
+    return TetrammDetector(
+        prefix=f"{PREFIX.beamline_prefix}-EA-XBPM-02:",
+        path_provider=get_path_provider(),
+        name="",
         type="Cividec Diamond XBPM",
-        path_provider=get_path_provider(),
     )
 
 
-def it(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> TetrammDetector:
-    return device_instantiation(
-        TetrammDetector,
-        "it",
-        "-EA-TTRM-02:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory()
+def it() -> TetrammDetector:
+    return TetrammDetector(
+        prefix=f"{PREFIX.beamline_prefix}-EA-TTRM-02:",
+        path_provider=get_path_provider(),
+        name="",
         type="PIN Diode",
-        path_provider=get_path_provider(),
     )
 
 
-def vfm(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> FocusingMirror:
-    return device_instantiation(
-        FocusingMirror,
-        "vfm",
-        "-OP-KBM-01:VFM:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
-
-
-def hfm(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> FocusingMirror:
-    return device_instantiation(
-        FocusingMirror,
-        "hfm",
-        "-OP-KBM-01:HFM:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
-
-
-def dcm(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> DoubleCrystalMonochromator:
-    return device_instantiation(
-        DoubleCrystalMonochromator,
-        "dcm",
+@device_factory()
+def vfm() -> FocusingMirror:
+    return FocusingMirror(
         "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-        bl_prefix=False,
-        motion_prefix=f"{BeamlinePrefix(BL).beamline_prefix}-MO-DCM-01:",
-        temperature_prefix=f"{BeamlinePrefix(BL).beamline_prefix}-DI-DCM-01:",
-        crystal_1_metadata=CrystalMetadata(
-            usage="Bragg",
-            type="silicon",
-            reflection=(1, 1, 1),
-            d_spacing=(3.13475, "nm"),
-        ),
-        crystal_2_metadata=CrystalMetadata(
-            usage="Bragg",
-            type="silicon",
-            reflection=(1, 1, 1),
-            d_spacing=(3.13475, "nm"),
-        ),
+        prefix=f"{PREFIX.beamline_prefix}-OP-KBM-01:VFM:",
     )
 
 
-def undulator(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> Undulator:
-    return device_instantiation(
-        Undulator,
-        "undulator",
-        f"{BeamlinePrefix(BL).insertion_prefix}-MO-SERVC-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-        bl_prefix=False,
+@device_factory()
+def hfm() -> FocusingMirror:
+    return FocusingMirror(
+        "",
+        prefix=f"{PREFIX.beamline_prefix}|-OP-KBM-01:HFM:",
+    )
+
+
+@device_factory()
+def dcm() -> DoubleCrystalMonochromator:
+    crystal_1_metadata = CrystalMetadata(
+        usage="Bragg",
+        type="silicon",
+        reflection=(1, 1, 1),
+        d_spacing=(3.13475, "nm"),
+    )
+    crystal_2_metadata = CrystalMetadata(
+        usage="Bragg",
+        type="silicon",
+        reflection=(1, 1, 1),
+        d_spacing=(3.13475, "nm"),
+    )
+    return DoubleCrystalMonochromator(
+        motion_prefix=f"{PREFIX.beamline_prefix}-MO-DCM-01:",
+        temperature_prefix=f"{PREFIX.beamline_prefix}-DI-DCM-01:",
+        crystal_1_metadata=crystal_1_metadata,
+        crystal_2_metadata=crystal_2_metadata,
+    )
+
+
+@device_factory()
+def undulator() -> Undulator:
+    return Undulator(
+        f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
+        id_gap_lookup_table_path="/dls_sw/i22/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
         poles=80,
         length=2.0,
-        id_gap_lookup_table_path="/dls_sw/i22/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
     )
 
 
-def slits_1(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> Slits:
-    return numbered_slits(
-        1,
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def slits_1() -> Slits:
+    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-01:")
 
 
-def slits_2(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> Slits:
-    return numbered_slits(
-        2,
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def slits_2() -> Slits:
+    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-02:")
 
 
-def slits_3(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> Slits:
-    return numbered_slits(
-        3,
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def slits_3() -> Slits:
+    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-03:")
 
 
-def slits_4(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> Slits:
-    return numbered_slits(
-        4,
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def slits_4() -> Slits:
+    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-04:")
 
 
-def slits_5(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> Slits:
-    return numbered_slits(
-        5,
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def slits_5() -> Slits:
+    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-05:")
 
 
-def slits_6(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> Slits:
-    return numbered_slits(
-        6,
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def slits_6() -> Slits:
+    return Slits(f"{PREFIX.beamline_prefix}-AL-SLITS-06:")
 
 
-def fswitch(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> FSwitch:
-    return device_instantiation(
-        FSwitch,
-        "fswitch",
-        "-MO-FSWT-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory()
+def fswitch() -> FSwitch:
+    return FSwitch(
+        f"{PREFIX.beamline_prefix}-MO-FSWT-01:",
         lens_geometry="paraboloid",
         cylindrical=True,
         lens_material="Beryllium",
@@ -287,94 +197,55 @@ def fswitch(
 
 # Must document what PandAs are physically connected to
 # See: https://github.com/bluesky/ophyd-async/issues/284
-def panda1(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> HDFPanda:
-    return device_instantiation(
-        HDFPanda,
-        "panda1",
-        "-EA-PANDA-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory()
+def panda1() -> HDFPanda:
+    return HDFPanda(
+        f"{PREFIX.beamline_prefix}-EA-PANDA-01:",
         path_provider=get_path_provider(),
     )
 
 
-@skip_device()
-def panda2(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> HDFPanda:
-    return device_instantiation(
-        HDFPanda,
-        "panda2",
-        "-EA-PANDA-02:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory(skip=True)
+def panda2() -> HDFPanda:
+    return HDFPanda(
+        f"{PREFIX.beamline_prefix}-EA-PANDA-02:",
         path_provider=get_path_provider(),
     )
 
 
-@skip_device()
-def panda3(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> HDFPanda:
-    return device_instantiation(
-        HDFPanda,
-        "panda3",
-        "-EA-PANDA-03:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory(skip=True)
+def panda3() -> HDFPanda:
+    return HDFPanda(
+        f"{PREFIX.beamline_prefix}-EA-PANDA-03:",
         path_provider=get_path_provider(),
     )
 
 
-@skip_device()
-def panda4(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> HDFPanda:
-    return device_instantiation(
-        HDFPanda,
-        "panda4",
-        "-EA-PANDA-04:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory(skip=True)
+def panda4() -> HDFPanda:
+    return HDFPanda(
+        f"{PREFIX.beamline_prefix}-EA-PANDA-04:",
         path_provider=get_path_provider(),
     )
 
 
-def oav(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> AravisDetector:
-    return device_instantiation(
-        NXSasOAV,
-        "oav",
-        "-DI-OAV-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+@device_factory()
+def oav() -> AravisDetector:
+    metadata_holder = NXSasMetadataHolder(
+        x_pixel_size=(3.45e-3, "mm"),  # Double check this figure
+        y_pixel_size=(3.45e-3, "mm"),
+        description="AVT Mako G-507B",
+        distance=(-1.0, "m"),
+    )
+    return NXSasOAV(
+        prefix="",
         drv_suffix="DET:",
         hdf_suffix="HDF5:",
-        metadata_holder=NXSasMetadataHolder(
-            x_pixel_size=(3.45e-3, "mm"),  # Double check this figure
-            y_pixel_size=(3.45e-3, "mm"),
-            description="AVT Mako G-507B",
-            distance=(-1.0, "m"),
-        ),
         path_provider=get_path_provider(),
+        metadata_holder=metadata_holder,
     )
 
 
-@skip_device()
-def linkam(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Linkam3:
-    return device_instantiation(
-        Linkam3,
-        "linkam",
-        "-EA-TEMPC-05",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def linkam() -> Linkam3:
+    return Linkam3(f"{PREFIX.beamline_prefix}-EA-TEMPC-05", "")

--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -1,7 +1,6 @@
 import inspect
 from collections.abc import Callable
-from functools import update_wrapper
-from typing import Annotated, Final, Generic, TypeVar, cast
+from typing import Annotated, Final, TypeVar, cast
 
 from bluesky.run_engine import call_in_bluesky_event_loop
 from ophyd import Device as OphydV1Device
@@ -11,7 +10,14 @@ from ophyd_async.core import Device as OphydV2Device
 from ophyd_async.core import wait_for_connection as v2_device_wait_for_connection
 
 from dodal.common.types import UpdatingPathProvider
-from dodal.utils import AnyDevice, BeamlinePrefix, skip_device
+from dodal.utils import (
+    AnyDevice,
+    BeamlinePrefix,
+    D,
+    DeviceInitializationController,
+    skip,
+    skip_device,
+)
 
 DEFAULT_CONNECTION_TIMEOUT: Final[float] = 5.0
 
@@ -127,69 +133,11 @@ def device_instantiation(
     return device_instance
 
 
-D = TypeVar("D", bound=OphydV2Device)
-_skip = bool | Callable[[], bool]
+def _cache_device(name: str) -> Callable[[OphydV2Device], None]:
+    def cache_device(device: OphydV2Device):
+        ACTIVE_DEVICES[name] = device
 
-
-class DeviceInitializationController(Generic[D]):
-    def __init__(
-        self,
-        factory: Callable[[], D],
-        eager_connect: bool,
-        use_factory_name: bool,
-        timeout: float,
-        mock: bool,
-        skip: _skip,
-    ):
-        self._factory: Callable[[], D] = factory
-        self._cached_device: D | None = None
-        self._eager_connect = eager_connect
-        self._use_factory_name = use_factory_name
-        self._timeout = timeout
-        self._mock = mock
-        self._skip = skip
-        update_wrapper(self, factory)
-
-    @property
-    def skip(self) -> bool:
-        return self._skip() if callable(self._skip) else self._skip
-
-    @property
-    def device(self) -> D | None:
-        return self._cached_device
-
-    def __call__(
-        self,
-        connect: bool | None = None,
-        name: str | None = None,
-        timeout: float | None = None,
-        mock: bool | None = None,
-    ) -> D:
-        if self.device is not None:
-            device = self.device
-        else:
-            device = self._factory()
-
-        if name:
-            device.set_name(name)
-        elif not device.name and self._use_factory_name:
-            device.set_name(self._factory.__name__)
-
-        if connect or connect is None and self._eager_connect:
-            call_in_bluesky_event_loop(
-                device.connect(
-                    timeout=timeout if timeout is not None else self._timeout,
-                    mock=mock if mock is not None else self._mock,
-                )
-            )
-
-        self._cache_device(device)
-        return device
-
-    def _cache_device(self, device: D):
-        if device.name:
-            ACTIVE_DEVICES[device.name] = device
-        self._cached_device = device
+    return cache_device
 
 
 def device_factory(
@@ -199,14 +147,16 @@ def device_factory(
     timeout: Annotated[float, "Timeout for connecting to the device"] = DEFAULT_TIMEOUT,
     mock: Annotated[bool, "Use Signals with mock backends for device"] = False,
     skip: Annotated[
-        _skip,
+        skip,
         "mark the factory to be (conditionally) skipped when beamline is imported by external program",
     ] = False,
 ) -> Callable[[Callable[[], D]], DeviceInitializationController[D]]:
     def decorator(factory: Callable[[], D]) -> DeviceInitializationController[D]:
-        return DeviceInitializationController(
+        controller = DeviceInitializationController(
             factory, eager_connect, use_factory_name, timeout, mock, skip
         )
+        controller.add_callback(_cache_device(factory.__name__))
+        return controller
 
     return decorator
 

--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -1,5 +1,6 @@
 import inspect
 from collections.abc import Callable
+from functools import update_wrapper
 from typing import Annotated, Final, Generic, TypeVar, cast
 
 from bluesky.run_engine import call_in_bluesky_event_loop
@@ -147,6 +148,7 @@ class DeviceInitializationController(Generic[D]):
         self._timeout = timeout
         self._mock = mock
         self._skip = skip
+        update_wrapper(self, factory)
 
     @property
     def skip(self) -> bool:

--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -15,8 +15,8 @@ from dodal.utils import (
     BeamlinePrefix,
     D,
     DeviceInitializationController,
+    SkipType,
     skip_device,
-    skip_type,
 )
 
 DEFAULT_CONNECTION_TIMEOUT: Final[float] = 5.0
@@ -147,7 +147,7 @@ def device_factory(
     timeout: Annotated[float, "Timeout for connecting to the device"] = DEFAULT_TIMEOUT,
     mock: Annotated[bool, "Use Signals with mock backends for device"] = False,
     skip: Annotated[
-        skip_type,
+        SkipType,
         "mark the factory to be (conditionally) skipped when beamline is imported by external program",
     ] = False,
 ) -> Callable[[Callable[[], D]], DeviceInitializationController[D]]:

--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -15,8 +15,8 @@ from dodal.utils import (
     BeamlinePrefix,
     D,
     DeviceInitializationController,
-    skip,
     skip_device,
+    skip_type,
 )
 
 DEFAULT_CONNECTION_TIMEOUT: Final[float] = 5.0
@@ -147,7 +147,7 @@ def device_factory(
     timeout: Annotated[float, "Timeout for connecting to the device"] = DEFAULT_TIMEOUT,
     mock: Annotated[bool, "Use Signals with mock backends for device"] = False,
     skip: Annotated[
-        skip,
+        skip_type,
         "mark the factory to be (conditionally) skipped when beamline is imported by external program",
     ] = False,
 ) -> Callable[[Callable[[], D]], DeviceInitializationController[D]]:

--- a/src/dodal/common/beamlines/device_helpers.py
+++ b/src/dodal/common/beamlines/device_helpers.py
@@ -2,6 +2,8 @@ from dodal.common.beamlines.beamline_utils import device_instantiation
 from dodal.devices.slits import Slits
 from dodal.utils import skip_device
 
+HDF5_PREFIX = "HDF5:"
+
 
 @skip_device()
 def numbered_slits(

--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -164,7 +164,7 @@ class FocusingMirrorWithStripes(FocusingMirror):
         # apply the current set stripe setting
         self.apply_stripe = epics_signal_x(prefix + "CHANGE.PROC")
 
-        super().__init__(name, prefix, *args, **kwargs)
+        super().__init__(prefix, name, *args, **kwargs)
 
     def energy_to_stripe(self, energy_kev) -> MirrorStripe:
         # In future, this should be configurable per-mirror

--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -126,7 +126,12 @@ class FocusingMirror(StandardReadable):
     """Focusing Mirror"""
 
     def __init__(
-        self, name, prefix, bragg_to_lat_lut_path=None, x_suffix="X", y_suffix="Y"
+        self,
+        prefix: str,
+        name: str = "",
+        bragg_to_lat_lut_path: str | None = None,
+        x_suffix: str = "X",
+        y_suffix: str = "Y",
     ):
         self.bragg_to_lat_lookup_table_path = bragg_to_lat_lut_path
         self.yaw_mrad = Motor(prefix + "YAW")
@@ -154,7 +159,7 @@ class FocusingMirrorWithStripes(FocusingMirror):
     """A focusing mirror where the stripe material can be changed. This is usually done
     based on the energy of the beamline."""
 
-    def __init__(self, name, prefix, *args, **kwargs):
+    def __init__(self, prefix: str, name: str = "", *args, **kwargs):
         self.stripe = epics_signal_rw(MirrorStripe, prefix + "STRP:DVAL")
         # apply the current set stripe setting
         self.apply_stripe = epics_signal_x(prefix + "CHANGE.PROC")

--- a/src/dodal/devices/i22/dcm.py
+++ b/src/dodal/devices/i22/dcm.py
@@ -43,7 +43,6 @@ class DoubleCrystalMonochromator(StandardReadable):
         temperature_prefix: str,
         crystal_1_metadata: CrystalMetadata | None = None,
         crystal_2_metadata: CrystalMetadata | None = None,
-        prefix: str = "",
         name: str = "",
     ) -> None:
         with self.add_children_as_readables():

--- a/src/dodal/devices/linkam3.py
+++ b/src/dodal/devices/linkam3.py
@@ -34,7 +34,7 @@ class Linkam3(StandardReadable):
     tolerance: float = 0.5
     settle_time: int = 0
 
-    def __init__(self, prefix: str, name: str):
+    def __init__(self, prefix: str, name: str = ""):
         self.temp = epics_signal_r(float, prefix + "TEMP:")
         self.dsc = epics_signal_r(float, prefix + "DSC:")
         self.start_heat = epics_signal_rw(bool, prefix + "STARTHEAT:")

--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -219,7 +219,7 @@ class TetrammDetector(StandardDetector):
         self,
         prefix: str,
         path_provider: PathProvider,
-        name: str,
+        name: str = "",
         type: str | None = None,
         **scalar_sigs: str,
     ) -> None:

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -309,6 +309,16 @@ def extract_dependencies(
             yield name
 
 
+def get_device_factories(
+    module: ModuleType,
+) -> dict[str, DeviceInitializationController]:
+    return {
+        name: controller
+        for name, controller in module.__dict__.items()
+        if isinstance(controller, DeviceInitializationController)
+    }
+
+
 def collect_factories(
     module: ModuleType, include_skipped: bool = False
 ) -> dict[str, AnyDeviceFactory]:

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -98,7 +98,7 @@ class BeamlinePrefix:
 
 T = TypeVar("T", bound=AnyDevice)
 D = TypeVar("D", bound=OphydV2Device)
-skip_type = bool | Callable[[], bool]
+SkipType = bool | Callable[[], bool]
 
 
 def skip_device(precondition=lambda: True):
@@ -122,7 +122,7 @@ class DeviceInitializationController(Generic[D]):
         use_factory_name: bool,
         timeout: float,
         mock: bool,
-        skip: skip_type,
+        skip: SkipType,
     ):
         self._factory: Callable[[], D] = factory
         self._cached_device: D | None = None
@@ -155,6 +155,9 @@ class DeviceInitializationController(Generic[D]):
         """Returns an instance of the Device the wrapped factory produces: the same
         instance will be returned if this method is called multiple times, and arguments
         may be passed to override this Controller's configuration.
+        Once the device is connected, the value of mock must be consistent, or connect
+        must be False.
+
 
         Args:
             connect_immediately (bool | None, optional): whether to call connect on the
@@ -174,7 +177,8 @@ class DeviceInitializationController(Generic[D]):
               ophyd_async's DEFAULT_TIMEOUT.
             mock (bool | None, optional): overrides whether to connect to Mock signal
               backends, if connect is called. Defaults to None, which uses the mock
-              parameter of this Controller.
+              parameter of this Controller. This value must be used consistently when
+              connect is called on the Device.
 
         Returns:
             D: a singleton instance of the Device class returned by the wrapped factory.

--- a/tests/fake_device_factory_beamline.py
+++ b/tests/fake_device_factory_beamline.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+from bluesky.protocols import Readable
+from ophyd_async.core import Device
+
+from dodal.common.beamlines.beamline_utils import device_factory
+from dodal.devices.cryostream import CryoStream
+
+
+class ReadableDevice(Readable, Device): ...
+
+
+@device_factory(skip=True, eager_connect=False)
+def device_a() -> ReadableDevice:
+    return _mock_with_name("readable")
+
+
+@device_factory(skip=lambda: True, eager_connect=False)
+def device_c() -> CryoStream:
+    return _mock_with_name("cryo")
+
+
+def _mock_with_name(name: str) -> MagicMock:
+    mock = MagicMock()
+    mock.name = name
+    return mock

--- a/tests/fake_device_factory_beamline.py
+++ b/tests/fake_device_factory_beamline.py
@@ -1,26 +1,24 @@
-from unittest.mock import MagicMock
-
-from bluesky.protocols import Readable
+from bluesky.protocols import Readable, Reading, SyncOrAsync
+from event_model.documents.event_descriptor import DataKey
 from ophyd_async.core import Device
 
 from dodal.common.beamlines.beamline_utils import device_factory
 from dodal.devices.cryostream import CryoStream
 
 
-class ReadableDevice(Readable, Device): ...
+class ReadableDevice(Readable, Device):
+    def read(self) -> SyncOrAsync[dict[str, Reading]]:
+        return {}
+
+    def describe(self) -> SyncOrAsync[dict[str, DataKey]]:
+        return {}
 
 
 @device_factory(skip=True, eager_connect=False)
 def device_a() -> ReadableDevice:
-    return _mock_with_name("readable")
+    return ReadableDevice("readable")
 
 
 @device_factory(skip=lambda: True, eager_connect=False)
 def device_c() -> CryoStream:
-    return _mock_with_name("cryo")
-
-
-def _mock_with_name(name: str) -> MagicMock:
-    mock = MagicMock()
-    mock.name = name
-    return mock
+    return CryoStream("FOO:")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,6 +131,22 @@ def test_make_device_dependency_throws():
         make_device(fake_beamline, "device_z")
 
 
+def test_device_factory_skips():
+    import tests.fake_device_factory_beamline as fake_beamline
+
+    devices, exceptions = make_all_devices(fake_beamline)
+    assert len(devices) == 0
+    assert len(exceptions) == 0
+
+
+def test_device_factory_can_ignore_skip():
+    import tests.fake_device_factory_beamline as fake_beamline
+
+    devices, exceptions = make_all_devices(fake_beamline, include_skipped=True)
+    assert len(devices) == 2
+    assert len(exceptions) == 0
+
+
 def device_a() -> Readable:
     return MagicMock()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,6 +147,17 @@ def test_device_factory_can_ignore_skip():
     assert len(exceptions) == 0
 
 
+def test_device_factory_can_rename(RE):
+    from tests.fake_device_factory_beamline import device_c
+
+    cryo = device_c(mock=True, connect_immediately=True)
+    assert cryo.name == "device_c"
+    assert cryo.fine.name == "device_c-fine"
+    device_c(name="cryo")
+    assert cryo.name == "cryo"
+    assert cryo.fine.name == "cryo-fine"
+
+
 def device_a() -> Readable:
     return MagicMock()
 


### PR DESCRIPTION
Fixes #483 

This is a re-implementation of #597 isolated to just the changes necessary to implement the `@device_factory()` decorator and have functions decorated with that decorator picked up by `make_all_devices`: respecting any configuration passed into the decorator.

NB: this is also required for [blueapi #647](https://github.com/DiamondLightSource/blueapi/issues/647)

### Instructions to reviewer on how to test:
1. System test the i22 beamline to ensure that devices are instantiated, connected and named appropriately.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
