### PR TITLE
Prevent devices connecting as side effect of use elsewhere

### DIFF
--- a/docs/how-to/include-devices-in-plans.md
+++ b/docs/how-to/include-devices-in-plans.md
@@ -28,7 +28,7 @@ from bluesky.protocols import Readable
 from bluesky.utils import MsgGenerator
 from dodal.beamlines import i22
 
-def my_plan(detector: Readable = i22.saxs(connect_immediately=False)) -> MsgGenerator:
+def my_plan(detector: Readable = i22.saxs()) -> MsgGenerator:
     yield from bp.count([detector])
 
 RE(my_plan()))

--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -142,7 +142,6 @@ def _cache_device(name: str) -> Callable[[OphydV2Device], None]:
 
 def device_factory(
     *,
-    eager_connect: Annotated[bool, "Connect or raise Exception at startup"] = True,
     use_factory_name: Annotated[bool, "Use factory name as name of device"] = True,
     timeout: Annotated[float, "Timeout for connecting to the device"] = DEFAULT_TIMEOUT,
     mock: Annotated[bool, "Use Signals with mock backends for device"] = False,
@@ -153,7 +152,7 @@ def device_factory(
 ) -> Callable[[Callable[[], D]], DeviceInitializationController[D]]:
     def decorator(factory: Callable[[], D]) -> DeviceInitializationController[D]:
         controller = DeviceInitializationController(
-            factory, eager_connect, use_factory_name, timeout, mock, skip
+            factory, use_factory_name, timeout, mock, skip
         )
         controller.add_callback(_cache_device(factory.__name__))
         return controller

--- a/src/dodal/common/coordination.py
+++ b/src/dodal/common/coordination.py
@@ -49,7 +49,7 @@ def inject(name: str) -> Any:  # type: ignore
         from bluesky.utils import MsgGenerator
         from dodal.beamlines import i22
 
-        def my_plan(detector: Readable = i22.saxs(connect_immediately=False)) -> MsgGenerator:
+        def my_plan(detector: Readable = i22.saxs()) -> MsgGenerator:
             ...
 
         Where previously the default would have been inject("saxs")

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -118,7 +118,6 @@ class DeviceInitializationController(Generic[D]):
     def __init__(
         self,
         factory: Callable[[], D],
-        eager_connect: bool,
         use_factory_name: bool,
         timeout: float,
         mock: bool,
@@ -127,7 +126,6 @@ class DeviceInitializationController(Generic[D]):
         self._factory: Callable[[], D] = factory
         self._cached_device: D | None = None
         self._callbacks: list[Callable[[D], None]] = []
-        self._eager_connect = eager_connect
         self._use_factory_name = use_factory_name
         self._timeout = timeout
         self._mock = mock
@@ -147,7 +145,7 @@ class DeviceInitializationController(Generic[D]):
 
     def __call__(
         self,
-        connect_immediately: bool | None = None,
+        connect_immediately: bool = False,
         name: str | None = None,
         connection_timeout: float | None = None,
         mock: bool | None = None,
@@ -160,12 +158,11 @@ class DeviceInitializationController(Generic[D]):
 
 
         Args:
-            connect_immediately (bool | None, optional): whether to call connect on the
+            connect_immediately (bool, default False): whether to call connect on the
               device before returning it- connect is idempotent for ophyd-async devices.
               Not connecting to the device allows for the instance to be created prior
               to the RunEngine event loop being configured or for connect to be called
-              lazily e.g. by the `ensure_connected` stub. Defaults to None, which defers
-              to the eager_connect parameter of this Controller.
+              lazily e.g. by the `ensure_connected` stub.
             name (str | None, optional): an override name to give the device, which is
               also used to name its children. Defaults to None, which does not name the
               device unless the device has no name and this Controller is configured to
@@ -188,7 +185,7 @@ class DeviceInitializationController(Generic[D]):
         else:
             device = self._factory()
 
-        if connect_immediately or connect_immediately is None and self._eager_connect:
+        if connect_immediately:
             call_in_bluesky_event_loop(
                 device.connect(
                     timeout=connection_timeout

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -151,7 +151,7 @@ def dummy_mirror() -> FocusingMirror:
 
 
 def test_device_controller_names():
-    @beamline_utils.device_factory(eager_connect=False)
+    @beamline_utils.device_factory()
     def device() -> FocusingMirror:
         return dummy_mirror()
 

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -167,7 +167,12 @@ def test_device_controller_connect(RE):
 
     mirror = device()
     assert mirror.name == "device"
-    assert mirror.connect.call_count == 1  # type: ignore
+    assert isinstance(mirror.connect, AsyncMock)
+    assert mirror.connect.call_count == 0
+
+    mirror2 = device(connect_immediately=True)
+    assert mirror is mirror2
+    assert mirror.connect.call_count == 1
 
 
 def test_skip(RE):

--- a/tests/fake_device_factory_beamline.py
+++ b/tests/fake_device_factory_beamline.py
@@ -14,11 +14,11 @@ class ReadableDevice(Readable, Device):
         return {}
 
 
-@device_factory(skip=True, eager_connect=False)
+@device_factory(skip=True)
 def device_a() -> ReadableDevice:
     return ReadableDevice("readable")
 
 
-@device_factory(skip=lambda: True, eager_connect=False)
+@device_factory(skip=lambda: True)
 def device_c() -> CryoStream:
     return CryoStream("FOO:")


### PR DESCRIPTION
Fixes #856, issues discussed in the comments of #854
With this change, devices are *always* created not connected, and it is the responsibility of the user to ensure their device is connected before trying to use it:

e.g. on an ipython terminal:
```python
from bluesky.utils import MsgGenerator
from bluesky.run_engine import RunEngine
from dodal.beamlines.i22 import saxs
from ophyd_async.core import ensure_connected

s = saxs()
mock = int(time.time()) % 2 == 0

def plan(det: Readable) -> MsgGenerator:
    yield from ensure_connected(det)
    yield from {}

# Connects by any of the below
await s.connect(mock=mock)
RE(ensure_connected(s, mock=mock))
RE(plan(s))
s = saxs(connect_immediately=True)
```

or in blueapi, we will call get_all_device_factories() and call connect on all devices in parallel, reporting on any device connection issues.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
