### PR TITLE
Update p99 to use device_factory

### DIFF
--- a/src/dodal/beamlines/p99.py
+++ b/src/dodal/beamlines/p99.py
@@ -1,61 +1,30 @@
-from dodal.common.beamlines.beamline_utils import device_instantiation, set_beamline
+from dodal.common.beamlines.beamline_utils import device_factory, set_beamline
 from dodal.devices.motors import XYZPositioner
 from dodal.devices.p99.sample_stage import FilterMotor, SampleAngleStage
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name
+from dodal.utils import BeamlinePrefix, get_beamline_name
 
-BL = get_beamline_name("BL99P")
+BL = get_beamline_name("p99")
+PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_beamline(BL)
 
 
-def sample_angle_stage(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> SampleAngleStage:
-    """Sample stage for p99"""
-
-    return device_instantiation(
-        SampleAngleStage,
-        prefix="-MO-STAGE-01:",
-        name="sample_angle_stage",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
+@device_factory()
+def angle_stage() -> SampleAngleStage:
+    return SampleAngleStage(f"{PREFIX.beamline_prefix}-MO-STAGE-01:")
 
 
-def sample_stage_filer(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> FilterMotor:
-    """Sample stage for p99"""
-
-    return device_instantiation(
-        FilterMotor,
-        prefix="-MO-STAGE-02:MP:SELECT",
-        name="sample_stage_filer",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
+@device_factory()
+def filter() -> FilterMotor:
+    return FilterMotor(f"{PREFIX.beamline_prefix}-MO-STAGE-02:MP:SELECT")
 
 
-def sample_xyz_stage(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XYZPositioner:
-    return device_instantiation(
-        FilterMotor,
-        prefix="-MO-STAGE-02:",
-        name="sample_xyz_stage",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
+@device_factory()
+def sample_stage() -> XYZPositioner:
+    return XYZPositioner(f"{PREFIX.beamline_prefix}-MO-STAGE-02:")
 
 
-def sample_lab_xyz_stage(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XYZPositioner:
-    return device_instantiation(
-        FilterMotor,
-        prefix="-MO-STAGE-02:LAB:",
-        name="sample_lab_xyz_stage",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
+@device_factory()
+def lab_stage() -> XYZPositioner:
+    return XYZPositioner(f"{PREFIX.beamline_prefix}-MO-STAGE-02:LAB:")

--- a/src/dodal/devices/motors.py
+++ b/src/dodal/devices/motors.py
@@ -1,8 +1,8 @@
-from ophyd_async.core import Device
+from ophyd_async.core import StandardReadable
 from ophyd_async.epics.motor import Motor
 
 
-class XYZPositioner(Device):
+class XYZPositioner(StandardReadable):
     """
 
     Standard ophyd_async xyz motor stage, by combining 3 Motors,
@@ -15,7 +15,7 @@ class XYZPositioner(Device):
     name:
         name for the stage.
     infix:
-        EPICS PV, default is the ["X", "Y", "Z"].
+        EPICS PV, default is the ("X", "Y", "Z").
     Notes
     -----
     Example usage::
@@ -23,14 +23,18 @@ class XYZPositioner(Device):
             xyz_stage = XYZPositioner("BLXX-MO-STAGE-XX:")
     Or::
         with DeviceCollector():
-            xyz_stage = XYZPositioner("BLXX-MO-STAGE-XX:", suffix = ["A", "B", "C"])
+            xyz_stage = XYZPositioner("BLXX-MO-STAGE-XX:", infix = ("A", "B", "C"))
 
     """
 
-    def __init__(self, prefix: str, name: str, infix: list[str] | None = None):
-        if infix is None:
-            infix = ["X", "Y", "Z"]
-        self.x = Motor(prefix + infix[0])
-        self.y = Motor(prefix + infix[1])
-        self.z = Motor(prefix + infix[2])
+    def __init__(
+        self,
+        prefix: str,
+        name: str = "",
+        infix: tuple[str, str, str] = ("X", "Y", "Z"),
+    ):
+        with self.add_children_as_readables():
+            self.x = Motor(prefix + infix[0])
+            self.y = Motor(prefix + infix[1])
+            self.z = Motor(prefix + infix[2])
         super().__init__(name=name)

--- a/src/dodal/devices/p99/sample_stage.py
+++ b/src/dodal/devices/p99/sample_stage.py
@@ -7,7 +7,7 @@ class SampleAngleStage(StandardReadable):
         with self.add_children_as_readables():
             self.theta = epics_signal_rw_rbv(float, prefix + "WRITETHETA", ":RBV")
             self.roll = epics_signal_rw_rbv(float, prefix + "WRITEROLL", ":RBV")
-            self.pitch = epics_signal_rw_rbv(float, prefix + "WRITEPITCH",":RBV")
+            self.pitch = epics_signal_rw_rbv(float, prefix + "WRITEPITCH", ":RBV")
         super().__init__(name=name)
 
 

--- a/src/dodal/devices/p99/sample_stage.py
+++ b/src/dodal/devices/p99/sample_stage.py
@@ -1,18 +1,13 @@
-from ophyd_async.core import Device, SubsetEnum
-from ophyd_async.epics.core import epics_signal_rw
+from ophyd_async.core import StandardReadable, SubsetEnum
+from ophyd_async.epics.core import epics_signal_rw, epics_signal_rw_rbv
 
 
-class SampleAngleStage(Device):
-    def __init__(self, prefix: str, name: str):
-        self.theta = epics_signal_rw(
-            float, prefix + "WRITETHETA:RBV", prefix + "WRITETHETA"
-        )
-        self.roll = epics_signal_rw(
-            float, prefix + "WRITEROLL:RBV", prefix + "WRITEROLL"
-        )
-        self.pitch = epics_signal_rw(
-            float, prefix + "WRITEPITCH:RBV", prefix + "WRITEPITCH"
-        )
+class SampleAngleStage(StandardReadable):
+    def __init__(self, prefix: str, name: str = ""):
+        with self.add_children_as_readables():
+            self.theta = epics_signal_rw_rbv(float, prefix + "WRITETHETA")
+            self.roll = epics_signal_rw_rbv(float, prefix + "WRITEROLL")
+            self.pitch = epics_signal_rw_rbv(float, prefix + "WRITEPITCH")
         super().__init__(name=name)
 
 
@@ -35,7 +30,8 @@ class p99StageSelections(SubsetEnum):
     User = "User"
 
 
-class FilterMotor(Device):
-    def __init__(self, prefix: str, name: str):
-        self.user_setpoint = epics_signal_rw(p99StageSelections, prefix)
+class FilterMotor(StandardReadable):
+    def __init__(self, prefix: str, name: str = ""):
+        with self.add_children_as_readables():
+            self.user_setpoint = epics_signal_rw(p99StageSelections, prefix)
         super().__init__(name=name)

--- a/src/dodal/devices/p99/sample_stage.py
+++ b/src/dodal/devices/p99/sample_stage.py
@@ -6,8 +6,8 @@ class SampleAngleStage(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.theta = epics_signal_rw_rbv(float, prefix + "WRITETHETA", ":RBV")
-            self.roll = epics_signal_rw_rbv(float, prefix + "WRITEROLL", ":RBV"))
-            self.pitch = epics_signal_rw_rbv(float, prefix + "WRITEPITCH",":RBV"))
+            self.roll = epics_signal_rw_rbv(float, prefix + "WRITEROLL", ":RBV")
+            self.pitch = epics_signal_rw_rbv(float, prefix + "WRITEPITCH",":RBV")
         super().__init__(name=name)
 
 

--- a/src/dodal/devices/p99/sample_stage.py
+++ b/src/dodal/devices/p99/sample_stage.py
@@ -5,9 +5,9 @@ from ophyd_async.epics.core import epics_signal_rw, epics_signal_rw_rbv
 class SampleAngleStage(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
-            self.theta = epics_signal_rw_rbv(float, prefix + "WRITETHETA")
-            self.roll = epics_signal_rw_rbv(float, prefix + "WRITEROLL")
-            self.pitch = epics_signal_rw_rbv(float, prefix + "WRITEPITCH")
+            self.theta = epics_signal_rw_rbv(float, prefix + "WRITETHETA", ":RBV")
+            self.roll = epics_signal_rw_rbv(float, prefix + "WRITEROLL", ":RBV"))
+            self.pitch = epics_signal_rw_rbv(float, prefix + "WRITEPITCH",":RBV"))
         super().__init__(name=name)
 
 


### PR DESCRIPTION
Minor tweaks to p99 devices for neatness and arg validation (number of infix args), switch to device_factory as new preferred way to instantiate devices

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [x] Would the PR title make sense to a scientist on a set of release notes
- [x] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [x] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [x] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
