### PR TITLE
Wait for odin to be initialised rather than just check

### DIFF
--- a/src/dodal/devices/eiger.py
+++ b/src/dodal/devices/eiger.py
@@ -131,7 +131,9 @@ class EigerDetector(Device):
             LOGGER.info("Disarming detector")
         finally:
             self.disarm_detector()
-            status_ok = self.odin.check_odin_state(self.GENERAL_STATUS_TIMEOUT)
+            status_ok = self.odin.check_and_wait_for_odin_state(
+                self.GENERAL_STATUS_TIMEOUT
+            )
             self.disable_roi_mode()
         return status_ok
 

--- a/src/dodal/devices/eiger.py
+++ b/src/dodal/devices/eiger.py
@@ -81,7 +81,9 @@ class EigerDetector(Device):
 
     def async_stage(self):
         self.odin.nodes.clear_odin_errors()
-        status_ok, error_message = self.odin.check_odin_initialised()
+        status_ok, error_message = self.odin.wait_for_odin_initialised(
+            self.GENERAL_STATUS_TIMEOUT
+        )
         if not status_ok:
             raise Exception(f"Odin not initialised: {error_message}")
 
@@ -129,7 +131,7 @@ class EigerDetector(Device):
             LOGGER.info("Disarming detector")
         finally:
             self.disarm_detector()
-            status_ok = self.odin.check_odin_state()
+            status_ok = self.odin.check_odin_state(self.GENERAL_STATUS_TIMEOUT)
             self.disable_roi_mode()
         return status_ok
 

--- a/src/dodal/devices/eiger_odin.py
+++ b/src/dodal/devices/eiger_odin.py
@@ -1,8 +1,10 @@
 # type: ignore # Eiger will soon be ophyd-async https://github.com/DiamondLightSource/dodal/issues/700
+from functools import partial, reduce
+
 from ophyd import Component, Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 from ophyd.areadetector.plugins import HDF5Plugin_V22
 from ophyd.sim import NullStatus
-from ophyd.status import StatusBase
+from ophyd.status import StatusBase, SubscriptionStatus
 
 from dodal.devices.status import await_value
 
@@ -84,24 +86,22 @@ class OdinNodesStatus(Device):
             lambda node: node.frames_dropped.get(), "dropped"
         )
 
-    def get_error_state(self) -> tuple[bool, str]:
-        is_error = []
-        error_messages = []
+    def wait_for_no_errors(self, timeout) -> dict[SubscriptionStatus, str]:
+        errors = {}
         for node_number, node_pv in enumerate(self.nodes):
-            is_error.append(node_pv.error_status.get())
-            if is_error[node_number]:
-                error_messages.append(
-                    f"Filewriter {node_number} is in an error state with error message\
+            errors[
+                await_value(node_pv.error_status, False, timeout)
+            ] = f"Filewriter {node_number} is in an error state with error message\
                      - {node_pv.error_message.get()}"
-                )
-        return any(is_error), "\n".join(error_messages)
 
-    def get_init_state(self) -> bool:
+        return errors
+
+    def get_init_state(self, timeout) -> SubscriptionStatus:
         is_initialised = []
         for node_pv in self.nodes:
-            is_initialised.append(node_pv.fr_initialised.get())
-            is_initialised.append(node_pv.fp_initialised.get())
-        return all(is_initialised)
+            is_initialised.append(await_value(node_pv.fr_initialised, True, timeout))
+            is_initialised.append(await_value(node_pv.fp_initialised, True, timeout))
+        return reduce(lambda x, y: x & y, is_initialised)
 
     def clear_odin_errors(self):
         clearing_status = NullStatus()
@@ -125,8 +125,8 @@ class EigerOdin(Device):
             writing_finished &= await_value(node_pv.writing, 0)
         return writing_finished
 
-    def check_odin_state(self) -> bool:
-        is_initialised, error_message = self.check_odin_initialised()
+    def check_odin_state(self, timeout) -> bool:
+        is_initialised, error_message = self.wait_for_odin_initialised(timeout)
         frames_dropped, frames_dropped_details = self.nodes.check_frames_dropped()
         frames_timed_out, frames_timed_out_details = self.nodes.check_frames_timed_out()
 
