### PR TITLE
Add "Reset" epics signal

### DIFF
--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -70,8 +70,8 @@ class BartRobot(StandardReadable, Movable):
         self.program_running = epics_signal_r(bool, prefix + "PROGRAM_RUNNING")
         self.program_name = epics_signal_r(str, prefix + "PROGRAM_NAME")
         self.error_str = epics_signal_r(str, prefix + "PRG_ERR_MSG")
-        # Change error_code to int type when https://github.com/bluesky/ophyd-async/issues/280 released
-        self.error_code = epics_signal_r(float, prefix + "PRG_ERR_CODE")
+        self.error_code = epics_signal_r(int, prefix + "PRG_ERR_CODE")
+        self.reset = epics_signal_x(prefix + "RESET.PROC")
         super().__init__(name=name)
 
     async def pin_mounted_or_no_pin_found(self):


### PR DESCRIPTION
Fixes [505](https://github.com/DiamondLightSource/mx-bluesky/issues/505)

### Instructions to reviewer on how to test:
1. Check if correct signal has been added to clear robot error
2. Check if amended error_code type is fine

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
