### PR TITLE
Fixes for ophyd async 0.9.0a1

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,4 @@
 import asyncio
-import importlib
 import logging
 import os
 import sys
@@ -18,14 +17,13 @@ from ophyd_async.core import (
     PathProvider,
 )
 
-from dodal.common.beamlines import beamline_parameters, beamline_utils
+from dodal.common.beamlines import beamline_utils
 from dodal.common.visit import (
     DirectoryServiceClient,
     LocalDirectoryServiceClient,
     StaticVisitPathProvider,
 )
 from dodal.log import LOGGER, GELFTCPHandler, set_up_all_logging_handlers
-from dodal.utils import make_all_devices
 
 MOCK_DAQ_CONFIG_PATH = "tests/devices/unit_tests/test_daq_configuration"
 mock_paths = [
@@ -80,31 +78,6 @@ if os.getenv("PYTEST_RAISE", "0") == "1":
     @pytest.hookimpl(tryfirst=True)
     def pytest_internalerror(excinfo: pytest.ExceptionInfo[Any]):
         raise excinfo.value
-
-
-def mock_beamline_module_filepaths(bl_name, bl_module):
-    if mock_attributes := mock_attributes_table.get(bl_name):
-        [bl_module.__setattr__(attr[0], attr[1]) for attr in mock_attributes]
-        beamline_parameters.BEAMLINE_PARAMETER_PATHS[bl_name] = (
-            "tests/test_data/i04_beamlineParameters"
-        )
-
-
-@pytest.fixture(scope="function")
-def module_and_devices_for_beamline(request):
-    beamline = request.param
-    with patch.dict(os.environ, {"BEAMLINE": beamline}, clear=True):
-        bl_mod = importlib.import_module("dodal.beamlines." + beamline)
-        importlib.reload(bl_mod)
-        mock_beamline_module_filepaths(beamline, bl_mod)
-        devices, exceptions = make_all_devices(
-            bl_mod,
-            include_skipped=True,
-            fake_with_ophyd_sim=True,
-        )
-        yield (bl_mod, devices, exceptions)
-        beamline_utils.clear_devices()
-        del bl_mod
 
 
 def pytest_runtest_setup(item):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async >= 0.8.0a5",
+    "ophyd-async >= 0.9.0a1",
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/src/dodal/devices/apple2_undulator.py
+++ b/src/dodal/devices/apple2_undulator.py
@@ -21,8 +21,8 @@ from dodal.log import LOGGER
 
 
 class UndulatorGateStatus(StrictEnum):
-    open = "Open"
-    close = "Closed"
+    OPEN = "Open"
+    CLOSE = "Closed"
 
 
 @dataclass
@@ -146,7 +146,7 @@ class UndulatorGap(StandardReadable, Movable):
         timeout = await self._cal_timeout()
         LOGGER.info(f"Moving {self.name} to {value} with timeout = {timeout}")
         await self.set_move.set(value=1, timeout=timeout)
-        await wait_for_value(self.gate, UndulatorGateStatus.close, timeout=timeout)
+        await wait_for_value(self.gate, UndulatorGateStatus.CLOSE, timeout=timeout)
 
     async def _cal_timeout(self) -> float:
         vel = await self.velocity.get_value()
@@ -157,7 +157,7 @@ class UndulatorGap(StandardReadable, Movable):
     async def check_id_status(self) -> None:
         if await self.fault.get_value() != 0:
             raise RuntimeError(f"{self.name} is in fault state")
-        if await self.gate.get_value() == UndulatorGateStatus.open:
+        if await self.gate.get_value() == UndulatorGateStatus.OPEN:
             raise RuntimeError(f"{self.name} is already in motion.")
 
     async def get_timeout(self) -> float:
@@ -251,7 +251,7 @@ class UndulatorPhaseAxes(StandardReadable, Movable):
         )
         timeout = await self._cal_timeout()
         await self.set_move.set(value=1, timeout=timeout)
-        await wait_for_value(self.gate, UndulatorGateStatus.close, timeout=timeout)
+        await wait_for_value(self.gate, UndulatorGateStatus.CLOSE, timeout=timeout)
 
     async def _cal_timeout(self) -> float:
         """
@@ -283,7 +283,7 @@ class UndulatorPhaseAxes(StandardReadable, Movable):
     async def check_id_status(self) -> None:
         if await self.fault.get_value() != 0:
             raise RuntimeError(f"{self.name} is in fault state")
-        if await self.gate.get_value() == UndulatorGateStatus.open:
+        if await self.gate.get_value() == UndulatorGateStatus.OPEN:
             raise RuntimeError(f"{self.name} is already in motion.")
 
     async def get_timeout(self) -> float:
@@ -325,7 +325,7 @@ class UndulatorJawPhase(StandardReadable, Movable):
         )
         timeout = await self._cal_timeout()
         await self.set_move.set(value=1, timeout=timeout)
-        await wait_for_value(self.gate, UndulatorGateStatus.close, timeout=timeout)
+        await wait_for_value(self.gate, UndulatorGateStatus.CLOSE, timeout=timeout)
 
     async def _cal_timeout(self) -> float:
         """
@@ -345,7 +345,7 @@ class UndulatorJawPhase(StandardReadable, Movable):
     async def check_id_status(self) -> None:
         if await self.fault.get_value() != 0:
             raise RuntimeError(f"{self.name} is in fault state")
