### PR TITLE
846 update i04 to use device_factory

### DIFF
--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -36,7 +36,7 @@ from dodal.devices.zebra.zebra_constants_mapping import (
 )
 from dodal.devices.zebra.zebra_controlled_shutter import ZebraShutter
 from dodal.log import set_beamline as set_log_beamline
-from dodal.utils import BeamlinePrefix, get_beamline_name, skip_device
+from dodal.utils import BeamlinePrefix, get_beamline_name
 
 ZOOM_PARAMS_FILE = (
     "/dls_sw/i04/software/gda/configurations/i04-config/xml/jCameraManZoomLevels.xml"
@@ -60,140 +60,107 @@ I04_ZEBRA_MAPPING = ZebraMapping(
 PREFIX = BeamlinePrefix(BL)
 
 
-def smargon(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Smargon:
+@device_factory()
+def smargon() -> Smargon:
     """Get the i04 Smargon device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        Smargon,
+    return Smargon(
+        f"{PREFIX.beamline_prefix}-MO-SGON-01:",
         "smargon",
-        "-MO-SGON-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def gonio_positioner(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XYZPositioner:
+@device_factory()
+def gonio_positioner() -> XYZPositioner:
     """Get the i04 lower_gonio_stages device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        XYZPositioner,
+    return XYZPositioner(
+        f"{PREFIX.beamline_prefix}-MO-GONIO-01:",
         "lower_gonio_stages",
-        "-MO-GONIO-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def sample_delivery_system(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XYZPositioner:
+@device_factory()
+def sample_delivery_system() -> XYZPositioner:
     """Get the i04 sample_delivery_system device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        XYZPositioner,
+    return XYZPositioner(
+        f"{PREFIX.beamline_prefix}-MO-SDE-01:",
         "sample_delivery_system",
-        "-MO-SDE-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def ipin(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> IPin:
+@device_factory()
+def ipin() -> IPin:
     """Get the i04 ipin device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        IPin,
+    return IPin(
+        f"{PREFIX.beamline_prefix}-EA-PIN-01:",
         "ipin",
-        "-EA-PIN-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def beamstop(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XYZPositioner:
+@device_factory()
+def beamstop() -> XYZPositioner:
     """Get the i04 beamstop device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        XYZPositioner,
+    return XYZPositioner(
+        f"{PREFIX.beamline_prefix}-MO-BS-01:",
         "beamstop",
-        "-MO-BS-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def sample_shutter(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> ZebraShutter:
+@device_factory()
+def sample_shutter() -> ZebraShutter:
     """Get the i04 sample shutter device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        ZebraShutter,
+    return ZebraShutter(
+        f"{PREFIX.beamline_prefix}-EA-SHTR-01:",
         "sample_shutter",
-        "-EA-SHTR-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def attenuator(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> BinaryFilterAttenuator:
+@device_factory()
+def attenuator() -> BinaryFilterAttenuator:
     """Get the i04 attenuator device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        BinaryFilterAttenuator,
+    return BinaryFilterAttenuator(
+        f"{PREFIX.beamline_prefix}-EA-ATTN-01:",
         "attenuator",
-        "-EA-ATTN-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def transfocator(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Transfocator:
+@device_factory()
+def transfocator() -> Transfocator:
     """Get the i04 transfocator device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        Transfocator,
+    return Transfocator(
+        f"{PREFIX.beamline_prefix}-MO-FSWT-01:",
         "transfocator",
-        "-MO-FSWT-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def xbpm_feedback(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> XBPMFeedback:
+@device_factory()
+def xbpm_feedback() -> XBPMFeedback:
     """Get the i04 xbpm_feedback device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        XBPMFeedback,
+    return XBPMFeedback(
+        PREFIX.beamline_prefix,
         "xbpm_feedback",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def flux(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> Flux:
+@device_factory()
+def flux(mock: bool = False) -> Flux:
     """Get the i04 flux device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
@@ -201,65 +168,50 @@ def flux(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) ->
         Flux,
         "flux",
         "-MO-FLUX-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+        wait=False,
+        fake=mock,
     )
 
 
-def dcm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> DCM:
+@device_factory()
+def dcm() -> DCM:
     """Get the i04 DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        DCM,
+    return DCM(
+        f"{PREFIX.beamline_prefix}-MO-DCM-01:",
         "dcm",
-        "-MO-DCM-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def backlight(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Backlight:
+@device_factory()
+def backlight() -> Backlight:
     """Get the i04 backlight device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        Backlight,
+    return Backlight(
+        PREFIX.beamline_prefix,
         "backlight",
-        "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def aperture_scatterguard(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-) -> ApertureScatterguard:
+@device_factory()
+def aperture_scatterguard() -> ApertureScatterguard:
     """Get the i04 aperture and scatterguard device, instantiate it if it hasn't already
     been. If this is called when already instantiated in i04, it will return the existing
     object.
     """
     params = get_beamline_parameters()
-    return device_instantiation(
-        device_factory=ApertureScatterguard,
+    return ApertureScatterguard(
+        prefix=PREFIX.beamline_prefix,
         name="aperture_scatterguard",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
         loaded_positions=load_positions_from_beamline_parameters(params),
         tolerances=AperturePosition.tolerances_from_gda_params(params),
     )
 
 
-@skip_device(lambda: BL == "s04")
-def eiger(
-    wait_for_connection: bool = True,
-    fake_with_ophyd_sim: bool = False,
-    params: DetectorParams | None = None,
-) -> EigerDetector:
+@device_factory(skip=BL == "s04")
+def eiger(mock: bool = False, params: DetectorParams | None = None) -> EigerDetector:
     """Get the i04 Eiger device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     If called with params, will update those params to the Eiger object.
@@ -273,30 +225,25 @@ def eiger(
         device_factory=EigerDetector,
         name="eiger",
         prefix="-EA-EIGER-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
+        wait=False,
+        fake=mock,
         post_create=set_params,
     )
 
 
-def zebra_fast_grid_scan(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> ZebraFastGridScan:
+@device_factory()
+def zebra_fast_grid_scan() -> ZebraFastGridScan:
     """Get the i04 zebra_fast_grid_scan device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        device_factory=ZebraFastGridScan,
+    return ZebraFastGridScan(
         name="zebra_fast_grid_scan",
-        prefix="-MO-SGON-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
+        prefix=f"{PREFIX.beamline_prefix}-MO-SGON-01:",
     )
 
 
-def s4_slit_gaps(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> S4SlitGaps:
+@device_factory()
+def s4_slit_gaps(mock: bool = False) -> S4SlitGaps:
     """Get the i04 s4_slit_gaps device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
@@ -304,60 +251,47 @@ def s4_slit_gaps(
         S4SlitGaps,
         "s4_slit_gaps",
         "-AL-SLITS-04:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+        wait=False,
+        fake=mock,
     )
 
 
-def undulator(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Undulator:
+@device_factory()
+def undulator() -> Undulator:
     """Get the i04 undulator device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        Undulator,
-        "undulator",
-        f"{BeamlinePrefix(BL).insertion_prefix}-MO-SERVC-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-        bl_prefix=False,
+    return Undulator(
+        name="undulator",
+        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
         id_gap_lookup_table_path="/dls_sw/i04/software/gda/config/lookupTables/BeamLine_Undulator_toGap.txt",
     )
 
 
-@skip_device(lambda: BL == "s04")
-def synchrotron(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Synchrotron:
+@device_factory(skip=BL == "s04")
+def synchrotron() -> Synchrotron:
     """Get the i04 synchrotron device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        Synchrotron,
-        "synchrotron",
+    return Synchrotron(
         "",
-        wait_for_connection,
-        fake_with_ophyd_sim,
-        bl_prefix=False,
+        "synchrotron",
     )
 
 
-def zebra(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> Zebra:
+@device_factory()
+def zebra() -> Zebra:
     """Get the i04 zebra device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        Zebra,
-        "zebra",
-        "-EA-ZEBRA-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return Zebra(
+        name="zebra",
+        prefix=f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:",
         mapping=I04_ZEBRA_MAPPING,
     )
 
 
-@skip_device(lambda: BL == "s04")
+@device_factory(skip=BL == "s04")
 def oav(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
@@ -366,74 +300,54 @@ def oav(
     """Get the i04 OAV device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        OAV,
-        "oav",
-        "-DI-OAV-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return OAV(
+        prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:",
+        name="oav",
         config=params or OAVConfig(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
     )
 
 
-@skip_device(lambda: BL == "s04")
-def detector_motion(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> DetectorMotion:
+@device_factory(skip=BL == "s04")
+def detector_motion() -> DetectorMotion:
     """Get the i04 detector motion device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        device_factory=DetectorMotion,
+    return DetectorMotion(
         name="detector_motion",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
+        prefix=PREFIX.beamline_prefix,
     )
 
 
-def thawer(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> Thawer:
+@device_factory()
+def thawer() -> Thawer:
     """Get the i04 thawer, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        Thawer,
+    return Thawer(
+        f"{PREFIX.beamline_prefix}-EA-THAW-01",
         "thawer",
-        "-EA-THAW-01",
-        wait_for_connection,
-        fake_with_ophyd_sim,
     )
 
 
-def robot(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> BartRobot:
+@device_factory()
+def robot() -> BartRobot:
     """Get the i04 robot device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        BartRobot,
+    return BartRobot(
         "robot",
-        "-MO-ROBOT-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+        f"{PREFIX.beamline_prefix}-MO-ROBOT-01:",
     )
 
 
-def oav_to_redis_forwarder(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> OAVToRedisForwarder:
+@device_factory()
+def oav_to_redis_forwarder() -> OAVToRedisForwarder:
     """Get the i04 OAV to redis forwarder, instantiate it if it hasn't already been.
     If this is called when already instantiated in i04, it will return the existing object.
     """
-    return device_instantiation(
-        OAVToRedisForwarder,
-        "oav_to_redis_forwarder",
-        "-DI-OAV-01:",
-        wait_for_connection,
-        fake_with_ophyd_sim,
+    return OAVToRedisForwarder(
+        f"{PREFIX.beamline_prefix}-DI-OAV-01:",
+        name="oav_to_redis_forwarder",
         redis_host=REDIS_HOST,
         redis_password=REDIS_PASSWORD,
         redis_db=7,


### PR DESCRIPTION
Part of a series of PRs that addresses #846

This PR builds on and depends on
* #975
* #984 

### Instructions to reviewer on how to test:
1. `dodal connect i04` connects to all devices
2. Tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