@@ -139,22 +139,29 @@ class EigerOdin(Device):
 
         return is_initialised and not frames_dropped and not frames_timed_out
 
-    def check_odin_initialised(self) -> tuple[bool, str]:
-        is_error_state, error_messages = self.nodes.get_error_state()
-        to_check = [
-            (not self.fan.consumers_connected.get(), "EigerFan is not connected"),
-            (not self.fan.on.get(), "EigerFan is not initialised"),
-            (not self.meta.initialised.get(), "MetaListener is not initialised"),
-            (is_error_state, error_messages),
-            (
-                not self.nodes.get_init_state(),
-                "One or more filewriters is not initialised",
-            ),
-        ]
+    def wait_for_odin_initialised(self, timeout) -> tuple[bool, str]:
+        errors = self.nodes.wait_for_no_errors(timeout)
+        await_true = partial(await_value, expected_value=True, timeout=timeout)
+        errors[
+            await_value(
+                self.fan.consumers_connected, expected_value=True, timeout=timeout
+            )
+        ] = "EigerFan is not connected"
+        errors[await_true(self.fan.on)] = "EigerFan is not initialised"
+        errors[await_true(self.meta.initialised)] = "MetaListener is not initialised"
+        errors[self.nodes.get_init_state(timeout)] = (
+            "One or more filewriters is not initialised"
+        )
 
-        errors = [message for check_result, message in to_check if check_result]
+        error_strings = []
 
-        return not errors, "\n".join(errors)
+        for error_status, string in errors.items():
+            try:
+                error_status.wait(timeout=timeout)
+            except Exception:
+                error_strings.append(string)
+
+        return not error_strings, "\n".join(error_strings)
 
     def stop(self) -> StatusBase:
         """Stop odin manually"""

--- a/system_tests/test_eiger_system.py
+++ b/system_tests/test_eiger_system.py
@@ -40,6 +40,6 @@ def test_can_stage_and_unstage_eiger(eiger: EigerDetector):
     eiger.stage()
     assert eiger.cam.acquire.get() == 1
     # S03 filewriters stay in error
