### PR TITLE
Prevent simulated connect from trying to connect to real devices on i22

### DIFF
--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -305,7 +305,10 @@ def invoke_factories(
             if isinstance(factory, DeviceInitializationController):
                 # replace with an arg
                 # https://github.com/DiamondLightSource/dodal/issues/844
-                devices[dependent_name] = factory(mock=kwargs.get("mock", False))
+                devices[dependent_name] = factory(
+                    mock=kwargs.get("mock", False)
+                    or kwargs.get("fake_with_ophyd_sim", False)
+                )
             else:
                 devices[dependent_name] = factory(**params, **kwargs)
         except Exception as e:


### PR DESCRIPTION
Fixes #848, #847

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
