### PR TITLE
Prevent deserialisation error when fetching data from GDA embedded visit service

### DIFF
--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -78,7 +78,7 @@ class RemoteDirectoryServiceClient(DirectoryServiceClient):
         ):
             response.raise_for_status()
             json = await response.json()
-            return DataCollectionIdentifier.model_validate_json(json)
+            return DataCollectionIdentifier.model_validate(json)
 
 
 class LocalDirectoryServiceClient(DirectoryServiceClient):

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -5,7 +5,7 @@ from dodal.common.visit import RemoteDirectoryServiceClient
 
 def create_valid_response(mock_request):
     mock_request.return_value.__aenter__.return_value = (mock_response := MagicMock())
-    mock_response.json = AsyncMock(return_value='{"collectionNumber": 1}')
+    mock_response.json = AsyncMock(return_value={"collectionNumber": 1})
 
 
 @patch("dodal.common.visit.ClientSession.request")


### PR DESCRIPTION
During beamline testing on i22 December 10th, it was found that the current visit service impl uses the wrong method to convert the return value of the GDA numTracker

### Instructions to reviewer on how to test:
1. Run a scan that uses GDA as the numTracker service
2. Confirm that the data_session can be deserialised

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
