### PR TITLE
Add dodal device for i03 beamstop

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -24,6 +24,7 @@ from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import PandAFastGridScan, ZebraFastGridScan
 from dodal.devices.flux import Flux
 from dodal.devices.focusing_mirror import FocusingMirrorWithStripes, MirrorVoltages
+from dodal.devices.i03.beamstop import Beamstop
 from dodal.devices.motors import XYZPositioner
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAVConfig
@@ -90,6 +91,22 @@ def attenuator(
         "-EA-ATTN-01:",
         wait_for_connection,
         fake_with_ophyd_sim,
+    )
+
+
+def beamstop(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> Beamstop:
+    """Get the i03 beamstop device, instantiate it if it hasn't already been.
+    If this is called when already instantiated in i03, it will return the existing object.
+    """
+    return device_instantiation(
+        Beamstop,
+        "beamstop",
+        "-MO-BS-01:",
+        wait_for_connection,
+        fake_with_ophyd_sim,
+        beamline_parameters=get_beamline_parameters(),
     )
 
 

--- a/src/dodal/devices/i03/beamstop.py
+++ b/src/dodal/devices/i03/beamstop.py
@@ -43,7 +43,7 @@ class Beamstop(StandardReadable):
     def __init__(
         self,
         prefix: str,
-        beamlineParameters: GDABeamlineParameters,
+        beamline_parameters: GDABeamlineParameters,
         name: str = "",
     ):
         with self.add_children_as_readables():
@@ -55,11 +55,11 @@ class Beamstop(StandardReadable):
             )
 
         self._in_beam_xyz = [
-            float(beamlineParameters[f"in_beam_{axis}_STANDARD"])
+            float(beamline_parameters[f"in_beam_{axis}_STANDARD"])
             for axis in ("x", "y", "z")
         ]
         self._xyz_tolerance = [
-            float(beamlineParameters[f"bs_{axis}_tolerance"])
+            float(beamline_parameters[f"bs_{axis}_tolerance"])
             for axis in ("x", "y", "z")
         ]
 

--- a/src/dodal/devices/i03/beamstop.py
+++ b/src/dodal/devices/i03/beamstop.py
@@ -1,0 +1,82 @@
+from asyncio import gather
+from math import isclose
+
+from ophyd_async.core import StandardReadable, StrictEnum
+from ophyd_async.epics.motor import Motor
+
+from dodal.common.beamlines.beamline_parameters import GDABeamlineParameters
+from dodal.common.signal_utils import create_hardware_backed_soft_signal
+
+
+class BeamstopPositions(StrictEnum):
+    """
+    Beamstop positions.
+    GDA supports Standard/High/Low resolution positions, as well as parked and
+    robot load however all 3 resolution positions are the same. We also
+    do not use the robot load position in Hyperion.
+
+    Until we support moving the beamstop it is only necessary to check whether the
+    beamstop is in beam or not.
+
+    Attributes:
+        IN_BEAM: The beamstop is in beam
+        UNKNOWN: The beamstop is in some other position, check the device motor
+            positions to determine it.
+    """
+
+    IN_BEAM = "In Beam"
+    UNKNOWN = "Unknown"
+
+
+class Beamstop(StandardReadable):
+    """
+    Beamstop for I03.
+
+    Attributes:
+        x: beamstop x position in mm
+        y: beamstop y position in mm
+        z: beamstop z position in mm
+        pos_select: Get the current position of the beamstop as an enum. Currently this
+            is read-only.
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        beamlineParameters: GDABeamlineParameters,
+        name: str = "",
+    ):
+        with self.add_children_as_readables():
+            self.x = Motor(prefix + "X")
+            self.y = Motor(prefix + "Y")
+            self.z = Motor(prefix + "Z")
+            self.pos_select = create_hardware_backed_soft_signal(
+                BeamstopPositions, self._get_selected_position
+            )
+
+        self._in_beam_xyz = [
+            float(beamlineParameters[f"in_beam_{axis}_STANDARD"])
+            for axis in ("x", "y", "z")
+        ]
+        self._xyz_tolerance = [
+            float(beamlineParameters[f"bs_{axis}_tolerance"])
+            for axis in ("x", "y", "z")
+        ]
+
+        super().__init__(name)
+
+    async def _get_selected_position(self) -> BeamstopPositions:
+        current_pos = await gather(
+            self.x.user_readback.get_value(),
+            self.y.user_readback.get_value(),
+            self.z.user_readback.get_value(),
+        )
+        if all(
+            isclose(axis_pos, axis_in_beam, abs_tol=axis_tolerance)
+            for axis_pos, axis_in_beam, axis_tolerance in zip(
+                current_pos, self._in_beam_xyz, self._xyz_tolerance, strict=False
+            )
+        ):
+            return BeamstopPositions.IN_BEAM
+        else:
+            return BeamstopPositions.UNKNOWN

--- a/src/dodal/devices/i03/beamstop.py
+++ b/src/dodal/devices/i03/beamstop.py
@@ -18,6 +18,9 @@ class BeamstopPositions(StrictEnum):
     Until we support moving the beamstop it is only necessary to check whether the
     beamstop is in beam or not.
 
+    See Also:
+        https://github.com/DiamondLightSource/mx-bluesky/issues/484
+
     Attributes:
         DATA_COLLECTION: The beamstop is in beam ready for data collection
         UNKNOWN: The beamstop is in some other position, check the device motor

--- a/src/dodal/devices/i03/beamstop.py
+++ b/src/dodal/devices/i03/beamstop.py
@@ -19,12 +19,12 @@ class BeamstopPositions(StrictEnum):
     beamstop is in beam or not.
 
     Attributes:
-        IN_BEAM: The beamstop is in beam
+        DATA_COLLECTION: The beamstop is in beam ready for data collection
         UNKNOWN: The beamstop is in some other position, check the device motor
             positions to determine it.
     """
 
