### PR TITLE
Remove logic for checking if zoom level is available

### DIFF
--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -1,12 +1,12 @@
 from enum import IntEnum
 
+from bluesky.protocols import Movable
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
     AsyncStatus,
     LazyMock,
     StandardReadable,
 )
-from bluesky.protocols import Movable
 from ophyd_async.epics.core import epics_signal_rw
 
 from dodal.common.signal_utils import create_hardware_backed_soft_signal
@@ -47,8 +47,8 @@ class ZoomController(StandardReadable, Movable):
         super().__init__(name=name)
 
     @AsyncStatus.wrap
-    async def set(self, level_to_set: str):
-        await self.level.set(level_to_set, wait=True)
+    async def set(self, value: str):
+        await self.level.set(value, wait=True)
 
 
 class OAV(StandardReadable):

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -6,6 +6,7 @@ from ophyd_async.core import (
     LazyMock,
     StandardReadable,
 )
+from bluesky.protocols import Movable
 from ophyd_async.epics.core import epics_signal_rw
 
 from dodal.common.signal_utils import create_hardware_backed_soft_signal
@@ -28,7 +29,7 @@ def _get_correct_zoom_string(zoom: str) -> str:
     return zoom
 
 
-class ZoomController(StandardReadable):
+class ZoomController(StandardReadable, Movable):
     """
     Device to control the zoom level. This should be set like
         o = OAV(name="oav")

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -13,12 +13,6 @@ from dodal.devices.areadetector.plugins.CAM import Cam
 from dodal.devices.oav.oav_parameters import DEFAULT_OAV_WINDOW, OAVConfig
 from dodal.devices.oav.snapshots.snapshot_with_beam_centre import SnapshotWithBeamCentre
 from dodal.devices.oav.snapshots.snapshot_with_grid import SnapshotWithGrid
-from dodal.log import LOGGER
-
-
-class ZoomLevelNotFoundError(Exception):
-    def __init__(self, errmsg):
-        LOGGER.error(errmsg)
 
 
 class Coords(IntEnum):

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -1,6 +1,11 @@
 from enum import IntEnum
 
-from ophyd_async.core import DEFAULT_TIMEOUT, AsyncStatus, LazyMock, StandardReadable
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    AsyncStatus,
+    LazyMock,
+    StandardReadable,
+)
 from ophyd_async.epics.core import epics_signal_rw
 
 from dodal.common.signal_utils import create_hardware_backed_soft_signal
@@ -46,17 +51,8 @@ class ZoomController(StandardReadable):
         self.level = epics_signal_rw(str, f"{prefix}MP:SELECT")
         super().__init__(name=name)
 
-    async def _get_allowed_zoom_levels(self) -> list:
-        zoom_levels = await self.level.describe()
-        return zoom_levels[self.level.name]["choices"]  # type: ignore
-
     @AsyncStatus.wrap
     async def set(self, level_to_set: str):
-        allowed_zoom_levels = await self._get_allowed_zoom_levels()
-        if level_to_set not in allowed_zoom_levels:
-            raise ZoomLevelNotFoundError(
-                f"{level_to_set} not found, expected one of {allowed_zoom_levels}"
-            )
         await self.level.set(level_to_set, wait=True)
 
 

--- a/system_tests/test_oav_system.py
+++ b/system_tests/test_oav_system.py
@@ -3,7 +3,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import DeviceCollector
 
-from dodal.devices.oav.oav_detector import OAV, OAVConfig, ZoomController
+from dodal.devices.oav.oav_detector import OAV, OAVConfig
 
 TEST_GRID_TOP_LEFT_X = 100
 TEST_GRID_TOP_LEFT_Y = 100
@@ -44,10 +44,3 @@ def test_grid_overlay(RE: RunEngine):
     snapshot_filename = "snapshot"
     snapshot_directory = "."
     RE(take_snapshot_with_grid(oav, snapshot_filename, snapshot_directory))
-
-
-@pytest.mark.s03
-async def test_get_zoom_levels():
-    my_zoom_controller = ZoomController("BL03I-EA-OAV-01:FZOOM:", name="test_zoom")
-    await my_zoom_controller.connect()
-    assert "1.0x" in await my_zoom_controller._get_allowed_zoom_levels()

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -7,7 +7,6 @@ from dodal.devices.oav.oav_detector import (
     OAV,
     Cam,
     ZoomController,
-    ZoomLevelNotFoundError,
 )
 
 
@@ -21,14 +20,6 @@ async def test_zoom_controller():
     await status
     assert status.success
     assert await zoom_controller.level.get_value() == "3.0x"
-
-
-async def test_zoom_controller_set_raises_error_for_wrong_level():
-    zoom_controller = ZoomController("", "fake zoom controller")
-    await zoom_controller.connect(mock=True)
-    zoom_controller._get_allowed_zoom_levels = AsyncMock(return_value=["1.0x", "3.0x"])
-    with pytest.raises(ZoomLevelNotFoundError):
-        await zoom_controller.set("5.0x")
 
 
 async def test_cam():


### PR DESCRIPTION
Fixes #884 

EPICS enum records should error if provided an unspecified value; thus, this PR removes logic checking for unspecified values in the `ZoomController`.

### Instructions to reviewer on how to test:
1. Test if setting the `str` signal `level` to an unspecified zoom level raises an error.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
