### PR TITLE
Correctly patch timeout in tests

### DIFF
--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -551,7 +551,7 @@ def test_given_in_free_run_mode_and_not_all_frames_collected_in_time_when_unstag
     fake_eiger.odin.check_and_wait_for_odin_state = MagicMock(return_value=True)
 
     fake_eiger.detector_params.trigger_mode = TriggerMode.FREE_RUN
-    fake_eiger.ALL_FRAMES_TIMEOUT = 0.1
+    fake_eiger.timeouts.all_frames_timeout = 0.1
     with pytest.raises(TimeoutError):
         fake_eiger.unstage()
 


### PR DESCRIPTION
Following https://github.com/DiamondLightSource/dodal/pull/806 we are now incorrectly patching timeouts in the tests, meaning that `test_given_in_free_run_mode_and_not_all_frames_collected_in_time_when_unstaged_then_odin_stopped_and_exception_thrown` takes ~30s. This fixes the patch.

### Instructions to reviewer on how to test:
1. Confirm test now completes in a sensible time

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
