### PR TITLE
Add constant for zocalo environment constant with new names

### DIFF
--- a/src/dodal/devices/zocalo/zocalo_constants.py
+++ b/src/dodal/devices/zocalo/zocalo_constants.py
@@ -1,0 +1,3 @@
+from dodal.utils import is_test_mode
+
+ZOCALO_ENV = "dev_bluesky" if is_test_mode() else "bluesky"

--- a/src/dodal/devices/zocalo/zocalo_interaction.py
+++ b/src/dodal/devices/zocalo/zocalo_interaction.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import zocalo.configuration
 from workflows.transport import lookup
 
+from dodal.devices.zocalo.zocalo_constants import ZOCALO_ENV
 from dodal.log import LOGGER
 
 
@@ -56,7 +57,7 @@ class ZocaloTrigger:
 
     see https://github.com/DiamondLightSource/dodal/wiki/How-to-Interact-with-Zocalo"""
 
-    def __init__(self, environment: str = "artemis"):
+    def __init__(self, environment: str = ZOCALO_ENV):
         self.zocalo_environment: str = environment
 
     def _send_to_zocalo(self, parameters: dict):

--- a/src/dodal/devices/zocalo/zocalo_results.py
+++ b/src/dodal/devices/zocalo/zocalo_results.py
@@ -20,6 +20,7 @@ from ophyd_async.core import (
 )
 from workflows.transport.common_transport import CommonTransport
 
+from dodal.devices.zocalo.zocalo_constants import ZOCALO_ENV
 from dodal.devices.zocalo.zocalo_interaction import _get_zocalo_connection
 from dodal.log import LOGGER
 
