### PR TITLE
Return immediately if transfocator number of lenses is already correct

### DIFF
--- a/src/dodal/devices/i04/transfocator.py
+++ b/src/dodal/devices/i04/transfocator.py
@@ -37,32 +37,18 @@ class Transfocator(StandardReadable):
 
         super().__init__(name=name)
 
-    async def _observe_beamsize_microns(self):
-        is_set_filters_done = False
-
-        async def set_based_on_prediction(value: float):
-            if not math.isclose(
-                self.latest_pred_vertical_num_lenses, value, abs_tol=1e-8
-            ):
-                # We can only put an integer number of lenses in the beam but the
-                # calculation in the IOC returns the theoretical float number of lenses
-                nonlocal is_set_filters_done
-                value = round(value)
-                LOGGER.info(f"Transfocator setting {value} filters")
-                await self.number_filters_sp.set(value)
-                await self.start.set(1)
-                LOGGER.info("Waiting for start_rbv to change to 1")
-                await wait_for_value(self.start_rbv, 1, self.TIMEOUT)
-                LOGGER.info("Waiting for start_rbv to change to 0")
-                await wait_for_value(self.start_rbv, 0, self.TIMEOUT)
-                self.latest_pred_vertical_num_lenses = value
-                is_set_filters_done = True
-
-        # The value hasn't changed so assume the device is already set up correctly
-        async for value in observe_value(self.predicted_vertical_num_lenses):
-            await set_based_on_prediction(value)
-            if is_set_filters_done:
-                break
+    async def set_based_on_prediction(self, value: float):
+        # We can only put an integer number of lenses in the beam but the
+        # calculation in the IOC returns the theoretical float number of lenses
+        value = round(value)
+        LOGGER.info(f"Transfocator setting {value} filters")
+        await self.number_filters_sp.set(value)
+        await self.start.set(1)
+        LOGGER.info("Waiting for start_rbv to change to 1")
+        await wait_for_value(self.start_rbv, 1, self.TIMEOUT)
+        LOGGER.info("Waiting for start_rbv to change to 0")
+        await wait_for_value(self.start_rbv, 0, self.TIMEOUT)
+        self.latest_pred_vertical_num_lenses = value
 
     @AsyncStatus.wrap
     async def set(self, value: float):
@@ -81,10 +67,17 @@ class Transfocator(StandardReadable):
 
         if await self.beamsize_set_microns.get_value() != value:
             # Logic in the IOC calculates predicted_vertical_num_lenses when beam_set_microns changes
-            await asyncio.gather(
-                self.beamsize_set_microns.set(value),
-                self._observe_beamsize_microns(),
+            predicted_vertical_num_lenses_iterator = observe_value(
+                self.predicted_vertical_num_lenses, timeout=self.TIMEOUT
             )
+            current_prediction = await anext(predicted_vertical_num_lenses_iterator)
+            set_status = self.beamsize_set_microns.set(value)
+            accepted_prediction = await anext(predicted_vertical_num_lenses_iterator)
+            if not math.isclose(current_prediction, accepted_prediction, abs_tol=1e-8):
+                await asyncio.gather(
+                    set_status,
+                    self.set_based_on_prediction(accepted_prediction),
+                )
 
         number_filters_rbv, vertical_lens_size_rbv = await asyncio.gather(
             self.number_filters_sp.get_value(),

--- a/tests/devices/i04/test_transfocator.py
+++ b/tests/devices/i04/test_transfocator.py
@@ -32,16 +32,16 @@ async def set_beamsize_to_same_value_as_mock_signal(
     await transfocator.set(value)
 
 
-@patch("dodal.devices.i04.transfocator.Transfocator._observe_beamsize_microns")
+@patch("dodal.devices.i04.transfocator.Transfocator.set_based_on_prediction")
 async def test_given_beamsize_already_set_then_when_transfocator_set_then_returns_immediately(
-    mock_observe_beamsize_microns,
+    mock_set_based_on_prediction,
     fake_transfocator: Transfocator,
 ):
     await asyncio.wait_for(
         set_beamsize_to_same_value_as_mock_signal(fake_transfocator, 100.0),
         timeout=0.01,
     )
-    mock_observe_beamsize_microns.assert_not_awaited()
+    mock_set_based_on_prediction.assert_not_awaited()
 
 
 @patch("dodal.devices.i04.transfocator.wait_for_value")
@@ -72,3 +72,11 @@ async def test_if_timeout_exceeded_and_start_rbv_not_equal_to_set_value_then_tim
         fake_transfocator.start_rbv.get_value = AsyncMock(side_effect=[0, 1])
         with pytest.raises((TimeoutError, asyncio.exceptions.TimeoutError)):
             await fake_transfocator.set(315)
+
+
+async def test_given_number_of_lenses_is_already_correct_then_transfocator_set_returns_immediately(
+    fake_transfocator: Transfocator,
+):
+    given_predicted_lenses_is_half_of_beamsize(fake_transfocator)
+    set_mock_value(fake_transfocator.predicted_vertical_num_lenses, 10)
+    await fake_transfocator.set(20)


### PR DESCRIPTION
Fixes #995 

### Instructions to reviewer on how to test:
1. Check that transfocator set operates as intended
2. Check that tests pass, and appropriately test an early return if predicted number of lenses is already set

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
