### PR TITLE
Changes to undulator_dcm, undulator factory methods to enable containerised system tests

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -335,7 +335,9 @@ def synchrotron(
 
 
 def undulator(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+    daq_configuration_path: str = None,
 ) -> Undulator:
     """Get the i03 undulator device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -347,12 +349,15 @@ def undulator(
         wait_for_connection,
         fake_with_ophyd_sim,
         bl_prefix=False,
-        id_gap_lookup_table_path="/dls_sw/i03/software/daq_configuration/lookup/BeamLine_Undulator_toGap.txt",
+        # evaluate here not as parameter default to enable post-import mocking
+        id_gap_lookup_table_path=f"{daq_configuration_path or DAQ_CONFIGURATION_PATH}/lookup/BeamLine_Undulator_toGap.txt",
     )
 
 
 def undulator_dcm(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+    wait_for_connection: bool = True,
+    fake_with_ophyd_sim: bool = False,
+    daq_configuration_path: str = None,
 ) -> UndulatorDCM:
     """Get the i03 undulator DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -363,9 +368,14 @@ def undulator_dcm(
         prefix="",
         wait=wait_for_connection,
         fake=fake_with_ophyd_sim,
-        undulator=undulator(wait_for_connection, fake_with_ophyd_sim),
+        undulator=undulator(
+            wait_for_connection,
+            fake_with_ophyd_sim,
+            daq_configuration_path=daq_configuration_path,
+        ),
         dcm=dcm(wait_for_connection, fake_with_ophyd_sim),
-        daq_configuration_path=DAQ_CONFIGURATION_PATH,
+        # evaluate here not as parameter default to enable post-import mocking
+        daq_configuration_path=daq_configuration_path or DAQ_CONFIGURATION_PATH,
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -337,7 +337,7 @@ def synchrotron(
 def undulator(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
-    daq_configuration_path: str = None,
+    daq_configuration_path: str | None = None,
 ) -> Undulator:
     """Get the i03 undulator device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.
@@ -357,7 +357,7 @@ def undulator(
 def undulator_dcm(
     wait_for_connection: bool = True,
     fake_with_ophyd_sim: bool = False,
-    daq_configuration_path: str = None,
+    daq_configuration_path: str | None = None,
 ) -> UndulatorDCM:
     """Get the i03 undulator DCM device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i03, it will return the existing object.


### PR DESCRIPTION
Adjust the undulator_dcm, undulator factory methods to enable better mocking without accessing `/dls_sw`

Required for

* DiamondLightSource/mx-bluesky#633

See related mx-bluesky PR

* DiamondLightSource/mx-bluesky#753

### Instructions to reviewer on how to test:
1. Unit tests pass
2. Mx-bluesky System tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
