### PR TITLE
Use Reference to prevent Device name mangling of undulator and dcm

### DIFF
--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from bluesky.protocols import Movable
-from ophyd_async.core import AsyncStatus, StandardReadable
+from ophyd_async.core import AsyncStatus, Reference, StandardReadable
 
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
 
@@ -33,12 +33,10 @@ class UndulatorDCM(StandardReadable, Movable):
         prefix: str = "",
         name: str = "",
     ):
-        super().__init__(name)
+        self.undulator = Reference(undulator)
+        self.dcm = Reference(dcm)
 
-        # Attributes are set after super call so they are not renamed to
-        # <name>-undulator, etc.
-        self.undulator = undulator
-        self.dcm = dcm
+        super().__init__(name)
 
         # These attributes are just used by hyperion for lookup purposes
         self.pitch_energy_table_path = (
@@ -55,11 +53,11 @@ class UndulatorDCM(StandardReadable, Movable):
 
     @AsyncStatus.wrap
     async def set(self, value: float):
-        await self.undulator.raise_if_not_enabled()
+        await self.undulator().raise_if_not_enabled()
         await asyncio.gather(
-            self.dcm.energy_in_kev.set(value, timeout=ENERGY_TIMEOUT_S),
-            self.undulator.set(value),
+            self.dcm().energy_in_kev.set(value, timeout=ENERGY_TIMEOUT_S),
+            self.undulator().set(value),
         )
         # DCM Perp pitch
         LOGGER.info(f"Adjusting DCM offset to {self.dcm_fixed_offset_mm} mm")
-        await self.dcm.offset_in_mm.set(self.dcm_fixed_offset_mm)
+        await self.dcm().offset_in_mm.set(self.dcm_fixed_offset_mm)

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -36,8 +36,6 @@ class UndulatorDCM(StandardReadable, Movable):
         self.undulator_ref = Reference(undulator)
         self.dcm_ref = Reference(dcm)
 
-        super().__init__(name)
-
         # These attributes are just used by hyperion for lookup purposes
         self.pitch_energy_table_path = (
             daq_configuration_path + "/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
@@ -50,6 +48,8 @@ class UndulatorDCM(StandardReadable, Movable):
         self.dcm_fixed_offset_mm = get_beamline_parameters(
             daq_configuration_path + "/domain/beamlineParameters"
         )["DCM_Perp_Offset_FIXED"]
+
+        super().__init__(name)
 
     @AsyncStatus.wrap
     async def set(self, value: float):

--- a/src/dodal/devices/undulator_dcm.py
+++ b/src/dodal/devices/undulator_dcm.py
@@ -33,8 +33,8 @@ class UndulatorDCM(StandardReadable, Movable):
         prefix: str = "",
         name: str = "",
     ):
-        self.undulator = Reference(undulator)
-        self.dcm = Reference(dcm)
+        self.undulator_ref = Reference(undulator)
+        self.dcm_ref = Reference(dcm)
 
         super().__init__(name)
 
@@ -53,11 +53,11 @@ class UndulatorDCM(StandardReadable, Movable):
 
     @AsyncStatus.wrap
     async def set(self, value: float):
-        await self.undulator().raise_if_not_enabled()
+        await self.undulator_ref().raise_if_not_enabled()
         await asyncio.gather(
-            self.dcm().energy_in_kev.set(value, timeout=ENERGY_TIMEOUT_S),
-            self.undulator().set(value),
+            self.dcm_ref().energy_in_kev.set(value, timeout=ENERGY_TIMEOUT_S),
+            self.undulator_ref().set(value),
         )
         # DCM Perp pitch
         LOGGER.info(f"Adjusting DCM offset to {self.dcm_fixed_offset_mm} mm")
-        await self.dcm().offset_in_mm.set(self.dcm_fixed_offset_mm)
+        await self.dcm_ref().offset_in_mm.set(self.dcm_fixed_offset_mm)

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -51,7 +51,7 @@ async def fake_undulator_dcm() -> UndulatorDCM:
 
 def test_lookup_table_paths_passed(fake_undulator_dcm: UndulatorDCM):
     assert (
-        fake_undulator_dcm.undulator().id_gap_lookup_table_path
+        fake_undulator_dcm.undulator_ref().id_gap_lookup_table_path
         == ID_GAP_LOOKUP_TABLE_PATH
     )
     assert (
@@ -73,21 +73,21 @@ async def test_fixed_offset_decoded(fake_undulator_dcm: UndulatorDCM):
 async def test_if_gap_is_wrong_then_logger_info_is_called_and_gap_is_set_correctly(
     mock_logger: MagicMock, mock_load: MagicMock, fake_undulator_dcm: UndulatorDCM
 ):
-    set_mock_value(fake_undulator_dcm.undulator().current_gap, 5.3)
-    set_mock_value(fake_undulator_dcm.dcm().energy_in_kev.user_readback, 5.7)
+    set_mock_value(fake_undulator_dcm.undulator_ref().current_gap, 5.3)
+    set_mock_value(fake_undulator_dcm.dcm_ref().energy_in_kev.user_readback, 5.7)
 
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
 
     await fake_undulator_dcm.set(6.9)
 
     assert (
-        await fake_undulator_dcm.dcm().energy_in_kev.user_setpoint.get_value()
+        await fake_undulator_dcm.dcm_ref().energy_in_kev.user_setpoint.get_value()
     ) == 6.9
     assert (
-        await fake_undulator_dcm.undulator().gap_motor.user_setpoint.get_value()
+        await fake_undulator_dcm.undulator_ref().gap_motor.user_setpoint.get_value()
     ) == 6.045
     assert (
-        await fake_undulator_dcm.dcm().offset_in_mm.user_setpoint.get_value()
+        await fake_undulator_dcm.dcm_ref().offset_in_mm.user_setpoint.get_value()
     ) == 25.6
     mock_logger.info.assert_called()
 
@@ -99,24 +99,24 @@ async def test_when_gap_access_is_not_checked_if_test_mode_enabled(
     mock_logger: MagicMock, mock_load: MagicMock, fake_undulator_dcm: UndulatorDCM
 ):
     set_mock_value(
-        fake_undulator_dcm.undulator().gap_access, UndulatorGapAccess.DISABLED
+        fake_undulator_dcm.undulator_ref().gap_access, UndulatorGapAccess.DISABLED
     )
-    set_mock_value(fake_undulator_dcm.undulator().current_gap, 5.3)
-    set_mock_value(fake_undulator_dcm.dcm().energy_in_kev.user_readback, 5.7)
+    set_mock_value(fake_undulator_dcm.undulator_ref().current_gap, 5.3)
+    set_mock_value(fake_undulator_dcm.dcm_ref().energy_in_kev.user_readback, 5.7)
 
-    set_mock_value(fake_undulator_dcm.undulator().gap_motor.user_setpoint, 0.0)
-    set_mock_value(fake_undulator_dcm.undulator().gap_motor.user_readback, 0.0)
+    set_mock_value(fake_undulator_dcm.undulator_ref().gap_motor.user_setpoint, 0.0)
+    set_mock_value(fake_undulator_dcm.undulator_ref().gap_motor.user_readback, 0.0)
 
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
 
     await fake_undulator_dcm.set(6.9)
 
     assert (
-        await fake_undulator_dcm.dcm().energy_in_kev.user_setpoint.get_value()
+        await fake_undulator_dcm.dcm_ref().energy_in_kev.user_setpoint.get_value()
     ) == 6.9
     # Verify undulator has not been asked to move
     assert (
-        await fake_undulator_dcm.undulator().gap_motor.user_setpoint.get_value()
+        await fake_undulator_dcm.undulator_ref().gap_motor.user_setpoint.get_value()
     ) == 0.0
 
     mock_logger.info.assert_called()
@@ -128,17 +128,17 @@ async def test_when_gap_access_is_not_checked_if_test_mode_enabled(
 async def test_if_gap_is_already_correct_then_dont_move_gap(
     mock_logger: MagicMock, mock_load: MagicMock, fake_undulator_dcm: UndulatorDCM
 ):
-    set_mock_value(fake_undulator_dcm.dcm().energy_in_kev.user_setpoint, 0.0)
-    set_mock_value(fake_undulator_dcm.dcm().energy_in_kev.user_readback, 0.0)
+    set_mock_value(fake_undulator_dcm.dcm_ref().energy_in_kev.user_setpoint, 0.0)
+    set_mock_value(fake_undulator_dcm.dcm_ref().energy_in_kev.user_readback, 0.0)
 
     mock_load.return_value = np.array([[5700, 5.4606], [7000, 6.045], [9700, 6.404]])
-    set_mock_value(fake_undulator_dcm.undulator().current_gap, 5.4605)
+    set_mock_value(fake_undulator_dcm.undulator_ref().current_gap, 5.4605)
 
     await fake_undulator_dcm.set(5.8)
 
     # Verify undulator has not been asked to move
     assert (
-        await fake_undulator_dcm.undulator().gap_motor.user_setpoint.get_value()
+        await fake_undulator_dcm.undulator_ref().gap_motor.user_setpoint.get_value()
     ) == 0.0
     mock_logger.info.assert_called_once()
     mock_logger.debug.assert_called_once()
@@ -147,19 +147,19 @@ async def test_if_gap_is_already_correct_then_dont_move_gap(
 async def test_dcm_offset_only_set_when_energy_set_completes(
     fake_undulator_dcm: UndulatorDCM,
 ):
-    set_mock_value(fake_undulator_dcm.undulator().current_gap, 5.0)
+    set_mock_value(fake_undulator_dcm.undulator_ref().current_gap, 5.0)
 
     release_dcm = asyncio.Event()
     release_undulator = asyncio.Event()
 
-    fake_undulator_dcm.dcm().energy_in_kev.set = MagicMock(
+    fake_undulator_dcm.dcm_ref().energy_in_kev.set = MagicMock(
         return_value=AsyncStatus(release_dcm.wait())
     )
-    fake_undulator_dcm.undulator().gap_motor.set = MagicMock(
+    fake_undulator_dcm.undulator_ref().gap_motor.set = MagicMock(
         return_value=AsyncStatus(release_undulator.wait())
     )
 
-    offset_put = get_mock_put(fake_undulator_dcm.dcm().offset_in_mm.user_setpoint)
+    offset_put = get_mock_put(fake_undulator_dcm.dcm_ref().offset_in_mm.user_setpoint)
     status = fake_undulator_dcm.set(5.0)
 
     await asyncio.wait([status.task], timeout=0.1)  # type: ignore
@@ -175,15 +175,15 @@ async def test_dcm_offset_only_set_when_energy_set_completes(
 async def test_energy_set_only_complete_when_all_statuses_are_finished(
     fake_undulator_dcm: UndulatorDCM,
 ):
-    set_mock_value(fake_undulator_dcm.undulator().current_gap, 5.0)
+    set_mock_value(fake_undulator_dcm.undulator_ref().current_gap, 5.0)
 
     release_dcm = asyncio.Event()
     release_undulator = asyncio.Event()
 
-    fake_undulator_dcm.dcm().energy_in_kev.set = MagicMock(
+    fake_undulator_dcm.dcm_ref().energy_in_kev.set = MagicMock(
         return_value=AsyncStatus(release_dcm.wait())
     )
-    fake_undulator_dcm.undulator().gap_motor.set = MagicMock(
+    fake_undulator_dcm.undulator_ref().gap_motor.set = MagicMock(
         return_value=AsyncStatus(release_undulator.wait())
     )
 
@@ -202,12 +202,12 @@ async def test_when_undulator_gap_is_disabled_setting_energy_errors_and_dcm_ener
     fake_undulator_dcm: UndulatorDCM,
 ):
     set_mock_value(
-        fake_undulator_dcm.undulator().gap_access, UndulatorGapAccess.DISABLED
+        fake_undulator_dcm.undulator_ref().gap_access, UndulatorGapAccess.DISABLED
     )
 
     with pytest.raises(AccessError):
         await fake_undulator_dcm.set(5)
 
     get_mock_put(
-        fake_undulator_dcm.dcm().energy_in_kev.user_setpoint
+        fake_undulator_dcm.dcm_ref().energy_in_kev.user_setpoint
     ).assert_not_called()


### PR DESCRIPTION
Fixes #929

### Instructions to reviewer on how to test:
1. Check for correct usage of Reference

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