-    eiger.odin.check_odin_initialised = lambda: (True, "")
+    eiger.odin.wait_for_odin_initialised = lambda: (True, "")
     eiger.unstage()
     assert eiger.cam.acquire.get() == 0

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -331,11 +331,11 @@ def test_unsuccessful_false_roi_mode_change_results_in_callback_error(
         run_functions_without_blocking(unwrapped_funcs).wait()
 
 
-@patch("dodal.devices.eiger.EigerOdin.check_odin_state")
+@patch("dodal.devices.eiger.EigerOdin.check_and_wait_for_odin_state")
 def test_bad_odin_state_results_in_unstage_returning_bad_status(
-    mock_check_odin_state, fake_eiger: EigerDetector
+    mock_check_and_wait_for_odin_state, fake_eiger: EigerDetector
 ):
-    mock_check_odin_state.return_value = False
+    mock_check_and_wait_for_odin_state.return_value = False
     happy_status = Status()
     happy_status.set_finished()
     fake_eiger.filewriters_finished = happy_status
@@ -533,7 +533,7 @@ def test_given_in_free_run_mode_when_unstaged_then_waiting_on_file_writer_to_fin
 
     fake_eiger.odin.file_writer.capture.sim_put(1)  # type: ignore
     fake_eiger.odin.file_writer.num_captured.sim_put(2000)  # type: ignore
-    fake_eiger.odin.check_odin_state = MagicMock(return_value=True)
+    fake_eiger.odin.check_and_wait_for_odin_state = MagicMock(return_value=True)
 
     fake_eiger.detector_params.trigger_mode = TriggerMode.FREE_RUN
     fake_eiger.unstage()
@@ -549,7 +549,7 @@ def test_given_in_free_run_mode_and_not_all_frames_collected_in_time_when_unstag
 
     fake_eiger.odin.file_writer.capture.sim_put(1)  # type: ignore
     fake_eiger.odin.file_writer.num_captured.sim_put(1000)  # type: ignore
-    fake_eiger.odin.check_odin_state = MagicMock(return_value=True)
+    fake_eiger.odin.check_and_wait_for_odin_state = MagicMock(return_value=True)
 
     fake_eiger.detector_params.trigger_mode = TriggerMode.FREE_RUN
     fake_eiger.ALL_FRAMES_TIMEOUT = 0.1
@@ -600,7 +600,7 @@ def test_given_detector_arming_when_unstage_then_wait_for_arming_to_finish(
 
     fake_eiger.odin.file_writer.capture.sim_put(1)  # type: ignore
     fake_eiger.odin.file_writer.num_captured.sim_put(2000)  # type: ignore
-    fake_eiger.odin.check_odin_state = MagicMock(return_value=True)
+    fake_eiger.odin.check_and_wait_for_odin_state = MagicMock(return_value=True)
 
     fake_eiger.arming_status = Status()
     fake_eiger.arming_status.wait = MagicMock()
@@ -611,7 +611,7 @@ def test_given_detector_arming_when_unstage_then_wait_for_arming_to_finish(
 def test_given_detector_arming_status_failed_when_unstage_then_detector_still_disarmed(
     fake_eiger: EigerDetector,
 ):
-    fake_eiger.odin.check_odin_state = MagicMock(return_value=True)
+    fake_eiger.odin.check_and_wait_for_odin_state = MagicMock(return_value=True)
     fake_eiger.cam.acquire.sim_put(1)  # type: ignore
 
     fake_eiger.wait_on_arming_if_started = MagicMock(side_effect=RuntimeError())

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -85,8 +85,8 @@ def get_bad_status(exception=StatusException):
 @pytest.fixture
 def mock_set_odin_filewriter(fake_eiger: EigerDetector):
     fake_eiger.odin.nodes.clear_odin_errors = MagicMock()
-    fake_eiger.odin.check_odin_initialised = MagicMock()
-    fake_eiger.odin.check_odin_initialised.return_value = (True, "")
+    fake_eiger.odin.wait_for_odin_initialised = MagicMock()
+    fake_eiger.odin.wait_for_odin_initialised.return_value = (True, "")
     fake_eiger.odin.file_writer.file_path.put(True)
 
     def do_set(val: str):
@@ -517,8 +517,8 @@ def test_given_in_free_run_mode_when_staged_then_triggers_and_filewriter_set_cor
     fake_eiger: EigerDetector,
 ):
     fake_eiger.odin.nodes.clear_odin_errors = MagicMock()
-    fake_eiger.odin.check_odin_initialised = MagicMock()
-    fake_eiger.odin.check_odin_initialised.return_value = (True, "")
+    fake_eiger.odin.wait_for_odin_initialised = MagicMock()
+    fake_eiger.odin.wait_for_odin_initialised.return_value = (True, "")
     fake_eiger.odin.file_writer.file_path.put(True)
     fake_eiger.detector_params.trigger_mode = TriggerMode.FREE_RUN
     fake_eiger.set_num_triggers_and_captures()

--- a/tests/devices/unit_tests/test_odin.py
+++ b/tests/devices/unit_tests/test_odin.py
@@ -156,3 +156,13 @@ def test_given_error_on_node_1_when_clear_odin_errors_called_then_resets_all_err
     nodes.clear_odin_errors()
     for node in nodes.nodes:
         node.clear_errors.set.assert_called_once_with(1)
+
+
+@patch("dodal.devices.eiger_odin.await_value")
+def test_given_await_value_returns_done_status_then_init_state_returns_done(
+    patch_await, fake_odin: EigerOdin
+):
+    patch_await.side_effect = lambda *_: fake_status(False)
+    full_status = fake_odin.nodes.get_init_state(None)
+    full_status.wait()
+    assert full_status.done

--- a/tests/devices/unit_tests/test_odin.py
+++ b/tests/devices/unit_tests/test_odin.py
@@ -62,7 +62,7 @@ def test_check_and_wait_for_odin_state(
     ],
 )
 @patch("dodal.devices.eiger_odin.await_value")
-def test_check_odin_initialised(
+def test_wait_for_odin_initialised(
     patch_await,
     fake_odin: EigerOdin,
     fan_connected: bool,

--- a/tests/devices/unit_tests/test_odin.py
+++ b/tests/devices/unit_tests/test_odin.py
@@ -1,10 +1,20 @@
 # type: ignore # Eiger will soon be ophyd-async https://github.com/DiamondLightSource/dodal/issues/700
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from ophyd.sim import make_fake_device
+from ophyd.status import Status
 
 from dodal.devices.eiger_odin import EigerOdin
+
+
+def fake_status(in_error: bool):
+    status = Status()
+    if in_error:
+        status.set_exception(Exception)
+    else:
+        status.set_finished()
+    return status
 
 
 @pytest.fixture
@@ -31,15 +41,15 @@ def test_check_odin_state(
     frames_timed_out: bool,
     expected_state: bool,
 ):
-    fake_odin.check_odin_initialised = Mock(return_value=[is_initialised, ""])
+    fake_odin.wait_for_odin_initialised = Mock(return_value=[is_initialised, ""])
     fake_odin.nodes.check_frames_dropped = Mock(return_value=[frames_dropped, ""])
     fake_odin.nodes.check_frames_timed_out = Mock(return_value=[frames_timed_out, ""])
 
     if is_initialised:
-        assert fake_odin.check_odin_state() == expected_state
+        assert fake_odin.check_odin_state(None) == expected_state
     else:
         with pytest.raises(RuntimeError):
-            fake_odin.check_odin_state()
+            fake_odin.check_odin_state(None)
 
 
 @pytest.mark.parametrize(
@@ -51,7 +61,9 @@ def test_check_odin_state(
         (True, True, False, False, False, 2, False),
     ],
 )
+@patch("dodal.devices.eiger_odin.await_value")
 def test_check_odin_initialised(
+    patch_await,
     fake_odin: EigerOdin,
     fan_connected: bool,
     fan_on: bool,
@@ -61,15 +73,22 @@ def test_check_odin_initialised(
     expected_error_num: int,
     expected_state: bool,
 ):
-    fake_odin.fan.consumers_connected.get = Mock(return_value=fan_connected)
-    fake_odin.fan.on.get = Mock(return_value=(fan_on))
-    fake_odin.meta.initialised.get = Mock(return_value=(meta_init))
-    fake_odin.nodes.get_error_state = Mock(
-        return_value=[node_error, "node error" if node_error else ""]
-    )
-    fake_odin.nodes.get_init_state = Mock(return_value=node_init)
+    def _patch_await(signal, *args, **kwargs):
+        signal_and_return = {
+            fake_odin.fan.consumers_connected: fake_status(not fan_connected),
+            fake_odin.fan.on: fake_status(not fan_on),
+            fake_odin.meta.initialised: fake_status(not meta_init),
+        }
+        return signal_and_return[signal]
 
-    error_state, error_message = fake_odin.check_odin_initialised()
+    patch_await.side_effect = _patch_await
+
+    fake_odin.nodes.wait_for_no_errors = Mock(
+        return_value={fake_status(node_error): "node error" if node_error else ""}
+    )
+    fake_odin.nodes.get_init_state = Mock(return_value=fake_status(not node_init))
+
+    error_state, error_message = fake_odin.wait_for_odin_initialised(0.5)
     assert error_state == expected_state
     assert (len(error_message) == 0) == expected_state
     assert error_message.count("\n") == (
@@ -77,18 +96,21 @@ def test_check_odin_initialised(
     )
 
 
+@patch("dodal.devices.eiger_odin.await_value")
 def test_given_node_in_error_node_error_status_gives_message_and_node_number(
+    patch_await,
     fake_odin: EigerOdin,
 ):
     ERR_MESSAGE = "Help, I'm in error!"
-    fake_odin.nodes.node_0.error_status.sim_put(True)  # type: ignore
+    patch_await.side_effect = lambda *_: fake_status(True)
     fake_odin.nodes.node_0.error_message.sim_put(ERR_MESSAGE)  # type: ignore
 
-    in_error, message = fake_odin.nodes.get_error_state()
+    error = fake_odin.nodes.wait_for_no_errors(None)
+    error_messages = list(error.values())
 
-    assert in_error
-    assert "0" in message
-    assert ERR_MESSAGE in message
+    assert any(status.exception for status in error.keys())
+    assert any("0" in message for message in error_messages)
+    assert any(ERR_MESSAGE in message for message in error_messages)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/539

### Instructions to reviewer on how to test:
1. Confirm tests still pass and code is now waiting some time for odin to be in the correct state

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
