### PR TITLE
MX Bluesky 651 fix energy changes

### DIFF
--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from ophyd_async.core import (
     AsyncStatus,
     Device,
@@ -34,6 +36,12 @@ class MirrorStripe(StrictEnum):
     RHODIUM = "Rhodium"
     BARE = "Bare"
     PLATINUM = "Platinum"
+
+
+class MirrorStripeConfiguration(TypedDict):
+    stripe: MirrorStripe
+    yaw_mrad: float
+    lat_mm: float
 
 
 class MirrorVoltageDemand(StrictEnum):
@@ -173,10 +181,10 @@ class FocusingMirrorWithStripes(FocusingMirror):
 
         super().__init__(prefix, name, *args, **kwargs)
 
-    def energy_to_stripe(self, energy_kev) -> tuple[MirrorStripe, float, float]:
-        """Return the stripe, yaw angle and lateral position"""
+    def energy_to_stripe(self, energy_kev) -> MirrorStripeConfiguration:
+        """Return the stripe, yaw angle and lateral position for the specified energy"""
         # In future, this should be configurable per-mirror
         if energy_kev < 7:
-            return MirrorStripe.BARE, 6.2, 0.0
+            return {"stripe": MirrorStripe.BARE, "yaw_mrad": 6.2, "lat_mm": 0.0}
         else:
-            return MirrorStripe.RHODIUM, 0.0, 10.0
+            return {"stripe": MirrorStripe.RHODIUM, "yaw_mrad": 0.0, "lat_mm": 10.0}

--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -173,9 +173,10 @@ class FocusingMirrorWithStripes(FocusingMirror):
 
         super().__init__(prefix, name, *args, **kwargs)
 
-    def energy_to_stripe(self, energy_kev) -> MirrorStripe:
+    def energy_to_stripe(self, energy_kev) -> tuple[MirrorStripe, float, float]:
+        """Return the stripe, yaw angle and lateral position"""
         # In future, this should be configurable per-mirror
         if energy_kev < 7:
-            return MirrorStripe.BARE
+            return MirrorStripe.BARE, 6.2, 0.0
         else:
-            return MirrorStripe.RHODIUM
+            return MirrorStripe.RHODIUM, 0.0, 10.0

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -4,7 +4,6 @@ from bluesky.protocols import Movable
 from ophyd_async.core import AsyncStatus, StandardReadable
 
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
-from dodal.log import LOGGER
 
 from .dcm import DCM
 from .undulator import Undulator
@@ -60,6 +59,3 @@ class UndulatorDCM(StandardReadable, Movable):
             self.dcm.energy_in_kev.set(value, timeout=ENERGY_TIMEOUT_S),
             self.undulator.set(value),
         )
-        # DCM Perp pitch
-        LOGGER.info(f"Adjusting DCM offset to {self.dcm_fixed_offset_mm} mm")
-        await self.dcm.offset_in_mm.set(self.dcm_fixed_offset_mm)

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -4,6 +4,7 @@ from bluesky.protocols import Movable
 from ophyd_async.core import AsyncStatus, StandardReadable
 
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
+from dodal.log import LOGGER
 
 from .dcm import DCM
 from .undulator import Undulator
@@ -59,3 +60,6 @@ class UndulatorDCM(StandardReadable, Movable):
             self.dcm.energy_in_kev.set(value, timeout=ENERGY_TIMEOUT_S),
             self.undulator.set(value),
         )
+        # DCM Perp pitch
+        LOGGER.info(f"Adjusting DCM offset to {self.dcm_fixed_offset_mm} mm")
+        await self.dcm.offset_in_mm.set(self.dcm_fixed_offset_mm)

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -5,6 +5,7 @@ from ophyd_async.core import AsyncStatus, StandardReadable
 
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
 
+from ..log import LOGGER
 from .dcm import DCM
 from .undulator import Undulator
 
@@ -59,3 +60,6 @@ class UndulatorDCM(StandardReadable, Movable):
             self.dcm.energy_in_kev.set(value, timeout=ENERGY_TIMEOUT_S),
             self.undulator.set(value),
         )
+        # DCM Perp pitch
+        LOGGER.info(f"Adjusting DCM offset to {self.dcm_fixed_offset_mm} mm")
+        await self.dcm.offset_in_mm.set(self.dcm_fixed_offset_mm)

--- a/tests/devices/unit_tests/test_focusing_mirror.py
+++ b/tests/devices/unit_tests/test_focusing_mirror.py
@@ -20,6 +20,7 @@ from ophyd_async.core import (
 from dodal.devices.focusing_mirror import (
     FocusingMirrorWithStripes,
     MirrorStripe,
+    MirrorStripeConfiguration,
     MirrorVoltageDemand,
     MirrorVoltages,
     SingleMirrorVoltage,
@@ -250,10 +251,16 @@ def test_mirror_populates_voltage_channels(RE):
     assert isinstance(mirror_voltages.horizontal_voltages[0], SingleMirrorVoltage)
 
 
+@pytest.mark.parametrize(
+    "energy_kev, expected_config",
+    [
+        [1, {"stripe": MirrorStripe.BARE, "yaw_mrad": 6.2, "lat_mm": 0.0}],
+        [14, {"stripe": MirrorStripe.RHODIUM, "yaw_mrad": 0.0, "lat_mm": 10.0}],
+    ],
+)
 async def test_given_striped_focussing_mirror_then_energy_to_stripe_returns_expected(
-    RE,
+    RE, energy_kev: float, expected_config: MirrorStripeConfiguration
 ):
     with DeviceCollector(mock=True):
         device = FocusingMirrorWithStripes(prefix="-OP-VFM-01:", name="mirror")
-    assert device.energy_to_stripe(1) == MirrorStripe.BARE
-    assert device.energy_to_stripe(14) == MirrorStripe.RHODIUM
+    assert device.energy_to_stripe(energy_kev) == expected_config

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -9,6 +9,7 @@ from ophyd_async.core import AsyncStatus, DeviceCollector, get_mock_put, set_moc
 from dodal.devices.dcm import DCM
 from dodal.devices.undulator import AccessError, Undulator, UndulatorGapAccess
 from dodal.devices.undulator_dcm import UndulatorDCM
+from dodal.devices.util.test_utils import patch_motor
 from dodal.log import LOGGER
 
 ID_GAP_LOOKUP_TABLE_PATH: str = (
@@ -43,6 +44,7 @@ async def fake_undulator_dcm() -> UndulatorDCM:
             daq_configuration_path=MOCK_DAQ_CONFIG_PATH,
             name="undulator_dcm",
         )
+    patch_motor(dcm.offset_in_mm)
     return undulator_dcm
 
 


### PR DESCRIPTION
Dodal changes for DiamondLightSource/mx-bluesky#651

See MX-bluesky PR DiamondLightSource/mx-bluesky#676

### Instructions to reviewer on how to test:
1. Energy changes work on beamline
2. Unit tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
