### PR TITLE
Removes/reduces refenece use on i10 IDs

### DIFF
--- a/src/dodal/beamlines/i10.py
+++ b/src/dodal/beamlines/i10.py
@@ -1,18 +1,8 @@
-from pathlib import Path
-
-from dodal.common.beamlines.beamline_utils import device_factory, device_instantiation
+from dodal.common.beamlines.beamline_utils import device_factory
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.devices.apple2_undulator import (
-    UndulatorGap,
-    UndulatorJawPhase,
-    UndulatorPhaseAxes,
-)
 from dodal.devices.current_amplifiers import CurrentAmpDet
 from dodal.devices.i10.i10_apple2 import (
-    I10Apple2,
-    I10Apple2PGM,
-    I10Apple2Pol,
-    LinearArbitraryAngle,
+    I10Id,
 )
 from dodal.devices.i10.i10_setting_data import I10Grating
 from dodal.devices.i10.mirrors import PiezoMirror
@@ -41,234 +31,48 @@ LOOK_UPTABLE_DIR = "/dls_sw/i10/software/gda/workspace_git/gda-diamond.git/confi
 """
 I10 has two insertion devices one up(idu) and one down stream(idd).
 It is worth noting that the down stream device is slightly longer,
- so it can reach Mn edge for linear arbitrary.
- idd == id1
- and
- idu == id2.
+so it can reach Mn edge for linear arbitrary.
+ idd == id1,    idu == id2.
 """
 
 
