### PR TITLE
Fix Zocalo system tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -157,19 +157,6 @@ async def static_path_provider(
 
 
 @pytest.fixture
-async def RE():
-    RE = RunEngine()
-    # make sure the event loop is thoroughly up and running before we try to create
-    # any ophyd_async devices which might need it
-    timeout = time.monotonic() + 1
-    while not RE.loop.is_running():
-        await asyncio.sleep(0)
-        if time.monotonic() > timeout:
-            raise TimeoutError("This really shouldn't happen but just in case...")
-    yield RE
-
-
-@pytest.fixture
 def run_engine_documents(RE: RunEngine) -> Mapping[str, list[dict]]:
     docs: dict[str, list[dict]] = {}
 
@@ -186,3 +173,16 @@ def failed_status(failure: Exception) -> Status:
     status = Status()
     status.set_exception(failure)
     return status
+
+
+@pytest.fixture
+async def RE():
+    RE = RunEngine()
+    # make sure the event loop is thoroughly up and running before we try to create
+    # any ophyd_async devices which might need it
+    timeout = time.monotonic() + 1
+    while not RE.loop.is_running():
+        await asyncio.sleep(0)
+        if time.monotonic() > timeout:
+            raise TimeoutError("This really shouldn't happen but just in case...")
+    yield RE

--- a/system_tests/test_zocalo_results.py
+++ b/system_tests/test_zocalo_results.py
@@ -1,10 +1,10 @@
 import asyncio
-import os
 
 import bluesky.plan_stubs as bps
 import psutil
 import pytest
 from bluesky.preprocessors import stage_decorator
+from bluesky.protocols import Reading
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
 
@@ -27,6 +27,8 @@ TEST_RESULT_LARGE: XrcResult = {
     "bounding_box": [[2, 2, 2], [8, 8, 7]],
 }
 
+DCID_WHICH_EXISTS_IN_DEV_ISPYB = 1000
+
 
 @pytest.fixture
 async def zocalo_device():
@@ -35,15 +37,35 @@ async def zocalo_device():
     return zd
 
 
+def convert_zocalo_device_reading_to_xrc_result(
+    zocalo_reading: dict[str, Reading],
+) -> XrcResult:
+    com = zocalo_reading["zocalo-centre_of_mass"]["value"][0]
+    max_voxel = zocalo_reading["zocalo-max_voxel"]["value"][0]
+    max_count = zocalo_reading["zocalo-max_count"]["value"][0]
+    n_voxels = zocalo_reading["zocalo-n_voxels"]["value"][0]
+    total_count = zocalo_reading["zocalo-total_count"]["value"][0]
+    bounding_box = zocalo_reading["zocalo-bounding_box"]["value"][0]
+
+    return XrcResult(
+        centre_of_mass=com.tolist(),
+        max_voxel=max_voxel.tolist(),
+        max_count=int(max_count),
+        n_voxels=int(n_voxels),
+        total_count=int(total_count),
+        bounding_box=bounding_box.tolist(),
+    )
+
+
 @pytest.mark.s03
 async def test_read_results_from_fake_zocalo(
     zocalo_device: ZocaloResults, RE: RunEngine
 ):
     zocalo_device._subscribe_to_results()
     zc = ZocaloTrigger(ZOCALO_ENV)
-    zc.run_start(ZocaloStartInfo(0, None, 0, 100, 0))
-    zc.run_end(0)
-    zocalo_device.timeout_s = 5
+    zc.run_start(ZocaloStartInfo(DCID_WHICH_EXISTS_IN_DEV_ISPYB, None, 0, 100, 0))
+    zc.run_end(DCID_WHICH_EXISTS_IN_DEV_ISPYB)
+    zocalo_device.timeout_s = 15
 
     def plan():
         yield from bps.open_run()
@@ -53,7 +75,7 @@ async def test_read_results_from_fake_zocalo(
     RE(plan())
 
     results = await zocalo_device.read()
-    assert results["zocalo-results"]["value"][0] == TEST_RESULT_LARGE
+    assert convert_zocalo_device_reading_to_xrc_result(results) == TEST_RESULT_LARGE
 
 
 @pytest.mark.s03
@@ -62,12 +84,12 @@ async def test_stage_unstage_controls_read_results_from_fake_zocalo(
 ):
     dodal.devices.zocalo.zocalo_results.CLEAR_QUEUE_WAIT_S = 0.05
     zc = ZocaloTrigger(ZOCALO_ENV)
-    zocalo_device.timeout_s = 5
+    zocalo_device.timeout_s = 15
 
     def plan():
         yield from bps.open_run()
-        zc.run_start(ZocaloStartInfo(0, None, 0, 100, 0))
-        zc.run_end(0)
+        zc.run_start(ZocaloStartInfo(DCID_WHICH_EXISTS_IN_DEV_ISPYB, None, 0, 100, 0))
+        zc.run_end(DCID_WHICH_EXISTS_IN_DEV_ISPYB)
         yield from bps.sleep(0.15)
         yield from bps.trigger_and_read([zocalo_device])
         yield from bps.close_run()
@@ -90,7 +112,7 @@ async def test_stage_unstage_controls_read_results_from_fake_zocalo(
     await asyncio.sleep(1)
 
     results = await zocalo_device.read()
-    assert results["zocalo-results"]["value"][0] == TEST_RESULT_LARGE
+    assert convert_zocalo_device_reading_to_xrc_result(results) == TEST_RESULT_LARGE
     await zocalo_device.unstage()
 
     # Generating some more results leaves them at RMQ
@@ -105,9 +127,7 @@ async def test_stage_unstage_controls_read_results_from_fake_zocalo(
 async def test_stale_connections_closed_after_unstage(
     zocalo_device: ZocaloResults, RE: RunEngine
 ):
-    this_process = psutil.Process(os.getpid())
-
-    connections_before = len(this_process.connections())
+    connections_before = len(psutil.net_connections())
 
     def stage_unstage():
         yield from bps.stage(zocalo_device)
@@ -115,6 +135,6 @@ async def test_stale_connections_closed_after_unstage(
 
     RE(stage_unstage())
 
-    connections_after = len(this_process.connections())
+    connections_after = len(psutil.net_connections())
 
     assert connections_before == connections_after

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from bluesky.run_engine import RunEngine as RE
+from conftest import mock_beamline_module_filepaths
 from ophyd import Device
 from ophyd.device import Device as OphydV1Device
 from ophyd.sim import FakeEpicsSignal
@@ -17,8 +18,6 @@ from dodal.devices.smargon import Smargon
 from dodal.devices.zebra import Zebra
 from dodal.log import LOGGER
 from dodal.utils import make_all_devices
-
-from ...conftest import mock_beamline_module_filepaths
 
 
 @pytest.fixture(autouse=True)

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import ANY, MagicMock, Mock, call, create_autospec, patch
 
 import pytest
+from conftest import failed_status
 from ophyd.sim import NullStatus, make_fake_device
 from ophyd.status import Status
 from ophyd.utils import UnknownStatusFailure
@@ -14,8 +15,6 @@ from dodal.devices.eiger import EigerDetector
 from dodal.devices.status import await_value
 from dodal.devices.util.epics_util import run_functions_without_blocking
 from dodal.log import LOGGER
-
-from ...conftest import failed_status
 
 TEST_DETECTOR_SIZE_CONSTANTS = EIGER2_X_16M_SIZE
 

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from conftest import MOCK_DAQ_CONFIG_PATH
 from ophyd_async.core import (
     AsyncStatus,
     DeviceCollector,
@@ -18,8 +19,6 @@ from dodal.devices.undulator_dcm import (
     UndulatorDCM,
 )
 from dodal.log import LOGGER
-
-from ...conftest import MOCK_DAQ_CONFIG_PATH
 
 ID_GAP_LOOKUP_TABLE_PATH: str = (
     "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"

--- a/tests/fake_zocalo/dls_start_fake_zocalo.sh
+++ b/tests/fake_zocalo/dls_start_fake_zocalo.sh
@@ -8,6 +8,17 @@ function cleanup()
 
 trap cleanup EXIT
 
+if [[ -n "$VIRTUAL_ENV" ]]; then
+    deactivate
+fi
+
+# Create .zocalo if it doesn't exist
+ZOCALO_DIR=/home/$USER/.zocalo/
+if [[ ! -d "$ZOCALO_DIR" ]]; then
+    echo "Creating directory $ZOCALO_DIR"
+    mkdir -p "$ZOCALO_DIR"
+fi
+
 # kills the gda dummy activemq, that takes the port for rabbitmq
 module load dasctools
 activemq-for-dummy stop
@@ -18,6 +29,5 @@ module load rabbitmq/dev
 # allows the `dev_bluesky` zocalo environment to be used
 module load dials/latest
 
-source ../hyperion/.venv/bin/activate
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 python $SCRIPT_DIR/__main__.py


### PR DESCRIPTION
Fixes Zocalo system tests by:

- Moving `conftest` up a directory, so that everything in `dodal/system_tests` uses it
- Small fixes to `dls_start_fake_zocalo.sh`
- Convert reading from `ZocaloResults` into `XrcResults` during the tests
- Correctly configure queues and exchanges for the dev rabbitmq instance


To Test (using this branch):
- Run `./dls_start_fake_zocalo.sh` and leave open on one terminal
- In another terminal, run `module load dials/latest` and then, within the mx-bluesky .venv, run `pytest test_zocalo_results.py`
- Confirm tests pass / post any errors
