### PR TITLE
Catch device creation exceptions in test_device_instantiation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from ophyd.status import Status
 from ophyd_async.core import (
+    NotConnected,
     PathInfo,
     PathProvider,
 )
@@ -65,11 +66,13 @@ def module_and_devices_for_beamline(request):
         bl_mod = importlib.import_module("dodal.beamlines." + beamline)
         importlib.reload(bl_mod)
         mock_beamline_module_filepaths(beamline, bl_mod)
-        devices, _ = make_all_devices(
+        devices, exceptions = make_all_devices(
             bl_mod,
             include_skipped=True,
             fake_with_ophyd_sim=True,
         )
+        if len(exceptions) > 0:
+            raise NotConnected(exceptions)
         yield (bl_mod, devices)
         beamline_utils.clear_devices()
         del bl_mod


### PR DESCRIPTION
Fixes #850 

### Instructions to reviewer on how to test:
1. Run unit tests
2. Break a device and confirm tests fail

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