@@ -114,7 +115,7 @@ class ZocaloResults(StandardReadable, Triggerable):
     def __init__(
         self,
         name: str = "zocalo",
-        zocalo_environment: str = "dev_artemis",
+        zocalo_environment: str = ZOCALO_ENV,
         channel: str = "xrc.i03",
         sort_key: str = DEFAULT_SORT_KEY.value,
         timeout_s: float = DEFAULT_TIMEOUT,

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -79,6 +79,10 @@ def get_beamline_name(default: str) -> str:
     return environ.get("BEAMLINE") or default
 
 
+def is_test_mode() -> bool:
+    return environ.get("DODAL_TEST_MODE") is True
+
+
 def get_hostname() -> str:
     return socket.gethostname().split(".")[0]
 

--- a/system_tests/test_zocalo_results.py
+++ b/system_tests/test_zocalo_results.py
@@ -16,6 +16,7 @@ from dodal.devices.zocalo import (
     ZocaloStartInfo,
     ZocaloTrigger,
 )
+from dodal.devices.zocalo.zocalo_constants import ZOCALO_ENV
 
 TEST_RESULT_LARGE: XrcResult = {
     "centre_of_mass": [1, 2, 3],
@@ -39,7 +40,7 @@ async def test_read_results_from_fake_zocalo(
     zocalo_device: ZocaloResults, RE: RunEngine
 ):
     zocalo_device._subscribe_to_results()
-    zc = ZocaloTrigger("dev_artemis")
+    zc = ZocaloTrigger(ZOCALO_ENV)
     zc.run_start(ZocaloStartInfo(0, None, 0, 100, 0))
     zc.run_end(0)
     zocalo_device.timeout_s = 5
@@ -60,7 +61,7 @@ async def test_stage_unstage_controls_read_results_from_fake_zocalo(
     zocalo_device: ZocaloResults, RE: RunEngine
 ):
     dodal.devices.zocalo.zocalo_results.CLEAR_QUEUE_WAIT_S = 0.05
-    zc = ZocaloTrigger("dev_artemis")
+    zc = ZocaloTrigger(ZOCALO_ENV)
     zocalo_device.timeout_s = 5
 
     def plan():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ mock_attributes_table = {
 }
 
 BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
+environ["DODAL_TEST_MODE"] = "true"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/devices/unit_tests/test_zocalo_interaction.py
+++ b/tests/devices/unit_tests/test_zocalo_interaction.py
@@ -11,7 +11,7 @@ from dodal.devices.zocalo import (
 )
 from dodal.devices.zocalo.zocalo_interaction import ZocaloStartInfo
 
-SIM_ZOCALO_ENV = "dev_artemis"
+SIM_ZOCALO_ENV = "dev_bluesky"
 
 EXPECTED_DCID = 100
 EXPECTED_FILENAME = "test/file"

--- a/tests/devices/unit_tests/test_zocalo_results.py
+++ b/tests/devices/unit_tests/test_zocalo_results.py
@@ -9,6 +9,7 @@ from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
 from ophyd_async.core import AsyncStatus
 
+from dodal.devices.zocalo.zocalo_constants import ZOCALO_ENV
 from dodal.devices.zocalo.zocalo_results import (
     ZOCALO_READING_PLAN_NAME,
     NoResultsFromZocalo,
@@ -88,7 +89,7 @@ async def zocalo_results():
         patch("dodal.devices.zocalo.zocalo_results._get_zocalo_connection"),
         patch("dodal.devices.zocalo.zocalo_results.CLEAR_QUEUE_WAIT_S", 0),
     ):
-        yield ZocaloResults(name="zocalo", zocalo_environment="dev_artemis")
+        yield ZocaloResults(name="zocalo", zocalo_environment=ZOCALO_ENV)
 
 
 @pytest.fixture
@@ -191,7 +192,7 @@ async def test_subscribe_only_on_called_stage(
     mock_connection: MagicMock, mock_wrap_subscribe: MagicMock, RE: RunEngine
 ):
     zocalo_results = ZocaloResults(
-        name="zocalo", zocalo_environment="dev_artemis", timeout_s=0
+        name="zocalo", zocalo_environment=ZOCALO_ENV, timeout_s=0
     )
     mock_wrap_subscribe.assert_not_called()
     await zocalo_results.stage()
@@ -216,7 +217,7 @@ async def test_zocalo_results_trigger_log_message(
 ):
     zocalo_results = ZocaloResults(
         name="zocalo",
-        zocalo_environment="dev_artemis",
+        zocalo_environment=ZOCALO_ENV,
         timeout_s=0,
         use_cpu_and_gpu=True,
     )
@@ -266,7 +267,7 @@ async def test_when_exception_caused_by_zocalo_message_then_exception_propagated
     mock_connection, RE: RunEngine
 ):
     zocalo_results = ZocaloResults(
-        name="zocalo", zocalo_environment="dev_artemis", timeout_s=0.1
+        name="zocalo", zocalo_environment=ZOCALO_ENV, timeout_s=0.1
     )
     await zocalo_results.connect()
     with pytest.raises(FailedStatus) as e:
@@ -435,7 +436,7 @@ async def test_gpu_results_ignored_and_cpu_results_used_if_toggle_disabled(
 ):
     zocalo_results = ZocaloResults(
         name="zocalo",
-        zocalo_environment="dev_artemis",
+        zocalo_environment=ZOCALO_ENV,
         timeout_s=0,
         use_cpu_and_gpu=False,
     )

--- a/tests/fake_zocalo/dls_start_fake_zocalo.sh
+++ b/tests/fake_zocalo/dls_start_fake_zocalo.sh
@@ -15,7 +15,7 @@ activemq-for-dummy stop
 # starts the rabbitmq server and generates some credentials in ~/.fake_zocalo
 module load rabbitmq/dev
 
-# allows the `dev_artemis` zocalo environment to be used
+# allows the `dev_bluesky` zocalo environment to be used
 module load dials/latest
 
 source ../hyperion/.venv/bin/activate


### PR DESCRIPTION
Fixes [#ISSUE](https://github.com/DiamondLightSource/mx-bluesky/issues/612)
Constant now defined in Dodal instead of `mx_bluesky` since it's needed by the device. Alternatively the Zocalo devices could take the environment as a parameter, but for now there's no need as it'll always use the same string


### Instructions to reviewer on how to test:
1. Tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