-    IN_BEAM = "In Beam"
+    DATA_COLLECTION = "Data Collection"
     UNKNOWN = "Unknown"
 
 
@@ -77,6 +77,6 @@ class Beamstop(StandardReadable):
                 current_pos, self._in_beam_xyz, self._xyz_tolerance, strict=False
             )
         ):
-            return BeamstopPositions.IN_BEAM
+            return BeamstopPositions.DATA_COLLECTION
         else:
             return BeamstopPositions.UNKNOWN

--- a/tests/devices/i03/test_beamstop.py
+++ b/tests/devices/i03/test_beamstop.py
@@ -39,16 +39,16 @@ async def test_beamstop_pos_select(
 ):
     beamstop = Beamstop("-MO-BS-01:", beamline_parameters, name="beamstop")
     await beamstop.connect(mock=True)
-    set_mock_value(beamstop.x.user_readback, x)
-    set_mock_value(beamstop.y.user_readback, y)
-    set_mock_value(beamstop.z.user_readback, z)
+    set_mock_value(beamstop.x_mm.user_readback, x)
+    set_mock_value(beamstop.y_mm.user_readback, y)
+    set_mock_value(beamstop.z_mm.user_readback, z)
 
     mock_callback = Mock()
     RE.subscribe(mock_callback, "event")
 
     @run_decorator()
     def check_in_beam():
-        current_pos = yield from bps.rd(beamstop.pos_select)
+        current_pos = yield from bps.rd(beamstop.selected_pos)
         assert current_pos == expected_pos
         yield from bps.create()
         yield from bps.read(beamstop)
@@ -60,7 +60,7 @@ async def test_beamstop_pos_select(
         dropwhile(lambda c: c.args[0] != "event", mock_callback.mock_calls)
     )
     data = event_call.args[1]["data"]
-    assert data["beamstop-x"] == x
-    assert data["beamstop-y"] == y
-    assert data["beamstop-z"] == z
-    assert data["beamstop-pos_select"] == expected_pos
+    assert data["beamstop-x_mm"] == x
+    assert data["beamstop-y_mm"] == y
+    assert data["beamstop-z_mm"] == z
+    assert data["beamstop-selected_pos"] == expected_pos

