### PR TITLE
Update training-rigs to use device_factory

### DIFF
--- a/src/dodal/beamlines/training_rig.py
+++ b/src/dodal/beamlines/training_rig.py
@@ -3,15 +3,16 @@ from pathlib import Path
 from ophyd_async.epics.adaravis import AravisDetector
 
 from dodal.common.beamlines.beamline_utils import (
-    device_instantiation,
+    device_factory,
     get_path_provider,
     set_path_provider,
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.beamlines.device_helpers import HDF5_PREFIX
 from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.training_rig.sample_stage import TrainingRigSampleStage
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import get_beamline_name
+from dodal.utils import BeamlinePrefix, get_beamline_name
 
 #
 # HTSS Training Rig
@@ -25,6 +26,7 @@ from dodal.utils import get_beamline_name
 #
 
 BL = get_beamline_name("p47")
+PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
 
@@ -37,28 +39,16 @@ set_path_provider(
 )
 
 
-def sample_stage(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> TrainingRigSampleStage:
-    return device_instantiation(
-        TrainingRigSampleStage,
-        "sample_stage",
-        "-MO-MAP-01:STAGE:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+@device_factory()
+def sample_stage() -> TrainingRigSampleStage:
+    return TrainingRigSampleStage(f"{PREFIX.beamline_prefix}-MO-MAP-01:STAGE:")
 
 
-def det(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> AravisDetector:
-    return device_instantiation(
-        AravisDetector,
-        "det",
-        "-EA-DET-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-        drv_suffix="DET:",
-        hdf_suffix="HDF5:",
+@device_factory()
+def det() -> AravisDetector:
+    return AravisDetector(
+        f"{PREFIX.beamline_prefix}-EA-DET-01:",
         path_provider=get_path_provider(),
+        drv_suffix="DET:",
+        hdf_suffix=HDF5_PREFIX,
     )

--- a/src/dodal/beamlines/training_rig.py
+++ b/src/dodal/beamlines/training_rig.py
@@ -21,11 +21,11 @@ from dodal.utils import BeamlinePrefix, get_beamline_name
 # simple motors, a GigE camera and a PandA.
 # Since there are multiple rigs whose PVs are identical aside from the prefix,
 # this module can be used for any rig. It should fill in the prefix automatically
-# if the ${BEAMLINE} environment variable is correctly set. It currently defaults
-# to p47.
+# if the ${BEAMLINE} environment variable is correctly set, else defaulting
+# to p46, which is known to be in good working order.
 #
 
-BL = get_beamline_name("p47")
+BL = get_beamline_name("p46")
 PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)


### PR DESCRIPTION
### Instructions to reviewer on how to test:
1. test beamline still connects using dodal connect from beamline workstation

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
