### PR TITLE
Increases sleep time to fix flaky test

### DIFF
--- a/tests/devices/unit_tests/test_bart_robot.py
+++ b/tests/devices/unit_tests/test_bart_robot.py
@@ -90,10 +90,10 @@ async def test_given_program_not_running_and_pin_unmounts_then_mounts_when_load_
 
     device.load = AsyncMock(side_effect=device.load)
     status = device.set(SampleLocation(15, 10))
-    await sleep(0.01)
+    await sleep(0.1)
     device.load.trigger.assert_called_once()  # type:ignore
     set_mock_value(device.gonio_pin_sensor, PinMounted.NO_PIN_MOUNTED)
-    await sleep(0.005)
+    await sleep(0.05)
     set_mock_value(device.gonio_pin_sensor, PinMounted.PIN_MOUNTED)
     await status
     assert status.success


### PR DESCRIPTION
Fixes[ #943](https://github.com/DiamondLightSource/dodal/issues/943)

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
