### PR TITLE
Add 'not external_tests' option to pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,9 +56,9 @@ def patch_open_to_prevent_dls_reads_in_tests():
         requested_path = Path(args[0])
         if requested_path.is_absolute():
             for p in BANNED_PATHS:
-                assert not requested_path.is_relative_to(
-                    p
-                ), f"Attempt to open {requested_path} from inside a unit test"
+                assert not requested_path.is_relative_to(p), (
+                    f"Attempt to open {requested_path} from inside a unit test"
+                )
         return unpatched_open(*args, **kwargs)
 
     with patch("builtins.open", side_effect=patched_open):


### PR DESCRIPTION
Fixes #954 
Enables us to run unit tests with `pytest -m "not external_tests"` rather than `pytest -m "not (s03 or adsim)"`

### Instructions to reviewer on how to test:
1. Confirm that running `pytest "not external_tests"` correctly skips `s03` and `adsim` tests but nothing else

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
