### PR TITLE
Add deprecation warning to inject

### DIFF
--- a/docs/how-to/include-devices-in-plans.md
+++ b/docs/how-to/include-devices-in-plans.md
@@ -1,0 +1,60 @@
+# Include Devices in Plans
+
+There are three main ways to include dodal devices in plans
+
+## 1. Pass as Argument
+
+```python
+import bluesky.plans as bp
+
+from bluesky.protocols import Readable
+from bluesky.utils import MsgGenerator
+from dodal.beamlines import i22
+
+def my_plan(detector: Readable) -> MsgGenerator:
+    yield from bp.count([detector])
+
+RE(my_plan(i22.saxs()))
+```
+
+This is useful for generic plans that can run on a variety of devices and are not designed with any specific device in mind.
+
+## 2. Pass as Default Argument
+
+```python
+import bluesky.plans as bp
+
+from bluesky.protocols import Readable
+from bluesky.utils import MsgGenerator
+from dodal.beamlines import i22
+
+def my_plan(detector: Readable = i22.saxs(connect_immediately=False)) -> MsgGenerator:
+    yield from bp.count([detector])
+
+RE(my_plan()))
+```
+
+This is useful for plans that will usually, but not exclusively, use the same device.
+
+## 3. Instantiate Within the Plan
+
+```python
+import bluesky.plans as bp
+import ophyd_async.plan_stubs as ops
+
+from bluesky.protocols import Readable
+from bluesky.utils import MsgGenerator
+from dodal.beamlines import i22
+
+def my_plan() -> MsgGenerator:
+    detector = i22.saxs(connect_immediately=False)
+    # We need to connect via the stub instead of directly 
+    # so that the RunEngine performs the connection in the
+    # correct event loop
+    yield from ops.ensure_connected(detector)
+    yield from bp.count([detector])
+
+RE(my_plan()))
+```
+
+This is useful for plans that are designed to only ever work with a specific device.

--- a/docs/how-to/include-devices-in-plans.md
+++ b/docs/how-to/include-devices-in-plans.md
@@ -1,6 +1,6 @@
 # Include Devices in Plans
 
-There are three main ways to include dodal devices in plans
+There are two main ways to include dodal devices in plans
 
 ## 1. Pass as Argument
 
@@ -34,27 +34,4 @@ def my_plan(detector: Readable = i22.saxs(connect_immediately=False)) -> MsgGene
 RE(my_plan()))
 ```
 
-This is useful for plans that will usually, but not exclusively, use the same device.
-
-## 3. Instantiate Within the Plan
-
-```python
-import bluesky.plans as bp
-import ophyd_async.plan_stubs as ops
-
-from bluesky.protocols import Readable
-from bluesky.utils import MsgGenerator
-from dodal.beamlines import i22
-
-def my_plan() -> MsgGenerator:
-    detector = i22.saxs(connect_immediately=False)
-    # We need to connect via the stub instead of directly 
-    # so that the RunEngine performs the connection in the
-    # correct event loop
-    yield from ops.ensure_connected(detector)
-    yield from bp.count([detector])
-
-RE(my_plan()))
-```
-
-This is useful for plans that are designed to only ever work with a specific device.
+This is useful for plans that will usually, but not exclusively, use the same device or that are designed to only ever work with a specific device.

--- a/src/dodal/common/coordination.py
+++ b/src/dodal/common/coordination.py
@@ -1,4 +1,6 @@
 import uuid
+import warnings
+from textwrap import dedent
 from typing import Any
 
 from dodal.common.types import Group
@@ -37,4 +39,20 @@ def inject(name: str) -> Any:  # type: ignore
 
     """
 
+    warnings.warn(
+        dedent("""
+        Inject is deprecated, users are now expected to call the device factory 
+        functions in dodal directly, these will cache devices as singletons after
+        they have been called once. For example:
+
+        import i22
+
+        + def my_plan(detector: Readable = i22.saxs()) -> MsgGenerator:
+            ...
+
+        Where previously the default would have been inject("saxs")
+        """),
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return name

--- a/src/dodal/common/coordination.py
+++ b/src/dodal/common/coordination.py
@@ -41,7 +41,7 @@ def inject(name: str) -> Any:  # type: ignore
 
     warnings.warn(
         dedent("""
-        Inject is deprecated, users are now expected to call the device factory 
+        Inject is deprecated, users are now expected to call the device factory
         functions in dodal directly, these will cache devices as singletons after
         they have been called once. For example:
 

--- a/src/dodal/common/coordination.py
+++ b/src/dodal/common/coordination.py
@@ -45,9 +45,11 @@ def inject(name: str) -> Any:  # type: ignore
         functions in dodal directly, these will cache devices as singletons after
         they have been called once. For example:
 
-        import i22
+        from bluesky.protocols import Readable
+        from bluesky.utils import MsgGenerator
+        from dodal.beamlines import i22
 
-        + def my_plan(detector: Readable = i22.saxs()) -> MsgGenerator:
+        def my_plan(detector: Readable = i22.saxs(connect_immediately=False)) -> MsgGenerator:
             ...
 
         Where previously the default would have been inject("saxs")

--- a/tests/common/test_coordination.py
+++ b/tests/common/test_coordination.py
@@ -16,17 +16,21 @@ def test_group_uid(group: str):
     assert not gid.endswith(f"{group}-")
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_inject_returns_value():
+    assert inject("foo") == "foo"
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_type_checking_ignores_inject():
-    with pytest.raises(DeprecationWarning):
+    def example_function(x: Movable = inject("foo")) -> MsgGenerator:  # noqa: B008
+        yield from {}
 
-        def example_function(x: Movable = inject("foo")) -> MsgGenerator:  # noqa: B008
-            yield from {}
-
-        # These asserts are sanity checks
-        # the real test is whether this test passes type checking
-        x: Parameter = signature(example_function).parameters["x"]
-        assert x.annotation == Movable
-        assert x.default == "foo"
+    # These asserts are sanity checks
+    # the real test is whether this test passes type checking
+    x: Parameter = signature(example_function).parameters["x"]
+    assert x.annotation == Movable
+    assert x.default == "foo"
 
 
 def test_inject_is_deprecated():

--- a/tests/common/test_coordination.py
+++ b/tests/common/test_coordination.py
@@ -17,11 +17,23 @@ def test_group_uid(group: str):
 
 
 def test_type_checking_ignores_inject():
-    def example_function(x: Movable = inject("foo")) -> MsgGenerator:  # noqa: B008
-        yield from {}
+    with pytest.raises(DeprecationWarning):
 
-    # These asserts are sanity checks
-    # the real test is whether this test passes type checking
-    x: Parameter = signature(example_function).parameters["x"]
-    assert x.annotation == Movable
-    assert x.default == "foo"
+        def example_function(x: Movable = inject("foo")) -> MsgGenerator:  # noqa: B008
+            yield from {}
+
+        # These asserts are sanity checks
+        # the real test is whether this test passes type checking
+        x: Parameter = signature(example_function).parameters["x"]
+        assert x.annotation == Movable
+        assert x.default == "foo"
+
+
+def test_inject_is_deprecated():
+    with pytest.raises(
+        DeprecationWarning,
+        match="Inject is deprecated, users are now expected to call the device factory",
+    ):
+
+        def example_function(x: Movable = inject("foo")) -> MsgGenerator:  # noqa: B008
+            yield from {}


### PR DESCRIPTION
Fixes #845 
Supersedes #839 

### Instructions to reviewer on how to test:
1. Confirm tests pass
2. Optional: write a plan that uses `inject` and confirm it raises a warning when run.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