-        if await self.gate.get_value() == UndulatorGateStatus.open:
+        if await self.gate.get_value() == UndulatorGateStatus.OPEN:
             raise RuntimeError(f"{self.name} is already in motion.")
 
     async def get_timeout(self) -> float:
@@ -458,7 +458,7 @@ class Apple2(StandardReadable, Movable):
             self.phase().set_move.set(value=1, timeout=timeout),
         )
         await wait_for_value(
-            self.gap().gate, UndulatorGateStatus.close, timeout=timeout
+            self.gap().gate, UndulatorGateStatus.CLOSE, timeout=timeout
         )
         self._energy_set(energy)  # Update energy for after move for readback.
 

--- a/src/dodal/devices/i10/i10_setting_data.py
+++ b/src/dodal/devices/i10/i10_setting_data.py
@@ -2,6 +2,6 @@ from ophyd_async.core import StrictEnum
 
 
 class I10Grating(StrictEnum):
-    Au400 = "400 line/mm Au"
-    Si400 = "400 line/mm Si"
-    Au1200 = "1200 line/mm Au"
+    AU_400 = "400 line/mm Au"
+    SI_400 = "400 line/mm Si"
+    AU_1200 = "1200 line/mm Au"

--- a/src/dodal/devices/i24/focus_mirrors.py
+++ b/src/dodal/devices/i24/focus_mirrors.py
@@ -5,21 +5,21 @@ from dodal.common.signal_utils import create_hardware_backed_soft_signal
 
 
 class HFocusMode(StrictEnum):
-    focus10 = "HMFMfocus10"
-    focus20d = "HMFMfocus20d"
-    focus30d = "HMFMfocus30d"
-    focus50d = "HMFMfocus50d"
-    focus1050d = "HMFMfocus1030d"
-    focus3010d = "HMFMfocus3010d"
+    FOCUS_10 = "HMFMfocus10"
+    FOCUS_20D = "HMFMfocus20d"
+    FOCUS_30D = "HMFMfocus30d"
+    FOCUS_50D = "HMFMfocus50d"
+    FOCUS_1050D = "HMFMfocus1030d"
+    FOCUS_3010D = "HMFMfocus3010d"
 
 
 class VFocusMode(StrictEnum):
