### PR TITLE
Implement crystal metadata for I03 DCM

### DIFF
--- a/src/dodal/devices/dcm.py
+++ b/src/dodal/devices/dcm.py
@@ -50,11 +50,12 @@ class DCM(StandardReadable):
                 str, initial_value=crystal_metadata.type
             )
             self.crystal_metadata_reflection, _ = soft_signal_r_and_setter(
-                Sequence[int], initial_value=list(crystal_metadata.reflection)
+                Sequence[int],
+                initial_value=list(crystal_metadata.reflection),  # type: ignore
             )
             self.crystal_metadata_d_spacing, _ = soft_signal_r_and_setter(
                 float,
-                initial_value=crystal_metadata.d_spacing[0],
-                units=crystal_metadata.d_spacing[1],
+                initial_value=crystal_metadata.d_spacing[0],  # type: ignore
+                units=crystal_metadata.d_spacing[1],  # type: ignore
             )
         super().__init__(name)

--- a/src/dodal/devices/dcm.py
+++ b/src/dodal/devices/dcm.py
@@ -1,6 +1,10 @@
-from ophyd_async.core import StandardReadable
+from collections.abc import Sequence
+
+from ophyd_async.core import StandardReadable, soft_signal_r_and_setter
 from ophyd_async.epics.motor import Motor
 from ophyd_async.epics.signal import epics_signal_r
+
+from dodal.common.crystal_metadata import CrystalMetadata, MaterialsEnum
 
 
 class DCM(StandardReadable):
@@ -17,6 +21,9 @@ class DCM(StandardReadable):
         self,
         prefix: str,
         name: str = "",
+        crystal_metadata: CrystalMetadata = CrystalMetadata(  # noqa: B008
+            MaterialsEnum.Si, (1, 1, 1)
+        ),
     ) -> None:
         with self.add_children_as_readables():
             self.bragg_in_degrees = Motor(prefix + "BRAGG")
@@ -36,4 +43,18 @@ class DCM(StandardReadable):
             self.perp_temp = epics_signal_r(float, prefix + "TEMP6")
             self.perp_sub_assembly_temp = epics_signal_r(float, prefix + "TEMP7")
 
+            self.crystal_metadata_usage, _ = soft_signal_r_and_setter(
+                str, initial_value=crystal_metadata.usage
+            )
+            self.crystal_metadata_type, _ = soft_signal_r_and_setter(
+                str, initial_value=crystal_metadata.type
+            )
+            self.crystal_metadata_reflection, _ = soft_signal_r_and_setter(
+                Sequence[int], initial_value=list(crystal_metadata.reflection)
+            )
+            self.crystal_metadata_d_spacing, _ = soft_signal_r_and_setter(
+                float,
+                initial_value=crystal_metadata.d_spacing[0],
+                units=crystal_metadata.d_spacing[1],
+            )
         super().__init__(name)

--- a/tests/devices/unit_tests/test_dcm.py
+++ b/tests/devices/unit_tests/test_dcm.py
@@ -20,6 +20,10 @@ async def dcm() -> DCM:
         "dcm-bragg_in_degrees",
         "dcm-energy_in_kev",
         "dcm-offset_in_mm",
+        "dcm-crystal_metadata_usage",
+        "dcm-crystal_metadata_type",
+        "dcm-crystal_metadata_reflection",
+        "dcm-crystal_metadata_d_spacing",
     ],
 )
 async def test_read_and_describe_includes(


### PR DESCRIPTION
Required for DiamondLightSource/hyperion#520

### Instructions to reviewer on how to test:
1. I03 DCM should now expose the crystal metadata
2. Tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
