### PR TITLE
Fix p38 init call

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -146,7 +146,7 @@ def dcm() -> DoubleCrystalMonochromator:
 def undulator() -> Undulator:
     return Undulator(
         prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
-        id_gap_lookup_table_path="/dls_sw/i22/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
+        id_gap_lookup_table_path="/dev/null",
         poles=80,
         length=2.0,
     )

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -146,7 +146,6 @@ def dcm() -> DoubleCrystalMonochromator:
 def undulator() -> Undulator:
     return Undulator(
         prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
-        id_gap_lookup_table_path="/dev/null",
         poles=80,
         length=2.0,
     )

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -200,7 +200,6 @@ def dcm() -> DoubleCrystalMonochromator:
 def undulator() -> Undulator:
     return Undulator(
         prefix=f"{BeamlinePrefix(BL).insertion_prefix}-MO-SERVC-01:",
-        id_gap_lookup_table_path="/dev/null",
         poles=80,
         length=2.0,
     )

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum
 
 import numpy as np
@@ -54,7 +55,7 @@ class Undulator(StandardReadable, Movable):
     def __init__(
         self,
         prefix: str,
-        id_gap_lookup_table_path: str,
+        id_gap_lookup_table_path: str = os.devnull,
         name: str = "",
         poles: int | None = None,
         length: float | None = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from ophyd.status import Status
 from ophyd_async.core import (
+    NotConnected,
     PathInfo,
     PathProvider,
 )
@@ -65,11 +66,13 @@ def module_and_devices_for_beamline(request):
         bl_mod = importlib.import_module("dodal.beamlines." + beamline)
         importlib.reload(bl_mod)
         mock_beamline_module_filepaths(beamline, bl_mod)
-        devices, _ = make_all_devices(
+        devices, exceptions = make_all_devices(
             bl_mod,
             include_skipped=True,
             fake_with_ophyd_sim=True,
         )
+        if len(exceptions) > 0:
+            raise NotConnected(exceptions)
         yield (bl_mod, devices)
         beamline_utils.clear_devices()
         del bl_mod


### PR DESCRIPTION
Fixes an issue with p38 that was discovered in debugging #850 
Prevents further issues with constructors not reflecting changes to the device class by switching that beamline to @device_factory.
As #706 added functionality to the Undulator that is not required/used on i22 and p38, switched those devices to fetch a blank lookup table (functionally identical to what was set for i22) that should be available regardless of the DLS filesystem.

### Instructions to reviewer on how to test:
1. Ensure that p38 connect test with mock devices has no exceptions

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
