### PR TITLE
Returning capitalized aperture value name for ApertureValue enum

### DIFF
--- a/src/dodal/devices/aperturescatterguard.py
+++ b/src/dodal/devices/aperturescatterguard.py
@@ -87,6 +87,9 @@ class ApertureValue(StrictEnum):
     MEDIUM = "MEDIUM_APERTURE"
     LARGE = "LARGE_APERTURE"
 
+    def __str__(self):
+        return self.name.capitalize()
+
 
 def load_positions_from_beamline_parameters(
     params: GDABeamlineParameters,

--- a/tests/devices/unit_tests/test_aperture_scatterguard.py
+++ b/tests/devices/unit_tests/test_aperture_scatterguard.py
@@ -426,3 +426,10 @@ def test_get_position_from_gda_aperture_name(
         ap_sg.get_position_from_gda_aperture_name(
             "VERY TINY APERTURE"  # type: ignore
         )
+
+
+def test_aperture_enum_name_formatting():
+    assert f"{ApertureValue.SMALL}" == "Small"
+    assert f"{ApertureValue.MEDIUM}" == "Medium"
+    assert f"{ApertureValue.LARGE}" == "Large"
+    assert f"{ApertureValue.ROBOT_LOAD}" == "Robot_load"


### PR DESCRIPTION
Fixes [#452](https://github.com/DiamondLightSource/mx-bluesky/issues/452)

### Instructions to reviewer on how to test:
1. Check if ApertureValue, formatted as a comment, returns names such as "Small" instead of "ApertureValue.SMALL".

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
