### PR TITLE
Fix type of array from beamline testing

### DIFF
--- a/src/dodal/devices/oav/pin_image_recognition/__init__.py
+++ b/src/dodal/devices/oav/pin_image_recognition/__init__.py
@@ -61,7 +61,7 @@ class PinTipDetection(StandardReadable):
         self.triggered_bottom_edge, self._bottom_edge_setter = soft_signal_r_and_setter(
             Array1D[np.int32], name="triggered_bottom_edge"
         )
-        self.array_data = epics_signal_r(Array1D[np.uint8], f"pva://{prefix}PVA:ARRAY")
+        self.array_data = epics_signal_r(np.ndarray, f"pva://{prefix}PVA:ARRAY")
 
         # Soft parameters for pin-tip detection.
         self.preprocess_operation = soft_signal_rw(int, 10, name="preprocess")

--- a/src/dodal/devices/oav/pin_image_recognition/__init__.py
+++ b/src/dodal/devices/oav/pin_image_recognition/__init__.py
@@ -99,9 +99,7 @@ class PinTipDetection(StandardReadable):
         self._top_edge_setter(results.edge_top)
         self._bottom_edge_setter(results.edge_bottom)
 
-    async def _get_tip_and_edge_data(
-        self, array_data: Array1D[np.uint8]
-    ) -> SampleLocation:
+    async def _get_tip_and_edge_data(self, array_data: np.ndarray) -> SampleLocation:
         """
         Gets the location of the pin tip and the top and bottom edges.
         """


### PR DESCRIPTION
Fixes #692

### Instructions to reviewer on how to test:
Hard to test without a PVA gateway. Confirm that it's the same as what's in `/dls_sw/i03/software/bluesky/hyperion_test_aperture_scatterguard`, which was tested on the beamline, maybe

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
