### PR TITLE
Update MX beamlines to use new device factory - part 1

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -322,35 +322,27 @@ def xspress3mini() -> Xspress3:
     )
 
 
-def panda(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> HDFPanda:
+@device_factory()
+def panda() -> HDFPanda:
     """Get the i03 panda device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        HDFPanda,
-        "panda",
-        "-EA-PANDA-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return HDFPanda(
+        f"{PREFIX.beamline_prefix}-EA-PANDA-01:",
         path_provider=get_path_provider(),
+        name="panda",
     )
 
 
+@device_factory()
 @skip_device(lambda: BL == "s03")
-def sample_shutter(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> ZebraShutter:
+def sample_shutter() -> ZebraShutter:
     """Get the i03 sample shutter device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        ZebraShutter,
+    return ZebraShutter(
+        f"{PREFIX.beamline_prefix}-EA-SHTR-01:",
         "sample_shutter",
-        "-EA-SHTR-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -360,79 +360,59 @@ def flux(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) ->
     )
 
 
-def xbpm_feedback(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XBPMFeedback:
+@device_factory()
+def xbpm_feedback() -> XBPMFeedback:
     """Get the i03 XBPM feeback device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        XBPMFeedback,
+    return XBPMFeedback(
+        PREFIX.beamline_prefix,
         "xbpm_feedback",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def zocalo(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> ZocaloResults:
+@device_factory()
+def zocalo() -> ZocaloResults:
     """Get the i03 ZocaloResults device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        ZocaloResults,
-        "zocalo",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return ZocaloResults(
+        name="zocalo",
+        prefix=PREFIX.beamline_prefix,
     )
 
 
-def robot(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> BartRobot:
+@device_factory()
+def robot() -> BartRobot:
     """Get the i03 robot device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        BartRobot,
+    return BartRobot(
         "robot",
-        "-MO-ROBOT-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+        f"{PREFIX.beamline_prefix}-MO-ROBOT-01:",
     )
 
 
-def webcam(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Webcam:
+@device_factory()
+def webcam() -> Webcam:
     """Get the i03 webcam, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Webcam,
+    return Webcam(
         "webcam",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+        PREFIX.beamline_prefix,
         url="http://i03-webcam1/axis-cgi/jpg/image.cgi",
     )
 
 
-def thawer(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Thawer:
+@device_factory()
+def thawer() -> Thawer:
     """Get the i03 thawer, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Thawer,
+    return Thawer(
+        f"{PREFIX.beamline_prefix}-EA-THAW-01",
         "thawer",
-        "-EA-THAW-01",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -140,9 +140,7 @@ def mirror_voltages() -> MirrorVoltages:
 
 
 @device_factory()
-def backlight(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Backlight:
+def backlight() -> Backlight:
     """Get the i03 backlight device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
@@ -280,12 +278,17 @@ def undulator_dcm(daq_configuration_path: str | None = None) -> UndulatorDCM:
     """
     # evaluate here not as parameter default to enable post-import mocking
     daq_configuration_path = daq_configuration_path or DAQ_CONFIGURATION_PATH
+    undulator_singleton = (
+        undulator(daq_configuration_path=daq_configuration_path)
+        if (daq_configuration_path and daq_configuration_path != DAQ_CONFIGURATION_PATH)
+        else undulator()
+    )
     return UndulatorDCM(
         name="undulator_dcm",
         prefix=PREFIX.beamline_prefix,
-        undulator=undulator(daq_configuration_path=daq_configuration_path),
+        undulator=undulator_singleton,
         dcm=dcm(),
-        daq_configuration_path=daq_configuration_path,
+        daq_configuration_path=daq_configuration_path or DAQ_CONFIGURATION_PATH,
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -50,7 +50,7 @@ from dodal.devices.zebra.zebra_constants_mapping import (
 from dodal.devices.zebra.zebra_controlled_shutter import ZebraShutter
 from dodal.devices.zocalo import ZocaloResults
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import BeamlinePrefix, get_beamline_name
+from dodal.utils import BeamlinePrefix, get_beamline_name, skip_device
 
 ZOOM_PARAMS_FILE = (
     "/dls_sw/i03/software/gda/configurations/i03-config/xml/jCameraManZoomLevels.xml"
@@ -160,7 +160,7 @@ def detector_motion() -> DetectorMotion:
     )
 
 
-@device_factory(skip=BL == "s03")
+@skip_device(lambda: BL == "s03")
 def eiger(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
@@ -339,7 +339,7 @@ def sample_shutter() -> ZebraShutter:
     )
 
 
-@device_factory(skip=BL == "s03")
+@skip_device(lambda: BL == "s03")
 def flux(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> Flux:
     """Get the i03 flux device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -450,14 +450,12 @@ def diamond_filter() -> DiamondFilter[I03Filters]:
     )
 
 
-def qbpm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> QBPM:
+@device_factory()
+def qbpm() -> QBPM:
     """Get the i03 qbpm device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        QBPM,
+    return QBPM(
+        f"{PREFIX.beamline_prefix}-DI-QBPM-01:",
         "qbpm",
-        "-DI-QBPM-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -416,48 +416,36 @@ def thawer() -> Thawer:
     )
 
 
-def lower_gonio(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XYZPositioner:
+@device_factory()
+def lower_gonio() -> XYZPositioner:
     """Get the i03 lower gonio device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        XYZPositioner,
+    return XYZPositioner(
+        f"{PREFIX.beamline_prefix}-MO-GONP-01:",
         "lower_gonio",
-        "-MO-GONP-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def cryo_stream(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> CryoStream:
+@device_factory()
+def cryo_stream() -> CryoStream:
     """Get the i03 cryostream device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        CryoStream,
+    return CryoStream(
+        PREFIX.beamline_prefix,
         "cryo_stream",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def diamond_filter(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> DiamondFilter[I03Filters]:
+@device_factory()
+def diamond_filter() -> DiamondFilter[I03Filters]:
     """Get the i03 diamond filter device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        DiamondFilter[I03Filters],
-        "diamond_filter",
-        "-MO-FLTR-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return DiamondFilter[I03Filters](
+        prefix=f"{PREFIX.beamline_prefix}-MO-FLTR-01:",
+        name="diamond_filter",
         data_type=I03Filters,
     )
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -277,10 +277,9 @@ def undulator_dcm(daq_configuration_path: str | None = None) -> UndulatorDCM:
     If this is called when already instantiated in i03, it will return the existing object.
     """
     # evaluate here not as parameter default to enable post-import mocking
-    daq_configuration_path = daq_configuration_path or DAQ_CONFIGURATION_PATH
     undulator_singleton = (
         undulator(daq_configuration_path=daq_configuration_path)
-        if (daq_configuration_path and daq_configuration_path != DAQ_CONFIGURATION_PATH)
+        if daq_configuration_path and daq_configuration_path != DAQ_CONFIGURATION_PATH
         else undulator()
     )
     return UndulatorDCM(

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -118,16 +118,12 @@ def dcm() -> DCM:
     )
 
 
+@device_factory()
 @skip_device(lambda: BL == "s03")
-def vfm(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> FocusingMirrorWithStripes:
-    return device_instantiation(
-        device_factory=FocusingMirrorWithStripes,
+def vfm() -> FocusingMirrorWithStripes:
+    return FocusingMirrorWithStripes(
+        prefix=f"{PREFIX.beamline_prefix}-OP-VFM-01:",
         name="vfm",
-        prefix="-OP-VFM-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
         bragg_to_lat_lut_path=DAQ_CONFIGURATION_PATH
         + "/lookup/BeamLineEnergy_DCM_VFM_x_converter.txt",
         x_suffix="LAT",
@@ -135,48 +131,35 @@ def vfm(
     )
 
 
+@device_factory()
 @skip_device(lambda: BL == "s03")
-def mirror_voltages(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> MirrorVoltages:
-    return device_instantiation(
-        device_factory=MirrorVoltages,
+def mirror_voltages() -> MirrorVoltages:
+    return MirrorVoltages(
         name="mirror_voltages",
-        prefix="-MO-PSU-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
+        prefix=f"{PREFIX.beamline_prefix}-MO-PSU-01:",
         daq_configuration_path=DAQ_CONFIGURATION_PATH,
     )
 
 
+@device_factory()
 def backlight(
     wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
 ) -> Backlight:
     """Get the i03 backlight device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        device_factory=Backlight,
-        name="backlight",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
+    return Backlight(prefix=PREFIX.beamline_prefix, name="backlight")
 
 
+@device_factory()
 @skip_device(lambda: BL == "s03")
-def detector_motion(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> DetectorMotion:
+def detector_motion() -> DetectorMotion:
     """Get the i03 detector motion device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        device_factory=DetectorMotion,
+    return DetectorMotion(
+        prefix=PREFIX.beamline_prefix,
         name="detector_motion",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
     )
 
 
@@ -205,85 +188,62 @@ def eiger(
     )
 
 
-def zebra_fast_grid_scan(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> ZebraFastGridScan:
+@device_factory()
+def zebra_fast_grid_scan() -> ZebraFastGridScan:
     """Get the i03 zebra_fast_grid_scan device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        device_factory=ZebraFastGridScan,
+    return ZebraFastGridScan(
+        prefix=f"{PREFIX.beamline_prefix}-MO-SGON-01:",
         name="zebra_fast_grid_scan",
-        prefix="-MO-SGON-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
     )
 
 
-def panda_fast_grid_scan(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> PandAFastGridScan:
+@device_factory()
+def panda_fast_grid_scan() -> PandAFastGridScan:
     """Get the i03 panda_fast_grid_scan device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     This is used instead of the zebra_fast_grid_scan device when using the PandA.
     """
-    return device_instantiation(
-        device_factory=PandAFastGridScan,
+    return PandAFastGridScan(
+        prefix=f"{PREFIX.beamline_prefix}-MO-SGON-01:",
         name="panda_fast_grid_scan",
-        prefix="-MO-SGON-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
     )
 
 
+@device_factory()
 @skip_device(lambda: BL == "s03")
 def oav(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
     params: OAVConfig | None = None,
 ) -> OAV:
     """Get the i03 OAV device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        OAV,
-        "oav",
-        "-DI-OAV-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return OAV(
+        prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:",
+        name="oav",
         config=params or OAVConfig(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
     )
 
 
+@device_factory()
 @skip_device(lambda: BL == "s03")
-def pin_tip_detection(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> PinTipDetection:
+def pin_tip_detection() -> PinTipDetection:
     """Get the i03 pin tip detection device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        PinTipDetection,
+    return PinTipDetection(
+        f"{PREFIX.beamline_prefix}-DI-OAV-01:",
         "pin_tip_detection",
-        "-DI-OAV-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def smargon(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Smargon:
+@device_factory()
+def smargon() -> Smargon:
     """Get the i03 Smargon device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Smargon,
-        "smargon",
-        "-MO-SGON-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+    return Smargon(f"{PREFIX.beamline_prefix}-MO-SGON-01:", "smargon")
 
 
 def s4_slit_gaps(
@@ -301,94 +261,64 @@ def s4_slit_gaps(
     )
 
 
+@device_factory()
 @skip_device(lambda: BL == "s03")
-def synchrotron(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Synchrotron:
+def synchrotron() -> Synchrotron:
     """Get the i03 synchrotron device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Synchrotron,
-        "synchrotron",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-        bl_prefix=False,
-    )
+    return Synchrotron("", "synchrotron")
 
 
-def undulator(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-    daq_configuration_path: str | None = None,
-) -> Undulator:
+@device_factory()
+def undulator(daq_configuration_path: str | None = None) -> Undulator:
     """Get the i03 undulator device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Undulator,
-        "undulator",
+    return Undulator(
         f"{BeamlinePrefix(BL).insertion_prefix}-MO-SERVC-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-        bl_prefix=False,
+        name="undulator",
         # evaluate here not as parameter default to enable post-import mocking
         id_gap_lookup_table_path=f"{daq_configuration_path or DAQ_CONFIGURATION_PATH}/lookup/BeamLine_Undulator_toGap.txt",
     )
 
 
-def undulator_dcm(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-    daq_configuration_path: str | None = None,
-) -> UndulatorDCM:
+@device_factory()
+def undulator_dcm(daq_configuration_path: str | None = None) -> UndulatorDCM:
     """Get the i03 undulator DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        UndulatorDCM,
+    # evaluate here not as parameter default to enable post-import mocking
+    daq_configuration_path = daq_configuration_path or DAQ_CONFIGURATION_PATH
+    return UndulatorDCM(
         name="undulator_dcm",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        undulator=undulator(
-            wait_for_connection,
-            fake_with_ophyd_sim,
-            daq_configuration_path=daq_configuration_path,
-        ),
+        prefix=PREFIX.beamline_prefix,
+        undulator=undulator(daq_configuration_path=daq_configuration_path),
         dcm=dcm(),
-        # evaluate here not as parameter default to enable post-import mocking
-        daq_configuration_path=daq_configuration_path or DAQ_CONFIGURATION_PATH,
+        daq_configuration_path=daq_configuration_path,
     )
 
 
-def zebra(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> Zebra:
+@device_factory()
+def zebra() -> Zebra:
     """Get the i03 zebra device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Zebra,
+    return Zebra(
         "zebra",
-        "-EA-ZEBRA-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+        f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:",
         mapping=I03_ZEBRA_MAPPING,
     )
 
 
-def xspress3mini(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Xspress3:
+@device_factory()
+def xspress3mini() -> Xspress3:
     """Get the i03 Xspress3Mini device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Xspress3,
+    return Xspress3(
+        f"{PREFIX.beamline_prefix}-EA-XSP3-01:",
         "xspress3mini",
-        "-EA-XSP3-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -50,7 +50,7 @@ from dodal.devices.zebra.zebra_constants_mapping import (
 from dodal.devices.zebra.zebra_controlled_shutter import ZebraShutter
 from dodal.devices.zocalo import ZocaloResults
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import BeamlinePrefix, get_beamline_name, skip_device
+from dodal.utils import BeamlinePrefix, get_beamline_name
 
 ZOOM_PARAMS_FILE = (
     "/dls_sw/i03/software/gda/configurations/i03-config/xml/jCameraManZoomLevels.xml"
@@ -118,8 +118,7 @@ def dcm() -> DCM:
     )
 
 
-@device_factory()
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def vfm() -> FocusingMirrorWithStripes:
     return FocusingMirrorWithStripes(
         prefix=f"{PREFIX.beamline_prefix}-OP-VFM-01:",
@@ -131,8 +130,7 @@ def vfm() -> FocusingMirrorWithStripes:
     )
 
 
-@device_factory()
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def mirror_voltages() -> MirrorVoltages:
     return MirrorVoltages(
         name="mirror_voltages",
@@ -151,8 +149,7 @@ def backlight(
     return Backlight(prefix=PREFIX.beamline_prefix, name="backlight")
 
 
-@device_factory()
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def detector_motion() -> DetectorMotion:
     """Get the i03 detector motion device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -163,7 +160,7 @@ def detector_motion() -> DetectorMotion:
     )
 
 
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def eiger(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
@@ -211,8 +208,7 @@ def panda_fast_grid_scan() -> PandAFastGridScan:
     )
 
 
-@device_factory()
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def oav(
     params: OAVConfig | None = None,
 ) -> OAV:
@@ -226,8 +222,7 @@ def oav(
     )
 
 
-@device_factory()
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def pin_tip_detection() -> PinTipDetection:
     """Get the i03 pin tip detection device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -261,8 +256,7 @@ def s4_slit_gaps(
     )
 
 
-@device_factory()
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def synchrotron() -> Synchrotron:
     """Get the i03 synchrotron device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -334,8 +328,7 @@ def panda() -> HDFPanda:
     )
 
 
-@device_factory()
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def sample_shutter() -> ZebraShutter:
     """Get the i03 sample shutter device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -346,7 +339,7 @@ def sample_shutter() -> ZebraShutter:
     )
 
 
-@skip_device(lambda: BL == "s03")
+@device_factory(skip=BL == "s03")
 def flux(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> Flux:
     """Get the i03 flux device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -2,6 +2,7 @@ from ophyd_async.fastcs.panda import HDFPanda
 
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
 from dodal.common.beamlines.beamline_utils import (
+    device_factory,
     device_instantiation,
     get_path_provider,
     set_path_provider,
@@ -69,68 +70,51 @@ I03_ZEBRA_MAPPING = ZebraMapping(
     AND_GATE_FOR_AUTO_SHUTTER=2,
 )
 
+PREFIX = BeamlinePrefix(BL)
 
-def aperture_scatterguard(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> ApertureScatterguard:
+
+@device_factory()
+def aperture_scatterguard() -> ApertureScatterguard:
     """Get the i03 aperture and scatterguard device, instantiate it if it hasn't already
     been. If this is called when already instantiated in i03, it will return the existing
     object.
     """
     params = get_beamline_parameters()
-    return device_instantiation(
-        device_factory=ApertureScatterguard,
-        name="aperture_scatterguard",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
+    return ApertureScatterguard(
+        prefix=PREFIX.beamline_prefix,
         loaded_positions=load_positions_from_beamline_parameters(params),
         tolerances=AperturePosition.tolerances_from_gda_params(params),
     )
 
 
-def attenuator(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> BinaryFilterAttenuator:
+@device_factory()
+def attenuator() -> BinaryFilterAttenuator:
     """Get the i03 attenuator device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        BinaryFilterAttenuator,
-        "attenuator",
-        "-EA-ATTN-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-    )
+    return BinaryFilterAttenuator(f"{PREFIX.beamline_prefix}-EA-ATTN-01:")
 
 
-def beamstop(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Beamstop:
+@device_factory()
+def beamstop() -> Beamstop:
     """Get the i03 beamstop device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Beamstop,
-        "beamstop",
-        "-MO-BS-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return Beamstop(
+        prefix=f"{PREFIX.beamline_prefix}-MO-BS-01:",
+        name="beamstop",
         beamline_parameters=get_beamline_parameters(),
     )
 
 
-def dcm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> DCM:
+@device_factory()
+def dcm() -> DCM:
     """Get the i03 DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        DCM,
+    return DCM(
+        f"{PREFIX.beamline_prefix}-MO-DCM-01:",
         "dcm",
-        "-MO-DCM-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
@@ -373,7 +357,7 @@ def undulator_dcm(
             fake_with_ophyd_sim,
             daq_configuration_path=daq_configuration_path,
         ),
-        dcm=dcm(wait_for_connection, fake_with_ophyd_sim),
+        dcm=dcm(),
         # evaluate here not as parameter default to enable post-import mocking
         daq_configuration_path=daq_configuration_path or DAQ_CONFIGURATION_PATH,
     )

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -241,18 +241,14 @@ def smargon() -> Smargon:
     return Smargon(f"{PREFIX.beamline_prefix}-MO-SGON-01:", "smargon")
 
 
-def s4_slit_gaps(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> S4SlitGaps:
+@device_factory()
+def s4_slit_gaps() -> S4SlitGaps:
     """Get the i03 s4_slit_gaps device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        S4SlitGaps,
+    return S4SlitGaps(
+        f"{PREFIX.beamline_prefix}-AL-SLITS-04:",
         "s4_slit_gaps",
-        "-AL-SLITS-04:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
@@ -299,8 +295,8 @@ def zebra() -> Zebra:
     If this is called when already instantiated in i03, it will return the existing object.
     """
     return Zebra(
-        "zebra",
-        f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:",
+        name="zebra",
+        prefix=f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:",
         mapping=I03_ZEBRA_MAPPING,
     )
 
@@ -339,17 +335,14 @@ def sample_shutter() -> ZebraShutter:
     )
 
 
-@skip_device(lambda: BL == "s03")
-def flux(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> Flux:
+@device_factory(skip=BL == "s03")
+def flux() -> Flux:
     """Get the i03 flux device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        Flux,
+    return Flux(
+        f"{PREFIX.beamline_prefix}-MO-FLUX-01:",
         "flux",
-        "-MO-FLUX-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -1,5 +1,5 @@
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
-from dodal.common.beamlines.beamline_utils import device_instantiation
+from dodal.common.beamlines.beamline_utils import device_factory, device_instantiation
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.devices.aperturescatterguard import (
     AperturePosition,
@@ -56,6 +56,8 @@ I04_ZEBRA_MAPPING = ZebraMapping(
     outputs=(ZebraTTLOutputs(TTL_DETECTOR=1, TTL_FAST_SHUTTER=2, TTL_XSPRESS3=3)),
     sources=ZebraSources(),
 )
+
+PREFIX = BeamlinePrefix(BL)
 
 
 def smargon(
@@ -438,17 +440,13 @@ def oav_to_redis_forwarder(
     )
 
 
-def diamond_filter(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> DiamondFilter[I04Filters]:
+@device_factory()
+def diamond_filter() -> DiamondFilter[I04Filters]:
     """Get the i04 diamond filter device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
     """
-    return device_instantiation(
-        DiamondFilter[I04Filters],
-        "diamond_filter",
-        "-MO-FLTR-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return DiamondFilter[I04Filters](
+        prefix=f"{PREFIX.beamline_prefix}-MO-FLTR-01:",
+        name="diamond_filter",
         data_type=I04Filters,
     )

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -431,8 +431,8 @@ def is_v2_device_type(obj: type[Any]) -> bool:
                 # when inspecting device_factory decorator function itself
                 # Later versions of Python seem not to be affected
                 pass
-    else:
-        return False
+
+    return False
 
 
 def is_v1_device_type(obj: type[Any]) -> bool:

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -161,7 +161,7 @@ class DeviceInitializationController(Generic[D]):
         Once the device is connected, the value of mock must be consistent, or connect
         must be False.
 
-        Additional keyword arguments will be passed through to the wrapped factory function
+        Additional keyword arguments will be passed through to the wrapped factory function.
 
         Args:
             connect_immediately (bool, default False): whether to call connect on the
@@ -185,8 +185,17 @@ class DeviceInitializationController(Generic[D]):
 
         Returns:
             D: a singleton instance of the Device class returned by the wrapped factory.
+
+        Raises:
+            RuntimeError:   If the device factory was invoked again with different
+             keyword arguments, without previously invoking cache_clear()
         """
         device = self._factory(**kwargs)
+        if self._factory.cache_info().currsize > 1:  # type: ignore
+            raise RuntimeError(
+                f"Device factory method called multiple times with different parameters: "
+                f"{self.__name__}"
+            )  # type: ignore
 
         if connect_immediately:
             call_in_bluesky_event_loop(

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -194,8 +194,8 @@ class DeviceInitializationController(Generic[D]):
         if self._factory.cache_info().currsize > 1:  # type: ignore
             raise RuntimeError(
                 f"Device factory method called multiple times with different parameters: "
-                f"{self.__name__}"
-            )  # type: ignore
+                f"{self.__name__}"  # type: ignore
+            )
 
         if connect_immediately:
             call_in_bluesky_event_loop(

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -128,7 +128,7 @@ class DeviceInitializationController(Generic[D]):
         mock: bool,
         skip: SkipType,
     ):
-        self._factory: Callable[[], D] = functools.cache(factory)
+        self._factory: Callable[..., D] = functools.cache(factory)
         self._use_factory_name = use_factory_name
         self._timeout = timeout
         self._mock = mock
@@ -153,6 +153,7 @@ class DeviceInitializationController(Generic[D]):
         name: str | None = None,
         connection_timeout: float | None = None,
         mock: bool | None = None,
+        **kwargs,
     ) -> D:
         """Returns an instance of the Device the wrapped factory produces: the same
         instance will be returned if this method is called multiple times, and arguments
@@ -160,6 +161,7 @@ class DeviceInitializationController(Generic[D]):
         Once the device is connected, the value of mock must be consistent, or connect
         must be False.
 
+        Additional keyword arguments will be passed through to the wrapped factory function
 
         Args:
             connect_immediately (bool, default False): whether to call connect on the
@@ -184,7 +186,7 @@ class DeviceInitializationController(Generic[D]):
         Returns:
             D: a singleton instance of the Device class returned by the wrapped factory.
         """
-        device = self._factory()
+        device = self._factory(**kwargs)
 
         if connect_immediately:
             call_in_bluesky_event_loop(
@@ -410,7 +412,7 @@ def is_any_device_factory(func: Callable) -> TypeGuard[AnyDeviceFactory]:
 
 
 def is_v2_device_type(obj: type[Any]) -> bool:
-    return inspect.isclass(obj) and isinstance(obj, OphydV2Device)
+    return inspect.isclass(obj) and issubclass(obj, OphydV2Device)
 
 
 def is_v1_device_type(obj: type[Any]) -> bool:

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -412,7 +412,17 @@ def is_any_device_factory(func: Callable) -> TypeGuard[AnyDeviceFactory]:
 
 
 def is_v2_device_type(obj: type[Any]) -> bool:
-    return inspect.isclass(obj) and issubclass(obj, OphydV2Device)
+    if inspect.isclass(obj):
+        non_parameterized_class = obj
+    elif hasattr(obj, "__origin__"):
+        # typing._GenericAlias is the same as types.GenericAlias, maybe?
+        # This is all very badly documented and possibly prone to change in future versions of Python
+        non_parameterized_class = obj.__origin__
+    else:
+        return False
+    return non_parameterized_class and issubclass(
+        non_parameterized_class, OphydV2Device
+    )
 
 
 def is_v1_device_type(obj: type[Any]) -> bool:

--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -6,9 +6,7 @@ def test_list():
     beamline_utils.clear_devices()
     i03.zebra(wait_for_connection=False, fake_with_ophyd_sim=True)
     i03.synchrotron(wait_for_connection=False, fake_with_ophyd_sim=True)
-    i03.aperture_scatterguard(wait_for_connection=False, fake_with_ophyd_sim=True)
     assert beamline_utils.list_active_devices() == [
         "zebra",
         "synchrotron",
-        "aperture_scatterguard",
     ]

--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -1,9 +1,0 @@
-from dodal.beamlines import i03
-from dodal.common.beamlines import beamline_utils
-
-
-def test_list():
-    i03.s4_slit_gaps(wait_for_connection=True, fake_with_ophyd_sim=True)
-    assert beamline_utils.list_active_devices() == ["s4_slit_gaps"]
-    beamline_utils.clear_devices()
-    assert beamline_utils.list_active_devices() == []

--- a/tests/beamlines/unit_tests/test_i03.py
+++ b/tests/beamlines/unit_tests/test_i03.py
@@ -3,10 +3,7 @@ from dodal.common.beamlines import beamline_utils
 
 
 def test_list():
+    i03.s4_slit_gaps(wait_for_connection=True, fake_with_ophyd_sim=True)
+    assert beamline_utils.list_active_devices() == ["s4_slit_gaps"]
     beamline_utils.clear_devices()
-    i03.zebra(wait_for_connection=False, fake_with_ophyd_sim=True)
-    i03.synchrotron(wait_for_connection=False, fake_with_ophyd_sim=True)
-    assert beamline_utils.list_active_devices() == [
-        "zebra",
-        "synchrotron",
-    ]
+    assert beamline_utils.list_active_devices() == []

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -85,7 +85,7 @@ def test_instantiate_v2_function_fake_makes_fake():
 def test_clear_devices(RE):
     devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert (
-        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys())
+        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 4
         and len(exceptions) == 0
     )
     beamline_utils.clear_devices()

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import os
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -36,6 +37,8 @@ def flush_event_loop_on_finish(event_loop):
 def setup():
     beamline_utils.clear_devices()
     mock_beamline_module_filepaths("i03", i03)
+    with patch.dict(os.environ, {"BEAMLINE": "i03"}):
+        yield
 
 
 def test_instantiate_function_makes_supplied_device():
@@ -83,7 +86,9 @@ def test_instantiate_v2_function_fake_makes_fake():
 
 
 def test_clear_devices(RE):
-    devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
+    devices, exceptions = make_all_devices(
+        i03, fake_with_ophyd_sim=True, include_skipped=True
+    )
     assert (
         # These are the only 3 devices remaining in i03 that are still OphydV1
         len(beamline_utils.ACTIVE_DEVICES) == len(["flux", "s4_slit_gaps", "eiger"])

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -85,7 +85,7 @@ def test_instantiate_v2_function_fake_makes_fake():
 def test_clear_devices(RE):
     devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert (
-        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 18
+        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 20
         and len(exceptions) == 0
     )
     beamline_utils.clear_devices()

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -85,24 +85,12 @@ def test_instantiate_v2_function_fake_makes_fake():
 def test_clear_devices(RE):
     devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert (
-        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 28
+        # These are the only 3 devices remaining in i03 that are still OphydV1
+        len(beamline_utils.ACTIVE_DEVICES) == len(["flux", "s4_slit_gaps", "eiger"])
         and len(exceptions) == 0
     )
     beamline_utils.clear_devices()
     assert beamline_utils.ACTIVE_DEVICES == {}
-
-
-def test_device_is_new_after_clearing(RE):
-    def _make_devices_and_get_id():
-        devices, _ = make_all_devices(i03, fake_with_ophyd_sim=True)
-        return [id(device) for device in devices.values()]
-
-    ids_1 = [_make_devices_and_get_id()]
-    ids_2 = [_make_devices_and_get_id()]
-    assert ids_1 == ids_2
-    beamline_utils.clear_devices()
-    ids_3 = [_make_devices_and_get_id()]
-    assert ids_1 != ids_3
 
 
 @pytest.mark.parametrize(

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -85,7 +85,7 @@ def test_instantiate_v2_function_fake_makes_fake():
 def test_clear_devices(RE):
     devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert (
-        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 20
+        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 25
         and len(exceptions) == 0
     )
     beamline_utils.clear_devices()

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -86,12 +86,10 @@ def test_instantiate_v2_function_fake_makes_fake():
 
 
 def test_clear_devices(RE):
-    devices, exceptions = make_all_devices(
-        i03, fake_with_ophyd_sim=True, include_skipped=True
-    )
+    devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert (
-        # These are the only 3 devices remaining in i03 that are still OphydV1
-        len(beamline_utils.ACTIVE_DEVICES) == len(["flux", "s4_slit_gaps", "eiger"])
+        # This is the only device is in i03 and is still OphydV1 and not skipped
+        len(beamline_utils.ACTIVE_DEVICES) == len(["s4_slit_gaps"])
         and len(exceptions) == 0
     )
     beamline_utils.clear_devices()

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -85,7 +85,7 @@ def test_instantiate_v2_function_fake_makes_fake():
 def test_clear_devices(RE):
     devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert (
-        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 25
+        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 28
         and len(exceptions) == 0
     )
     beamline_utils.clear_devices()

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -18,7 +18,7 @@ from dodal.devices.focusing_mirror import FocusingMirror
 from dodal.devices.motors import XYZPositioner
 from dodal.devices.smargon import Smargon
 from dodal.log import LOGGER
-from dodal.utils import DeviceInitializationController, make_all_devices
+from dodal.utils import DeviceInitializationController
 
 from ...conftest import mock_beamline_module_filepaths
 
@@ -83,17 +83,6 @@ def test_instantiate_v2_function_fake_makes_fake():
     )
     assert isinstance(fake_smargon, StandardReadable)
     assert fake_smargon.omega.user_setpoint.source.startswith("mock+ca")
-
-
-def test_clear_devices(RE):
-    devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
-    assert (
-        # This is the only device is in i03 and is still OphydV1 and not skipped
-        len(beamline_utils.ACTIVE_DEVICES) == len(["s4_slit_gaps"])
-        and len(exceptions) == 0
-    )
-    beamline_utils.clear_devices()
-    assert beamline_utils.ACTIVE_DEVICES == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -85,7 +85,7 @@ def test_instantiate_v2_function_fake_makes_fake():
 def test_clear_devices(RE):
     devices, exceptions = make_all_devices(i03, fake_with_ophyd_sim=True)
     assert (
-        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 4
+        len(beamline_utils.ACTIVE_DEVICES) == len(devices.keys()) - 18
         and len(exceptions) == 0
     )
     beamline_utils.clear_devices()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 import pytest
 
 from conftest import mock_attributes_table
+from dodal.beamlines import i03
 from dodal.common.beamlines import beamline_parameters, beamline_utils
-from dodal.utils import make_all_devices
+from dodal.utils import collect_factories, make_all_devices
 
 
 @pytest.fixture(scope="function")
@@ -32,3 +33,15 @@ def mock_beamline_module_filepaths(bl_name, bl_module):
         beamline_parameters.BEAMLINE_PARAMETER_PATHS[bl_name] = (
             "tests/test_data/i04_beamlineParameters"
         )
+
+
+@pytest.fixture(scope="session")
+def i03_device_factories():
+    return [f for f in collect_factories(i03).values() if hasattr(f, "cache_clear")]
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_device_factory_caches_after_every_test(i03_device_factories):
+    yield None
+    for f in i03_device_factories:
+        f.cache_clear()  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ def module_and_devices_for_beamline(request):
     beamline = request.param
     with patch.dict(os.environ, {"BEAMLINE": beamline}, clear=True):
         bl_mod = importlib.import_module("dodal.beamlines." + beamline)
-        importlib.reload(bl_mod)
         mock_beamline_module_filepaths(beamline, bl_mod)
         devices, exceptions = make_all_devices(
             bl_mod,

--- a/tests/devices/unit_tests/conftest.py
+++ b/tests/devices/unit_tests/conftest.py
@@ -8,7 +8,7 @@ from dodal.devices.util.test_utils import patch_motor
 
 @pytest.fixture
 def smargon(RE: RunEngine):
-    smargon = i03.smargon(fake_with_ophyd_sim=True)
+    smargon = i03.smargon(connect_immediately=True, mock=True)
 
     for motor in [smargon.omega, smargon.x, smargon.y, smargon.z]:
         patch_motor(motor)

--- a/tests/devices/unit_tests/test_webcam.py
+++ b/tests/devices/unit_tests/test_webcam.py
@@ -12,7 +12,7 @@ from dodal.devices.webcam import Webcam, create_placeholder_image
 @pytest.fixture
 def webcam() -> Webcam:
     RunEngine()
-    return i03.webcam(fake_with_ophyd_sim=True)
+    return i03.webcam(connect_immediately=True, mock=True)
 
 
 async def test_given_last_saved_path_when_device_read_then_returns_path(webcam: Webcam):

--- a/tests/fake_beamline.py
+++ b/tests/fake_beamline.py
@@ -5,6 +5,7 @@ from ophyd import EpicsMotor
 
 from dodal.devices.cryostream import CryoStream
 from dodal.devices.diamond_filter import DiamondFilter, I03Filters
+from dodal.utils import OphydV2Device
 
 
 def device_a() -> Readable:
@@ -21,6 +22,10 @@ def device_c() -> CryoStream:
 
 def generic_device_d() -> DiamondFilter[I03Filters]:
     return _mock_with_name("diamond_filter")
+
+
+def plain_ophyd_v2_device() -> OphydV2Device:
+    return _mock_with_name("ophyd_v2_device")
 
 
 def not_device() -> int:

--- a/tests/fake_beamline.py
+++ b/tests/fake_beamline.py
@@ -4,6 +4,7 @@ from bluesky.protocols import Readable
 from ophyd import EpicsMotor
 
 from dodal.devices.cryostream import CryoStream
+from dodal.devices.diamond_filter import DiamondFilter, I03Filters
 
 
 def device_a() -> Readable:
@@ -16,6 +17,10 @@ def device_b() -> EpicsMotor:
 
 def device_c() -> CryoStream:
     return _mock_with_name("cryo")
+
+
+def generic_device_d() -> DiamondFilter[I03Filters]:
+    return _mock_with_name("diamond_filter")
 
 
 def not_device() -> int:

--- a/tests/plan_stubs/test_topup_plan.py
+++ b/tests/plan_stubs/test_topup_plan.py
@@ -15,7 +15,7 @@ from dodal.plan_stubs.check_topup import (
 
 @pytest.fixture
 def synchrotron(RE) -> Synchrotron:
-    return i03.synchrotron(fake_with_ophyd_sim=True)
+    return i03.synchrotron(connect_immediately=True, mock=True)
 
 
 @patch("dodal.plan_stubs.check_topup.wait_for_topup_complete")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,12 +29,13 @@ def test_finds_device_factories() -> None:
 
     factories = collect_factories(fake_beamline)
 
-    from tests.fake_beamline import device_a, device_b, device_c
+    from tests.fake_beamline import device_a, device_b, device_c, generic_device_d
 
     assert {
         "device_a": device_a,
         "device_b": device_b,
         "device_c": device_c,
+        "generic_device_d": generic_device_d,
     } == factories
 
 
@@ -42,7 +43,9 @@ def test_makes_devices() -> None:
     import tests.fake_beamline as fake_beamline
 
     devices, exceptions = make_all_devices(fake_beamline)
-    assert {"readable", "motor", "cryo"} == devices.keys() and len(exceptions) == 0
+    assert {"readable", "motor", "cryo", "diamond_filter"} == devices.keys() and len(
+        exceptions
+    ) == 0
 
 
 def test_makes_devices_with_dependencies() -> None:
@@ -61,7 +64,9 @@ def test_makes_devices_with_disordered_dependencies() -> None:
 
 def test_makes_devices_with_module_name() -> None:
     devices, exceptions = make_all_devices("tests.fake_beamline")
-    assert {"readable", "motor", "cryo"} == devices.keys() and len(exceptions) == 0
+    assert {"readable", "motor", "cryo", "diamond_filter"} == devices.keys() and len(
+        exceptions
+    ) == 0
 
 
 def test_get_hostname() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,8 @@ from dodal.utils import (
     make_device,
 )
 
+MOCK_DAQ_CONFIG_PATH = "tests/devices/unit_tests/test_daq_configuration"
+
 
 def test_finds_device_factories() -> None:
     import tests.fake_beamline as fake_beamline
@@ -425,3 +427,28 @@ def test_filter_ophyd_devices_raises_for_extra_types():
 )
 def test_is_v2_device_type(input: Any, expected_result: bool):
     assert is_v2_device_type(input) == expected_result
+
+
+def test_calling_factory_with_different_args_raises_an_exception():
+    i03.undulator(daq_configuration_path=MOCK_DAQ_CONFIG_PATH)
+    with pytest.raises(
+        RuntimeError,
+        match="Device factory method called multiple times with different parameters",
+    ):
+        i03.undulator(daq_configuration_path=MOCK_DAQ_CONFIG_PATH + "x")
+
+
+def test_calling_factory_with_different_args_does_not_raise_an_exception_after_cache_clear():
+    i03.undulator(daq_configuration_path=MOCK_DAQ_CONFIG_PATH)
+    i03.undulator.cache_clear()  # type: ignore
+    i03.undulator(daq_configuration_path=MOCK_DAQ_CONFIG_PATH + "x")
+
+
+def test_factories_can_be_called_in_any_order():
+    pass
+
+
+def test_factory_calls_are_cached():
+    undulator1 = i03.undulator(daq_configuration_path=MOCK_DAQ_CONFIG_PATH)
+    undulator2 = i03.undulator(daq_configuration_path=MOCK_DAQ_CONFIG_PATH)
+    assert undulator1 is undulator2


### PR DESCRIPTION
Fixes 
* #846

for I03, other beamlines to follow in separate PR on top of this one.

Also fixes the following issues:
* `diamond_filter` was not being instantiated because python generic device types were not recognised as valid device factories.
* ~`device_factory` did not support usage with sync v1 ophyd devices~ These changes now in follow on PR #984 

See also mx-bluesky PR
* DiamondLightSource/mx-bluesky#735


### Instructions to reviewer on how to test:
1. Dodal connect i03, i04 should still work

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
