### PR TITLE
Implement `dodal connect ALL` to test connection to all beamlines

### DIFF
--- a/src/dodal/cli.py
+++ b/src/dodal/cli.py
@@ -8,6 +8,7 @@ from dodal.beamlines import all_beamline_names, module_name_for_beamline
 from dodal.utils import make_all_devices
 
 from . import __version__
+from .common.beamlines.beamline_utils import clear_devices
 
 
 @click.group(invoke_without_command=True)
@@ -21,7 +22,7 @@ def main(ctx: click.Context) -> None:
 @main.command(name="connect")
 @click.argument(
     "beamline",
-    type=click.Choice(list(all_beamline_names())),
+    type=click.Choice(list(all_beamline_names()) + ["ALL"]),
     required=True,
 )
 @click.option(
@@ -32,6 +33,15 @@ def main(ctx: click.Context) -> None:
     default=False,
 )
 @click.option(
+    "--include-training",
+    is_flag=True,
+    help="Include beamlines from the training module",
+    default=False,
+)
+@click.option(
+    "--include-sim", is_flag=True, help="Include sim beamlines sxx", default=False
+)
+@click.option(
     "-s",
     "--sim-backend",
     is_flag=True,
@@ -39,33 +49,63 @@ def main(ctx: click.Context) -> None:
     "attempt any I/O. Useful as a a dry-run.",
     default=False,
 )
-def connect(beamline: str, all: bool, sim_backend: bool) -> None:
+def connect(
+    beamline: str,
+    all: bool,
+    sim_backend: bool,
+    include_training: bool,
+    include_sim: bool,
+) -> None:
     """Initialises a beamline module, connects to all devices, reports
     any connection issues."""
 
-    os.environ["BEAMLINE"] = beamline
+    if beamline == "ALL":
+        beamlines = sorted(all_beamline_names())
+        module_names = {bl: module_name_for_beamline(bl) for bl in beamlines}
 
-    module_name = module_name_for_beamline(beamline)
-    full_module_path = f"dodal.beamlines.{module_name}"
+        def included(bl: str):
+            return not (
+                (bl.startswith("s") and not include_sim)
+                or ("training_rig" == module_names[bl] and not include_training)
+            )
 
-    # We need to make a RunEngine to allow ophyd-async devices to connect.
-    # See https://blueskyproject.io/ophyd-async/main/explanations/event-loop-choice.html
-    RunEngine()
+        beamlines = [bl for bl in beamlines if included(bl)]
+    else:
+        beamlines = [beamline]
+        module_names = {beamline: module_name_for_beamline(beamline)}
 
-    print(f"Attempting connection to {beamline} (using {full_module_path})")
-    devices, exceptions = make_all_devices(
-        full_module_path,
-        include_skipped=all,
-        fake_with_ophyd_sim=sim_backend,
-    )
-    sim_statement = " (sim mode)" if sim_backend else ""
+    success = True
 
-    print(f"{len(devices)} devices connected{sim_statement}:")
-    connected_devices = "\n".join(
-        sorted([f"\t{device_name}" for device_name in devices.keys()])
-    )
-    print(connected_devices)
+    for beamline in beamlines:
+        clear_devices()
+        os.environ["BEAMLINE"] = beamline
 
-    # If exceptions have occurred, this will print details of the relevant PVs
-    if len(exceptions) > 0:
-        raise NotConnected(exceptions)
+        module_name = module_names[beamline]
+        full_module_path = f"dodal.beamlines.{module_name}"
+
+        # We need to make a RunEngine to allow ophyd-async devices to connect.
+        # See https://blueskyproject.io/ophyd-async/main/explanations/event-loop-choice.html
+        RunEngine()
+
+        print("***************************************************************")
+        print(f"Attempting connection to {beamline} (using {full_module_path})")
+        print("***************************************************************")
+        devices, exceptions = make_all_devices(
+            full_module_path,
+            include_skipped=all,
+            fake_with_ophyd_sim=sim_backend,
+        )
+        sim_statement = " (sim mode)" if sim_backend else ""
+
+        print(f"{len(devices)} devices connected{sim_statement}:")
+        connected_devices = "\n".join(
+            sorted([f"\t{device_name}" for device_name in devices.keys()])
+        )
+        print(connected_devices)
+
+        # If exceptions have occurred, this will print details of the relevant PVs
+        if len(exceptions) > 0:
+            success = False
+            print(str(NotConnected(exceptions)))
+
+    exit(0 if success else 1)


### PR DESCRIPTION
Fixes #875

Running `dodal connect ALL` will result in the special ALL beamline name being expanded into the list of all known beamlines. `dodal connect` will then attempt to connect to the beamlines in order and print out the connect results for each.

By default, training (in the `training_rig` module) and sim (starting with `s`) beamlines are skipped but can be included with the `--include-training` and `--include-sim` options respectively.

### Instructions to reviewer on how to test:
1. `dodal connect` works as advertised
2. Unit tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