-    focus10 = "VMFMfocus10"
-    focus20d = "VMFMfocus20d"
-    focus30d = "VMFMfocus30d"
-    focus50d = "VMFMfocus50d"
-    focus1030d = "VMFMfocus1030d"
-    focus3010d = "VMFMfocus3010d"
+    FOCUS_10 = "VMFMfocus10"
+    FOCUS_20D = "VMFMfocus20d"
+    FOCUS_30D = "VMFMfocus30d"
+    FOCUS_50D = "VMFMfocus50d"
+    FOCUS_1030D = "VMFMfocus1030d"
+    FOCUS_3010D = "VMFMfocus3010d"
 
 
 BEAM_SIZES = {

--- a/src/dodal/devices/linkam3.py
+++ b/src/dodal/devices/linkam3.py
@@ -14,8 +14,8 @@ from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 
 class PumpControl(StrictEnum):
-    Manual = "Manual"
-    Auto = "Auto"
+    MANUAL = "Manual"
+    AUTO = "Auto"
 
 
 class Linkam3(StandardReadable):

--- a/src/dodal/devices/p99/sample_stage.py
+++ b/src/dodal/devices/p99/sample_stage.py
@@ -12,22 +12,22 @@ class SampleAngleStage(StandardReadable):
 
 
 class p99StageSelections(SubsetEnum):
-    Empty = "Empty"
-    Mn5um = "Mn 5um"
-    Fe = "Fe (empty)"
-    Co5um = "Co 5um"
-    Ni5um = "Ni 5um"
-    Cu5um = "Cu 5um"
-    Zn5um = "Zn 5um"
-    Zr = "Zr (empty)"
-    Mo = "Mo (empty)"
-    Rh = "Rh (empty)"
-    Pd = "Pd (empty)"
-    Ag = "Ag (empty)"
-    Cd25um = "Cd 25um"
+    EMPTY = "Empty"
+    MN5UM = "Mn 5um"
+    FE = "Fe (empty)"
+    CO5UM = "Co 5um"
+    NI5UM = "Ni 5um"
+    CU5UM = "Cu 5um"
+    ZN5UM = "Zn 5um"
+    ZR = "Zr (empty)"
+    MO = "Mo (empty)"
+    RH = "Rh (empty)"
+    PD = "Pd (empty)"
+    AG = "Ag (empty)"
+    CD25UM = "Cd 25um"
     W = "W (empty)"
-    Pt = "Pt (empty)"
-    User = "User"
+    PT = "Pt (empty)"
+    USER = "User"
 
 
 class FilterMotor(StandardReadable):

--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -22,31 +22,31 @@ from ophyd_async.epics.core import (
 
 
 class TetrammRange(StrictEnum):
-    uA = "+- 120 uA"
-    nA = "+- 120 nA"
+    UA = "+- 120 uA"
+    NA = "+- 120 nA"
 
 
 class TetrammTrigger(StrictEnum):
-    FreeRun = "Free run"
-    ExtTrigger = "Ext. trig."
-    ExtBulb = "Ext. bulb"
-    ExtGate = "Ext. gate"
+    FREE_RUN = "Free run"
+    EXT_TRIGGER = "Ext. trig."
+    EXT_BULB = "Ext. bulb"
+    EXT_GATE = "Ext. gate"
 
 
 class TetrammChannels(StrictEnum):
-    One = "1"
-    Two = "2"
-    Four = "4"
+    ONE = "1"
+    TWO = "2"
+    FOUR = "4"
 
 
 class TetrammResolution(StrictEnum):
-    SixteenBits = "16 bits"
-    TwentyFourBits = "24 bits"
+    SIXTEEN_BITS = "16 bits"
+    TWENTY_FOUR_BITS = "24 bits"
 
 
 class TetrammGeometry(StrictEnum):
-    Diamond = "Diamond"
-    Square = "Square"
+    DIAMOND = "Diamond"
+    SQUARE = "Square"
 
 
 class TetrammDriver(Device):
@@ -118,7 +118,7 @@ class TetrammController(DetectorController):
         assert trigger_info.livetime is not None
 
         # trigger mode must be set first and on its own!
-        await self._drv.trigger_mode.set(TetrammTrigger.ExtTrigger)
+        await self._drv.trigger_mode.set(TetrammTrigger.EXT_TRIGGER)
 
         await asyncio.gather(
             self._drv.averaging_time.set(trigger_info.livetime),
@@ -134,8 +134,8 @@ class TetrammController(DetectorController):
 
     def _validate_trigger(self, trigger: DetectorTrigger) -> None:
         supported_trigger_types = {
-            DetectorTrigger.edge_trigger,
-            DetectorTrigger.constant_gate,
+            DetectorTrigger.EDGE_TRIGGER,
+            DetectorTrigger.CONSTANT_GATE,
         }
 
         if trigger not in supported_trigger_types:

--- a/src/dodal/devices/util/test_utils.py
+++ b/src/dodal/devices/util/test_utils.py
@@ -1,8 +1,8 @@
-from ophyd_async.core import (
+from ophyd_async.epics.motor import Motor
+from ophyd_async.testing import (
     callback_on_mock_put,
     set_mock_value,
 )
-from ophyd_async.epics.motor import Motor
 
 
 def patch_motor(motor: Motor, initial_position=0):

--- a/src/dodal/devices/xspress3/xspress3.py
+++ b/src/dodal/devices/xspress3/xspress3.py
@@ -26,12 +26,12 @@ class TriggerMode(StrictEnum):
     SOFTWARE = "Software"
     HARDWARE = "Hardware"
     BURST = "Burst"
-    TTL_Veto_Only = "TTL Veto Only"
+    TTL_VETO_ONLY = "TTL Veto Only"
     IDC = "IDC"
     SOTWARE_START_STOP = "Software Start/Stop"
     TTL_BOTH = "TTL Both"
     LVDS_VETO_ONLY = "LVDS Veto Only"
-    LVDS_both = "LVDS Both"
+    LVDS_BOTH = "LVDS Both"
 
 
 class UpdateRBV(StrictEnum):
@@ -49,7 +49,7 @@ class DetectorState(StrictEnum):
     ACQUIRE = "Acquire"
     READOUT = "Readout"
     CORRECT = "Correct"
-    Saving = "Saving"
+    SAVING = "Saving"
     ABORTING = "Aborting"
     ERROR = "Error"
     WAITING = "Waiting"

--- a/src/dodal/devices/zebra.py
+++ b/src/dodal/devices/zebra.py
@@ -59,25 +59,25 @@ class TrigSource(StrictEnum):
 
 
 class EncEnum(StrictEnum):
-    Enc1 = "Enc1"
-    Enc2 = "Enc2"
-    Enc3 = "Enc3"
-    Enc4 = "Enc4"
-    Enc1_4Av = "Enc1-4Av"
+    ENC1 = "Enc1"
+    ENC2 = "Enc2"
+    ENC3 = "Enc3"
+    ENC4 = "Enc4"
+    ENC1_4AV = "Enc1-4Av"
 
 
 class I03Axes:
-    SMARGON_X1 = EncEnum.Enc1
-    SMARGON_Y = EncEnum.Enc2
-    SMARGON_Z = EncEnum.Enc3
-    OMEGA = EncEnum.Enc4
+    SMARGON_X1 = EncEnum.ENC1
+    SMARGON_Y = EncEnum.ENC2
+    SMARGON_Z = EncEnum.ENC3
+    OMEGA = EncEnum.ENC4
 
 
 class I24Axes:
-    VGON_Z = EncEnum.Enc1
-    OMEGA = EncEnum.Enc2
-    VGON_X = EncEnum.Enc3
-    VGON_YH = EncEnum.Enc4
+    VGON_Z = EncEnum.ENC1
+    OMEGA = EncEnum.ENC2
+    VGON_X = EncEnum.ENC3
+    VGON_YH = EncEnum.ENC4
 
 
 class RotationDirection(StrictEnum):

--- a/system_tests/test_oav_to_redis_system.py
+++ b/system_tests/test_oav_to_redis_system.py
@@ -3,7 +3,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from aiohttp.client_exceptions import ClientConnectorError
-from ophyd_async.core import DeviceCollector, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.oav.oav_to_redis_forwarder import OAVToRedisForwarder, Source
 

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -4,7 +4,6 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from bluesky.run_engine import RunEngine as RE
-from conftest import mock_beamline_module_filepaths
 from ophyd import Device
 from ophyd.device import Device as OphydV1Device
 from ophyd.sim import FakeEpicsSignal
@@ -20,6 +19,8 @@ from dodal.devices.smargon import Smargon
 from dodal.devices.zebra import Zebra
 from dodal.log import LOGGER
 from dodal.utils import DeviceInitializationController, make_all_devices
+
+from ...conftest import mock_beamline_module_filepaths
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+from conftest import mock_attributes_table
+from dodal.common.beamlines import beamline_parameters, beamline_utils
+from dodal.utils import make_all_devices
+
+
+@pytest.fixture(scope="function")
+def module_and_devices_for_beamline(request):
+    beamline = request.param
+    with patch.dict(os.environ, {"BEAMLINE": beamline}, clear=True):
+        bl_mod = importlib.import_module("dodal.beamlines." + beamline)
+        importlib.reload(bl_mod)
+        mock_beamline_module_filepaths(beamline, bl_mod)
+        devices, exceptions = make_all_devices(
+            bl_mod,
+            include_skipped=True,
+            fake_with_ophyd_sim=True,
+        )
+        yield (bl_mod, devices, exceptions)
+        beamline_utils.clear_devices()
+        del bl_mod
+
+
+def mock_beamline_module_filepaths(bl_name, bl_module):
+    if mock_attributes := mock_attributes_table.get(bl_name):
+        [bl_module.__setattr__(attr[0], attr[1]) for attr in mock_attributes]
+        beamline_parameters.BEAMLINE_PARAMETER_PATHS[bl_name] = (
+            "tests/test_data/i04_beamlineParameters"
+        )

--- a/tests/devices/i10/test_i10Apple2.py
+++ b/tests/devices/i10/test_i10Apple2.py
@@ -9,8 +9,8 @@ import pytest
 from bluesky.plans import scan
 from bluesky.run_engine import RunEngine
 from numpy import poly1d
-from ophyd_async.core import (
-    DeviceCollector,
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import (
     assert_emitted,
     callback_on_mock_put,
     get_mock_put,
@@ -43,7 +43,7 @@ async def mock_id_gap(prefix: str = "BLXX-EA-DET-007:") -> UndulatorGap:
     async with DeviceCollector(mock=True):
         mock_id_gap = UndulatorGap(prefix, "mock_id_gap")
     assert mock_id_gap.name == "mock_id_gap"
-    set_mock_value(mock_id_gap.gate, UndulatorGateStatus.close)
+    set_mock_value(mock_id_gap.gate, UndulatorGateStatus.CLOSE)
     set_mock_value(mock_id_gap.velocity, 1)
     set_mock_value(mock_id_gap.user_readback, 20)
     set_mock_value(mock_id_gap.user_setpoint, "20")
@@ -62,7 +62,7 @@ async def mock_phaseAxes(prefix: str = "BLXX-EA-DET-007:") -> UndulatorPhaseAxes
             btm_inner="RPQ4",
         )
     assert mock_phaseAxes.name == "mock_phaseAxes"
-    set_mock_value(mock_phaseAxes.gate, UndulatorGateStatus.close)
+    set_mock_value(mock_phaseAxes.gate, UndulatorGateStatus.CLOSE)
     set_mock_value(mock_phaseAxes.top_outer.velocity, 2)
     set_mock_value(mock_phaseAxes.top_inner.velocity, 2)
     set_mock_value(mock_phaseAxes.btm_outer.velocity, 2)
@@ -92,7 +92,7 @@ async def mock_jaw_phase(prefix: str = "BLXX-EA-DET-007:") -> UndulatorJawPhase:
         mock_jaw_phase = UndulatorJawPhase(
             prefix=prefix, move_pv="RPQ1", jaw_phase="JAW"
         )
-    set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.close)
+    set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.CLOSE)
     set_mock_value(mock_jaw_phase.jaw_phase.velocity, 2)
     set_mock_value(mock_jaw_phase.jaw_phase.user_setpoint_readback, 0)
     set_mock_value(mock_jaw_phase.fault, 0)
@@ -249,7 +249,7 @@ async def test_fail_I10Apple2_set_id_not_ready(mock_id: I10Apple2):
         await mock_id.set(600)
     assert str(e.value) == mock_id.gap().name + " is in fault state"
     set_mock_value(mock_id.gap().fault, 0)
-    set_mock_value(mock_id.gap().gate, UndulatorGateStatus.open)
+    set_mock_value(mock_id.gap().gate, UndulatorGateStatus.OPEN)
     with pytest.raises(RuntimeError) as e:
         await mock_id.set(600)
     assert str(e.value) == mock_id.gap().name + " is already in motion."

--- a/tests/devices/i22/test_dcm.py
+++ b/tests/devices/i22/test_dcm.py
@@ -4,8 +4,8 @@ from unittest.mock import ANY
 import bluesky.plans as bp
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import (
-    DeviceCollector,
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import (
     assert_configuration,
     assert_emitted,
     assert_reading,

--- a/tests/devices/i22/test_fswitch.py
+++ b/tests/devices/i22/test_fswitch.py
@@ -4,7 +4,8 @@ import pytest
 from bluesky.plans import count
 from bluesky.run_engine import RunEngine
 from event_model import DataKey
-from ophyd_async.core import DeviceCollector, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.i22.fswitch import FilterState, FSwitch
 

--- a/tests/devices/test_diamond_filter.py
+++ b/tests/devices/test_diamond_filter.py
@@ -1,10 +1,8 @@
 from unittest.mock import ANY
 
 import pytest
-from ophyd_async.core import (
-    DeviceCollector,
-    assert_reading,
-)
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import assert_reading
 
 from dodal.devices.diamond_filter import DiamondFilter, I03Filters, I04Filters
 

--- a/tests/devices/unit_tests/i24/test_dual_backlight.py
+++ b/tests/devices/unit_tests/i24/test_dual_backlight.py
@@ -1,7 +1,7 @@
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.i24.dual_backlight import (
     BacklightPositions,

--- a/tests/devices/unit_tests/i24/test_focus_mirrors.py
+++ b/tests/devices/unit_tests/i24/test_focus_mirrors.py
@@ -17,9 +17,9 @@ async def test_setting_mirror_focus_returns_correct_beam_size(
 ):
     def set_mirrors():
         yield from bps.abs_set(
-            fake_mirrors.horizontal, HFocusMode.focus3010d, wait=True
+            fake_mirrors.horizontal, HFocusMode.FOCUS_3010D, wait=True
         )
-        yield from bps.abs_set(fake_mirrors.vertical, VFocusMode.focus3010d, wait=True)
+        yield from bps.abs_set(fake_mirrors.vertical, VFocusMode.FOCUS_3010D, wait=True)
 
     RE(set_mirrors())
 

--- a/tests/devices/unit_tests/i24/test_pilatus_metadata.py
+++ b/tests/devices/unit_tests/i24/test_pilatus_metadata.py
@@ -1,6 +1,6 @@
 import bluesky.plan_stubs as bps
 import pytest
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.i24.pilatus_metadata import PilatusMetadata
 

--- a/tests/devices/unit_tests/i24/test_pmac.py
+++ b/tests/devices/unit_tests/i24/test_pmac.py
@@ -4,7 +4,7 @@ from unittest.mock import call, patch
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import callback_on_mock_put, get_mock_put, set_mock_value
+from ophyd_async.testing import callback_on_mock_put, get_mock_put, set_mock_value
 
 from dodal.devices.i24.pmac import (
     HOME_STR,

--- a/tests/devices/unit_tests/oav/conftest.py
+++ b/tests/devices/unit_tests/oav/conftest.py
@@ -1,7 +1,8 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from ophyd_async.core import DeviceCollector, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAVConfig

--- a/tests/devices/unit_tests/oav/image_recognition/test_pin_tip_detect.py
+++ b/tests/devices/unit_tests/oav/image_recognition/test_pin_tip_detect.py
@@ -2,7 +2,7 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.oav.pin_image_recognition import (
     MxSampleDetect,

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.oav.oav_detector import (
     OAV,

--- a/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
+++ b/tests/devices/unit_tests/oav/test_oav_to_redis_forwarder.py
@@ -3,7 +3,8 @@ from datetime import timedelta
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
-from ophyd_async.core import DeviceCollector, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.oav.oav_to_redis_forwarder import (
     OAVToRedisForwarder,

--- a/tests/devices/unit_tests/oav/test_oav_utils.py
+++ b/tests/devices/unit_tests/oav/test_oav_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
 from ophyd.sim import instantiate_fake_device
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.oav.oav_calculations import calculate_beam_distance
 from dodal.devices.oav.oav_detector import OAV

--- a/tests/devices/unit_tests/oav/test_snapshots.py
+++ b/tests/devices/unit_tests/oav/test_snapshots.py
@@ -4,9 +4,9 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 import pytest
 from ophyd_async.core import (
     DeviceCollector,
-    set_mock_value,
     soft_signal_r_and_setter,
 )
+from ophyd_async.testing import set_mock_value
 from PIL import Image
 
 from dodal.devices.oav.snapshots.snapshot_with_beam_centre import (

--- a/tests/devices/unit_tests/p99/test_p99_stage.py
+++ b/tests/devices/unit_tests/p99/test_p99_stage.py
@@ -1,5 +1,6 @@
 import pytest
-from ophyd_async.core import DeviceCollector, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.p99.sample_stage import (
     FilterMotor,
@@ -38,5 +39,5 @@ async def test_sampleAngleStage(sim_sampleAngleStage: SampleAngleStage) -> None:
 
 async def test_filter_wheel(sim_filter_wheel: FilterMotor) -> None:
     assert sim_filter_wheel.name == "sim_filter_wheel"
-    set_mock_value(sim_filter_wheel.user_setpoint, p99StageSelections.Cd25um)
-    assert await sim_filter_wheel.user_setpoint.get_value() == p99StageSelections.Cd25um
+    set_mock_value(sim_filter_wheel.user_setpoint, p99StageSelections.CD25UM)
+    assert await sim_filter_wheel.user_setpoint.get_value() == p99StageSelections.CD25UM

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, call
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import (
-    DeviceCollector,
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import (
     callback_on_mock_put,
     get_mock_put,
     set_mock_value,

--- a/tests/devices/unit_tests/test_attenuator.py
+++ b/tests/devices/unit_tests/test_attenuator.py
@@ -3,7 +3,8 @@ import asyncio
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import DeviceCollector, callback_on_mock_put, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import callback_on_mock_put, set_mock_value
 
 from dodal.devices.attenuator import Attenuator
 

--- a/tests/devices/unit_tests/test_backlight.py
+++ b/tests/devices/unit_tests/test_backlight.py
@@ -3,7 +3,8 @@ from unittest.mock import ANY, AsyncMock, patch
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.backlight import Backlight, BacklightPosition, BacklightPower
 

--- a/tests/devices/unit_tests/test_bart_robot.py
+++ b/tests/devices/unit_tests/test_bart_robot.py
@@ -2,7 +2,7 @@ from asyncio import create_task, sleep
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.robot import BartRobot, PinMounted, RobotLoadFailed, SampleLocation
 

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from unittest.mock import ANY, MagicMock, Mock, call, create_autospec, patch
 
 import pytest
-from conftest import failed_status
 from ophyd.sim import NullStatus, make_fake_device
 from ophyd.status import Status
 from ophyd.utils import UnknownStatusFailure
 
+from conftest import failed_status
 from dodal.devices.detector import DetectorParams, TriggerMode
 from dodal.devices.detector.det_dim_constants import EIGER2_X_16M_SIZE
 from dodal.devices.eiger import AVAILABLE_TIMEOUTS, EigerDetector

--- a/tests/devices/unit_tests/test_focusing_mirror.py
+++ b/tests/devices/unit_tests/test_focusing_mirror.py
@@ -10,8 +10,8 @@ import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
-from ophyd_async.core import (
-    DeviceCollector,
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import (
     callback_on_mock_put,
     get_mock_put,
     set_mock_value,

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -7,7 +7,8 @@ from bluesky import plan_stubs as bps
 from bluesky import preprocessors as bpp
 from bluesky.run_engine import RunEngine
 from ophyd.status import DeviceStatus, Status
-from ophyd_async.core import DeviceCollector, get_mock_put, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import get_mock_put, set_mock_value
 
 from dodal.devices.fast_grid_scan import (
     FastGridScanCommon,

--- a/tests/devices/unit_tests/test_hutch_shutter.py
+++ b/tests/devices/unit_tests/test_hutch_shutter.py
@@ -3,7 +3,7 @@ from unittest.mock import call
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import (
+from ophyd_async.testing import (
     callback_on_mock_put,
     get_mock_put,
     set_mock_value,

--- a/tests/devices/unit_tests/test_linkam3.py
+++ b/tests/devices/unit_tests/test_linkam3.py
@@ -1,8 +1,8 @@
 from unittest.mock import ANY
 
 import pytest
-from ophyd_async.core import (
-    DeviceCollector,
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import (
     callback_on_mock_put,
     get_mock_put,
     set_mock_value,

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -2,7 +2,8 @@ import asyncio
 from unittest.mock import ANY
 
 import pytest
-from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.pressure_jump_cell import (
     FastValveControlRequest,

--- a/tests/devices/unit_tests/test_qbpm.py
+++ b/tests/devices/unit_tests/test_qbpm.py
@@ -1,10 +1,8 @@
 from unittest.mock import ANY
 
 import pytest
-from ophyd_async.core import (
-    DeviceCollector,
-    assert_reading,
-)
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import assert_reading
 
 from dodal.devices.qbpm import QBPM
 

--- a/tests/devices/unit_tests/test_shutter.py
+++ b/tests/devices/unit_tests/test_shutter.py
@@ -1,5 +1,6 @@
 import pytest
-from ophyd_async.core import DeviceCollector, callback_on_mock_put, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import callback_on_mock_put, set_mock_value
 
 from dodal.devices.zebra_controlled_shutter import (
     ZebraShutter,

--- a/tests/devices/unit_tests/test_slits.py
+++ b/tests/devices/unit_tests/test_slits.py
@@ -3,7 +3,8 @@ from typing import Any
 from unittest.mock import ANY
 
 import pytest
-from ophyd_async.core import DeviceCollector, StandardReadable, set_mock_value
+from ophyd_async.core import DeviceCollector, StandardReadable
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.slits import Slits
 

--- a/tests/devices/unit_tests/test_smargon.py
+++ b/tests/devices/unit_tests/test_smargon.py
@@ -1,7 +1,8 @@
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import DeviceCollector, observe_value, set_mock_value
+from ophyd_async.core import DeviceCollector, observe_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.smargon import Smargon, StubPosition
 

--- a/tests/devices/unit_tests/test_synchrotron.py
+++ b/tests/devices/unit_tests/test_synchrotron.py
@@ -5,7 +5,8 @@ from typing import Any
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import DeviceCollector, StandardReadable, set_mock_value
+from ophyd_async.core import DeviceCollector, StandardReadable
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.synchrotron import (
     Synchrotron,

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -1,13 +1,8 @@
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import (
-    DetectorTrigger,
-    DeviceCollector,
-    PathProvider,
-    TriggerInfo,
-    set_mock_value,
-)
+from ophyd_async.core import DetectorTrigger, DeviceCollector, PathProvider, TriggerInfo
 from ophyd_async.epics.adcore import FileWriteMode
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.tetramm import (
     TetrammController,
@@ -57,7 +52,7 @@ async def tetramm(static_path_provider: PathProvider) -> TetrammDetector:
 def supported_trigger_info() -> TriggerInfo:
     return TriggerInfo(
         number_of_triggers=1,
-        trigger=DetectorTrigger.constant_gate,
+        trigger=DetectorTrigger.CONSTANT_GATE,
         deadtime=1.0,
         livetime=0.02,
         frame_timeout=None,
@@ -69,7 +64,7 @@ async def test_max_frame_rate_is_calculated_correctly(
 ):
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.edge_trigger, livetime=2.0
+            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=2.0
         )
     )
 
@@ -112,7 +107,7 @@ async def test_min_exposure_is_calculated_correctly(
     # 100_000 / 17 ~ 5800; 5800 * 0.01 = 58; 58 << tetramm_controller.maximum_readings_per_frame
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.edge_trigger, livetime=0.01
+            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.01
         )
     )
     assert tetramm_controller.readings_per_frame == int(readings_per_time * 0.01)
@@ -120,7 +115,7 @@ async def test_min_exposure_is_calculated_correctly(
     # 100_000 / 17 ~ 5800; 5800 * 0.2 = 1160; 1160 > tetramm_controller.maximum_readings_per_frame
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.edge_trigger, livetime=0.2
+            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.2
         )
     )
     assert (
@@ -132,7 +127,7 @@ async def test_min_exposure_is_calculated_correctly(
     tetramm_controller.maximum_readings_per_frame = 1200
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.edge_trigger, livetime=0.1
+            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.1
         )
     )
     assert tetramm_controller.readings_per_frame == int(readings_per_time * 0.1)
@@ -170,7 +165,7 @@ async def test_set_invalid_exposure_for_number_of_values_per_reading(
         await tetramm_controller.prepare(
             TriggerInfo(
                 number_of_triggers=0,
-                trigger=DetectorTrigger.edge_trigger,
+                trigger=DetectorTrigger.EDGE_TRIGGER,
                 livetime=4e-5,
             )
         )
@@ -200,7 +195,7 @@ async def test_sample_rate_scales_with_exposure_time(
     await tetramm.prepare(
         TriggerInfo(
             number_of_triggers=100,
-            trigger=DetectorTrigger.edge_trigger,
+            trigger=DetectorTrigger.EDGE_TRIGGER,
             deadtime=2e-5,
             livetime=exposure,
             frame_timeout=None,
@@ -213,8 +208,8 @@ async def test_sample_rate_scales_with_exposure_time(
 @pytest.mark.parametrize(
     "trigger_type",
     [
-        DetectorTrigger.internal,
-        DetectorTrigger.variable_gate,
+        DetectorTrigger.INTERNAL,
+        DetectorTrigger.VARIABLE_GATE,
     ],
 )
 async def test_arm_raises_value_error_for_invalid_trigger_type(
@@ -222,8 +217,8 @@ async def test_arm_raises_value_error_for_invalid_trigger_type(
     trigger_type: DetectorTrigger,
 ):
     accepted_types = {
-        DetectorTrigger.edge_trigger,
-        DetectorTrigger.constant_gate,
+        DetectorTrigger.EDGE_TRIGGER,
+        DetectorTrigger.CONSTANT_GATE,
     }
     with pytest.raises(
         ValueError,
@@ -244,8 +239,8 @@ async def test_arm_raises_value_error_for_invalid_trigger_type(
 @pytest.mark.parametrize(
     "trigger_type",
     [
-        DetectorTrigger.edge_trigger,
-        DetectorTrigger.constant_gate,
+        DetectorTrigger.EDGE_TRIGGER,
+        DetectorTrigger.CONSTANT_GATE,
     ],
 )
 async def test_arm_sets_signals_correctly_given_valid_inputs(
@@ -272,7 +267,7 @@ async def test_disarm_disarms_driver(
     await tetramm.prepare(
         TriggerInfo(
             number_of_triggers=0,
-            trigger=DetectorTrigger.edge_trigger,
+            trigger=DetectorTrigger.EDGE_TRIGGER,
             livetime=VALID_TEST_EXPOSURE_TIME,
             deadtime=VALID_TEST_DEADTIME,
         )
@@ -297,7 +292,7 @@ async def test_prepare_with_too_low_a_deadtime_raises_error(
         await tetramm.prepare(
             TriggerInfo(
                 number_of_triggers=5,
-                trigger=DetectorTrigger.edge_trigger,
+                trigger=DetectorTrigger.EDGE_TRIGGER,
                 deadtime=1.0 / 100_000.0,
                 livetime=VALID_TEST_EXPOSURE_TIME,
                 frame_timeout=None,
@@ -312,7 +307,7 @@ async def test_prepare_arms_tetramm(
     await tetramm.prepare(
         TriggerInfo(
             number_of_triggers=5,
-            trigger=DetectorTrigger.edge_trigger,
+            trigger=DetectorTrigger.EDGE_TRIGGER,
             deadtime=0.1,
             livetime=VALID_TEST_EXPOSURE_TIME,
             frame_timeout=None,
@@ -333,7 +328,7 @@ async def test_prepare_sets_up_writer(
     assert await tetramm.hdf.lazy_open.get_value()
     assert await tetramm.hdf.swmr_mode.get_value()
     assert (await tetramm.hdf.file_template.get_value()) == "%s/%s.h5"
-    assert (await tetramm.hdf.file_write_mode.get_value()) == FileWriteMode.stream
+    assert (await tetramm.hdf.file_write_mode.get_value()) == FileWriteMode.STREAM
 
 
 async def test_stage_sets_up_accurate_describe_output(
@@ -359,7 +354,7 @@ async def test_stage_sets_up_accurate_describe_output(
 async def test_error_if_armed_without_exposure(tetramm_controller: TetrammController):
     with pytest.raises(ValueError):
         await tetramm_controller.prepare(
-            TriggerInfo(number_of_triggers=10, trigger=DetectorTrigger.internal)
+            TriggerInfo(number_of_triggers=10, trigger=DetectorTrigger.INTERNAL)
         )
 
 
@@ -372,7 +367,7 @@ async def test_pilatus_controller(
     await controller.prepare(
         TriggerInfo(
             number_of_triggers=1,
-            trigger=DetectorTrigger.constant_gate,
+            trigger=DetectorTrigger.CONSTANT_GATE,
             livetime=VALID_TEST_EXPOSURE_TIME,
             deadtime=VALID_TEST_DEADTIME,
         )
@@ -388,7 +383,7 @@ async def test_pilatus_controller(
 
 
 async def assert_armed(driver: TetrammDriver) -> None:
-    assert (await driver.trigger_mode.get_value()) is TetrammTrigger.ExtTrigger
+    assert (await driver.trigger_mode.get_value()) is TetrammTrigger.EXT_TRIGGER
     assert (await driver.averaging_time.get_value()) == VALID_TEST_EXPOSURE_TIME
     assert (await driver.values_per_reading.get_value()) == 5
     assert (await driver.acquire.get_value()) == 1

--- a/tests/devices/unit_tests/test_thawer.py
+++ b/tests/devices/unit_tests/test_thawer.py
@@ -2,7 +2,8 @@ import asyncio
 from unittest.mock import ANY, AsyncMock, call, patch
 
 import pytest
-from ophyd_async.core import DeviceCollector, get_mock_put
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import get_mock_put
 
 from dodal.devices.thawer import Thawer, ThawerStates, ThawingException, ThawingTimer
 

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -2,8 +2,8 @@ from unittest.mock import ANY
 
 import numpy as np
 import pytest
-from ophyd_async.core import (
-    DeviceCollector,
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import (
     assert_configuration,
     assert_reading,
     set_mock_value,

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from conftest import MOCK_DAQ_CONFIG_PATH
-from ophyd_async.core import AsyncStatus, DeviceCollector, get_mock_put, set_mock_value
+from ophyd_async.core import AsyncStatus, DeviceCollector
+from ophyd_async.testing import get_mock_put, set_mock_value
 
+from conftest import MOCK_DAQ_CONFIG_PATH
 from dodal.devices.dcm import DCM
 from dodal.devices.undulator import AccessError, Undulator, UndulatorGapAccess
 from dodal.devices.undulator_dcm import UndulatorDCM

--- a/tests/devices/unit_tests/test_utils.py
+++ b/tests/devices/unit_tests/test_utils.py
@@ -5,7 +5,8 @@ import pytest
 from ophyd.sim import NullStatus
 from ophyd.status import Status
 from ophyd.utils.errors import StatusTimeoutError, WaitTimeoutError
-from ophyd_async.core import AsyncStatus, get_mock_put, set_mock_value
+from ophyd_async.core import AsyncStatus
+from ophyd_async.testing import get_mock_put, set_mock_value
 
 from dodal.devices.util.epics_util import SetWhenEnabled, run_functions_without_blocking
 from dodal.log import LOGGER, GELFTCPHandler, logging, set_up_all_logging_handlers

--- a/tests/devices/unit_tests/test_watsonmarlow323_pump.py
+++ b/tests/devices/unit_tests/test_watsonmarlow323_pump.py
@@ -1,7 +1,8 @@
 from unittest.mock import ANY
 
 import pytest
-from ophyd_async.core import DeviceCollector, assert_reading, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.watsonmarlow323_pump import (
     WatsonMarlow323Pump,

--- a/tests/devices/unit_tests/test_xbpm_feedback.py
+++ b/tests/devices/unit_tests/test_xbpm_feedback.py
@@ -1,7 +1,8 @@
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import DeviceCollector, set_mock_value
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.xbpm_feedback import XBPMFeedback
 

--- a/tests/devices/unit_tests/test_xspress3.py
+++ b/tests/devices/unit_tests/test_xspress3.py
@@ -5,8 +5,8 @@ import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
-from ophyd_async.core import (
-    DeviceCollector,
+from ophyd_async.core import DeviceCollector
+from ophyd_async.testing import (
     callback_on_mock_put,
     get_mock_put,
     set_mock_value,

--- a/tests/devices/unit_tests/test_zebra.py
+++ b/tests/devices/unit_tests/test_zebra.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.devices.zebra import (
     ArmDemand,

--- a/tests/plan_stubs/test_motor_util_plans.py
+++ b/tests/plan_stubs/test_motor_util_plans.py
@@ -4,14 +4,12 @@ import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
-from ophyd_async.core import (
-    Device,
-    DeviceCollector,
+from ophyd_async.core import Device, DeviceCollector, soft_signal_rw
+from ophyd_async.epics.motor import Motor
+from ophyd_async.testing import (
     get_mock_put,
     set_mock_value,
-    soft_signal_rw,
 )
-from ophyd_async.epics.motor import Motor
 
 from dodal.devices.util.test_utils import patch_motor
 from dodal.plan_stubs.motor_utils import (

--- a/tests/plan_stubs/test_topup_plan.py
+++ b/tests/plan_stubs/test_topup_plan.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 
 from dodal.beamlines import i03
 from dodal.devices.synchrotron import Synchrotron, SynchrotronMode


### PR DESCRIPTION
Fixes dodal to work with changes in ophyd_async 0.9.0a1 pre-release

### Instructions to reviewer on how to test:
1. All tests pass
2. devices connect with `dodal connect`

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