-def idd_gap(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> UndulatorGap:
-    return device_instantiation(
-        device_factory=UndulatorGap,
-        name="idd_gap",
-        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        bl_prefix=False,
-    )
-
-
-def idd_phase_axes(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> UndulatorPhaseAxes:
-    return device_instantiation(
-        device_factory=UndulatorPhaseAxes,
-        name="idd_phase_axes",
-        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
-        top_outer="RPQ1",
-        top_inner="RPQ2",
-        btm_inner="RPQ3",
-        btm_outer="RPQ4",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        bl_prefix=False,
-    )
-
-
-def idd_jaw(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> UndulatorJawPhase:
-    return device_instantiation(
-        device_factory=UndulatorJawPhase,
-        name="idd_jaw",
-        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
-        move_pv="RPQ1",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        bl_prefix=False,
-    )
-
-
-def idu_gap(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> UndulatorGap:
-    return device_instantiation(
-        device_factory=UndulatorGap,
-        name="idu_gap",
-        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-21:",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        bl_prefix=False,
-    )
-
-
-def idu_phase_axes(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> UndulatorPhaseAxes:
-    return device_instantiation(
-        device_factory=UndulatorPhaseAxes,
-        name="idu_phase_axes",
-        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-21:",
-        top_outer="RPQ1",
-        top_inner="RPQ2",
-        btm_inner="RPQ3",
-        btm_outer="RPQ4",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        bl_prefix=False,
-    )
-
-
-def idu_jaw(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> UndulatorJawPhase:
-    return device_instantiation(
-        device_factory=UndulatorJawPhase,
-        name="idu_jaw",
-        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-21:",
-        move_pv="RPQ1",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-        bl_prefix=False,
-    )
-
-
-def pgm(wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False) -> PGM:
-    return device_instantiation(
-        device_factory=PGM,
-        name="pgm",
-        prefix="-OP-PGM-01:",
+@device_factory()
+def pgm() -> PGM:
+    "I10 Plane Grating Monochromator, it can change energy via pgm.energy.set(<energy>)"
+    return PGM(
+        prefix=f"{PREFIX.beamline_prefix}-OP-PGM-01:",
         grating=I10Grating,
         gratingPv="NLINES2",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
     )
 
 
-def idu_gap_phase(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> I10Apple2:
-    return device_instantiation(
-        device_factory=I10Apple2,
-        id_gap=idu_gap(wait_for_connection, fake_with_ophyd_sim),
-        id_phase=idu_phase_axes(wait_for_connection, fake_with_ophyd_sim),
-        id_jaw_phase=idu_jaw(wait_for_connection, fake_with_ophyd_sim),
-        energy_gap_table_path=Path(
-            LOOK_UPTABLE_DIR + "IDEnergy2GapCalibrations.csv",
-        ),
-        energy_phase_table_path=Path(
-            LOOK_UPTABLE_DIR + "IDEnergy2PhaseCalibrations.csv",
-        ),
-        source=("Source", "idu"),
-        name="idu_gap_phase",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
+@device_factory()
+def idd() -> I10Id:
+    """i10 downstream insertion device:
+    id.energy.set(<energy>) to change beamline energy.
+    id.energy.energy_offset.set(<off_set>) to change id energy offset relative to pgm.
+    id.pol.set(<polarization>) to change polarization.
+    id.laa.set(<linear polarization angle>) to change polarization angle, must be in LA mode.
+    """
+    return I10Id(
+        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-01:",
+        pgm=pgm(),
+        look_up_table_dir=LOOK_UPTABLE_DIR,
     )
 
 
-def idd_gap_phase(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> I10Apple2:
-    return device_instantiation(
-        device_factory=I10Apple2,
-        id_gap=idd_gap(wait_for_connection, fake_with_ophyd_sim),
-        id_phase=idd_phase_axes(wait_for_connection, fake_with_ophyd_sim),
-        id_jaw_phase=idd_jaw(wait_for_connection, fake_with_ophyd_sim),
-        energy_gap_table_path=Path(
-            LOOK_UPTABLE_DIR + "IDEnergy2GapCalibrations.csv",
-        ),
-        energy_phase_table_path=Path(
-            LOOK_UPTABLE_DIR + "IDEnergy2PhaseCalibrations.csv",
-        ),
-        source=("Source", "idd"),
-        name="idd_gap_phase",
-        prefix="",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
-
-
-def idu_pol(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> I10Apple2Pol:
-    return device_instantiation(
-        device_factory=I10Apple2Pol,
-        prefix="",
-        id=idu_gap_phase(wait_for_connection, fake_with_ophyd_sim),
-        name="idu_pol",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
-
-
-def idd_pol(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> I10Apple2Pol:
-    return device_instantiation(
-        device_factory=I10Apple2Pol,
-        prefix="",
-        id=idd_gap_phase(wait_for_connection, fake_with_ophyd_sim),
-        name="idd_pol",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
-
-
-def idu(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> I10Apple2PGM:
-    return device_instantiation(
-        device_factory=I10Apple2PGM,
-        prefix="",
-        id=idu_gap_phase(wait_for_connection, fake_with_ophyd_sim),
-        pgm=pgm(wait_for_connection, fake_with_ophyd_sim),
-        name="idu",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
-
-
-def idd(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> I10Apple2PGM:
-    return device_instantiation(
-        device_factory=I10Apple2PGM,
-        prefix="",
-        id=idd_gap_phase(wait_for_connection, fake_with_ophyd_sim),
-        pgm=pgm(wait_for_connection, fake_with_ophyd_sim),
-        name="idd",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
-
-
-def idu_la_angle(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> LinearArbitraryAngle:
-    return device_instantiation(
-        device_factory=LinearArbitraryAngle,
-        prefix="",
-        id=idu(wait_for_connection, fake_with_ophyd_sim),
-        name="idu_la_angle",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
-    )
-
-
-def idd_la_angle(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> LinearArbitraryAngle:
-    return device_instantiation(
-        device_factory=LinearArbitraryAngle,
-        prefix="",
-        id=idu(wait_for_connection, fake_with_ophyd_sim),
-        name="idd_la_angle",
-        wait=wait_for_connection,
-        fake=fake_with_ophyd_sim,
+@device_factory()
+def idu() -> I10Id:
+    """i10 upstream insertion device:
+    id.energy.set(<energy>) to change beamline energy.
+    id.energy.energy_offset.set(<off_set>) to change id energy offset relative to pgm.
+    id.pol.set(<polarization>) to change polarization.
+    id.laa.set(<linear polarization angle>) to change polarization angle, must be in LA mode.
+    """
+    return I10Id(
+        prefix=f"{PREFIX.insertion_prefix}-MO-SERVC-21:",
+        pgm=pgm(),
+        look_up_table_dir=LOOK_UPTABLE_DIR,
     )
 
 
@@ -358,7 +162,7 @@ def pa_stage() -> PaStage:
 
 
 @device_factory()
-def simple_stage() -> XYZPositioner:
+def sample_stage() -> XYZPositioner:
     return XYZPositioner(prefix="ME01D-MO-CRYO-01:")
 
 

--- a/src/dodal/devices/apple2_undulator.py
+++ b/src/dodal/devices/apple2_undulator.py
@@ -7,7 +7,6 @@ import numpy as np
 from bluesky.protocols import Movable
 from ophyd_async.core import (
     AsyncStatus,
-    Reference,
     StandardReadable,
     StandardReadableFormat,
     StrictEnum,
@@ -388,8 +387,8 @@ class Apple2(StandardReadable, Movable):
 
         # Attributes are set after super call so they are not renamed to
         # <name>-undulator, etc.
-        self.gap = Reference(id_gap)
-        self.phase = Reference(id_phase)
+        self.gap = id_gap
+        self.phase = id_phase
 
         with self.add_children_as_readables(StandardReadableFormat.HINTED_SIGNAL):
             # Store the polarisation for readback.
@@ -437,16 +436,16 @@ class Apple2(StandardReadable, Movable):
         """
 
         # Only need to check gap as the phase motors share both fault and gate with gap.
-        await self.gap().check_id_status()
+        await self.gap.check_id_status()
         await asyncio.gather(
-            self.phase().top_outer.user_setpoint.set(value=value.top_outer),
-            self.phase().top_inner.user_setpoint.set(value=value.top_inner),
-            self.phase().btm_inner.user_setpoint.set(value=value.btm_inner),
-            self.phase().btm_outer.user_setpoint.set(value=value.btm_outer),
-            self.gap().user_setpoint.set(value=value.gap),
+            self.phase.top_outer.user_setpoint.set(value=value.top_outer),
+            self.phase.top_inner.user_setpoint.set(value=value.top_inner),
+            self.phase.btm_inner.user_setpoint.set(value=value.btm_inner),
+            self.phase.btm_outer.user_setpoint.set(value=value.btm_outer),
+            self.gap.user_setpoint.set(value=value.gap),
         )
         timeout = np.max(
-            await asyncio.gather(self.gap().get_timeout(), self.phase().get_timeout())
+            await asyncio.gather(self.gap.get_timeout(), self.phase.get_timeout())
         )
         LOGGER.info(
             f"Moving f{self.name} energy and polorisation to {energy}, {self.pol}"
@@ -454,12 +453,10 @@ class Apple2(StandardReadable, Movable):
         )
 
         await asyncio.gather(
-            self.gap().set_move.set(value=1, timeout=timeout),
-            self.phase().set_move.set(value=1, timeout=timeout),
+            self.gap.set_move.set(value=1, timeout=timeout),
+            self.phase.set_move.set(value=1, timeout=timeout),
         )
-        await wait_for_value(
-            self.gap().gate, UndulatorGateStatus.CLOSE, timeout=timeout
-        )
+        await wait_for_value(self.gap.gate, UndulatorGateStatus.CLOSE, timeout=timeout)
         self._energy_set(energy)  # Update energy for after move for readback.
 
     def _get_id_gap_phase(self, energy: float) -> tuple[float, float]:
@@ -524,11 +521,11 @@ class Apple2(StandardReadable, Movable):
         (May be for future one can use the inverse poly to work out the energy and try to match it with the current energy
         to workout the polarisation but during my test the inverse poly is too unstable for general use.)
         """
-        top_outer = await self.phase().top_outer.user_setpoint_readback.get_value()
-        top_inner = await self.phase().top_inner.user_setpoint_readback.get_value()
-        btm_inner = await self.phase().btm_inner.user_setpoint_readback.get_value()
-        btm_outer = await self.phase().btm_outer.user_setpoint_readback.get_value()
-        gap = await self.gap().user_readback.get_value()
+        top_outer = await self.phase.top_outer.user_setpoint_readback.get_value()
+        top_inner = await self.phase.top_inner.user_setpoint_readback.get_value()
+        btm_inner = await self.phase.btm_inner.user_setpoint_readback.get_value()
+        btm_outer = await self.phase.btm_outer.user_setpoint_readback.get_value()
+        gap = await self.gap.user_readback.get_value()
         if gap > MAXIMUM_GAP_MOTOR_POSITION:
             raise RuntimeError(
                 f"{self.name} is not in use, close gap or set polarisation to use this ID"


### PR DESCRIPTION

Fixes #1029 and it is related to #1002 as it remove the use of references in Apple2.

### Instructions to reviewer on how to test:
1. Run test.
2. Confirm connection.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