--- a/tests/devices/i03/test_beamstop.py
+++ b/tests/devices/i03/test_beamstop.py
@@ -22,8 +22,8 @@ def beamline_parameters() -> GDABeamlineParameters:
     "x, y, z, expected_pos",
     [
         [0, 0, 0, BeamstopPositions.UNKNOWN],
-        [1.52, 44.78, 30.0, BeamstopPositions.IN_BEAM],
-        [1.501, 44.776, 29.71, BeamstopPositions.IN_BEAM],
+        [1.52, 44.78, 30.0, BeamstopPositions.DATA_COLLECTION],
+        [1.501, 44.776, 29.71, BeamstopPositions.DATA_COLLECTION],
         [1.499, 44.776, 29.71, BeamstopPositions.UNKNOWN],
         [1.501, 44.774, 29.71, BeamstopPositions.UNKNOWN],
         [1.501, 44.776, 29.69, BeamstopPositions.UNKNOWN],

--- a/tests/devices/i03/test_beamstop.py
+++ b/tests/devices/i03/test_beamstop.py
@@ -1,0 +1,66 @@
+from itertools import dropwhile
+from unittest.mock import Mock
+
+import pytest
+from bluesky import plan_stubs as bps
+from bluesky.preprocessors import run_decorator
+from bluesky.run_engine import RunEngine
+from ophyd_async.testing import set_mock_value
+
+from dodal.common.beamlines.beamline_parameters import GDABeamlineParameters
+from dodal.devices.i03.beamstop import Beamstop, BeamstopPositions
+
+
+@pytest.fixture
+def beamline_parameters() -> GDABeamlineParameters:
+    return GDABeamlineParameters.from_file(
+        "tests/test_data/test_beamline_parameters.txt"
+    )
+
+
+@pytest.mark.parametrize(
+    "x, y, z, expected_pos",
+    [
+        [0, 0, 0, BeamstopPositions.UNKNOWN],
+        [1.52, 44.78, 30.0, BeamstopPositions.IN_BEAM],
+        [1.501, 44.776, 29.71, BeamstopPositions.IN_BEAM],
+        [1.499, 44.776, 29.71, BeamstopPositions.UNKNOWN],
+        [1.501, 44.774, 29.71, BeamstopPositions.UNKNOWN],
+        [1.501, 44.776, 29.69, BeamstopPositions.UNKNOWN],
+    ],
+)
+async def test_beamstop_pos_select(
+    beamline_parameters: GDABeamlineParameters,
+    RE: RunEngine,
+    x: float,
+    y: float,
+    z: float,
+    expected_pos: BeamstopPositions,
+):
+    beamstop = Beamstop("-MO-BS-01:", beamline_parameters, name="beamstop")
+    await beamstop.connect(mock=True)
+    set_mock_value(beamstop.x.user_readback, x)
+    set_mock_value(beamstop.y.user_readback, y)
+    set_mock_value(beamstop.z.user_readback, z)
+
+    mock_callback = Mock()
+    RE.subscribe(mock_callback, "event")
+
+    @run_decorator()
+    def check_in_beam():
+        current_pos = yield from bps.rd(beamstop.pos_select)
+        assert current_pos == expected_pos
+        yield from bps.create()
+        yield from bps.read(beamstop)
+        yield from bps.save()
+
+    RE(check_in_beam())
+
+    event_call = next(
+        dropwhile(lambda c: c.args[0] != "event", mock_callback.mock_calls)
+    )
+    data = event_call.args[1]["data"]
+    assert data["beamstop-x"] == x
+    assert data["beamstop-y"] == y
+    assert data["beamstop-z"] == z
+    assert data["beamstop-pos_select"] == expected_pos


### PR DESCRIPTION
Part of fix for DiamondLightSource/mx-bluesky#698

This adds a beamstop device to the i03 beamline.

See also mx-bluesky PR [698](https://github.com/DiamondLightSource/mx-bluesky/pull/725)

### Instructions to reviewer on how to test:
1. `dodal connect i03` connects the beamstop
2. tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
