### PR TITLE
add one second test check to CI

### DIFF
--- a/.github/scripts/check_test_durations.py
+++ b/.github/scripts/check_test_durations.py
@@ -1,0 +1,21 @@
+import json
+import sys
+
+THRESHOLD = 1.0  # seconds
+
+with open("report.json") as f:
+    data = json.load(f)
+
+slow_tests = [
+    (t["nodeid"], t["call"]["duration"])
+    for t in data["tests"]
+    if "call" in t and t["call"]["duration"] > THRESHOLD
+]
+
+if slow_tests:
+    print("❌ The following tests exceeded the 1s threshold:")
+    for test, duration in slow_tests:
+        print(f" - {test}: {duration:.2f}s")
+    sys.exit(1)
+
+print("✅ All tests ran within the acceptable time limit.")

--- a/.github/scripts/check_test_durations.py
+++ b/.github/scripts/check_test_durations.py
@@ -1,19 +1,28 @@
 import json
 import sys
 
-THRESHOLD = 1.0  # seconds
+# Get report filename and threshold from command-line arguments
+REPORT_FILE = sys.argv[1] if len(sys.argv) > 1 else "report.json"
+THRESHOLD = float(sys.argv[2]) if len(sys.argv) > 2 else 1.0
 
-with open("report.json") as f:
-    data = json.load(f)
+try:
+    with open(REPORT_FILE) as f:
+        data = json.load(f)
+except FileNotFoundError:
+    print(f"❌ Error: Report file '{REPORT_FILE}' not found.")
+    sys.exit(1)
+except json.JSONDecodeError:
+    print(f"❌ Error: Failed to parse JSON in '{REPORT_FILE}'.")
+    sys.exit(1)
 
 slow_tests = [
     (t["nodeid"], t["call"]["duration"])
-    for t in data["tests"]
+    for t in data.get("tests", [])
     if "call" in t and t["call"]["duration"] > THRESHOLD
 ]
 
 if slow_tests:
-    print("❌ The following tests exceeded the 1s threshold:")
+    print(f"❌ The following tests exceeded the {THRESHOLD:.2f}s threshold:")
     for test, duration in slow_tests:
         print(f" - {test}: {duration:.2f}s")
     sys.exit(1)

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -68,6 +68,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           name: ${{ inputs.python-version }}/${{ inputs.runs-on }}
-          files: cov.xml
+          files: ./unit_cov.xml,./system_cov.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -50,13 +50,19 @@ jobs:
           python-version: ${{ inputs.python-version }}
           pip-install: ".[dev]"
 
-      - name: Run tests
-        run: tox -e report
+      - name: Run unit tests
+        run: tox -e unit-report
 
-      - name: Check test durations
+      - name: Check unit test durations
         run: |
-          python .github/scripts/check_test_durations.py
+          python .github/scripts/check_test_durations.py unit-report.json 1
 
+      - name: Run system tests
+        run: tox -e system-report
+
+      - name: Check system test durations
+        run: |
+          python .github/scripts/check_test_durations.py system-report.json 5
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -51,7 +51,11 @@ jobs:
           pip-install: ".[dev]"
 
       - name: Run tests
-        run: tox -e tests
+        run: tox -e tests-report
+      - name: Check test durations
+        run: |
+          python .github/scripts/check_test_durations.py
+
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -51,7 +51,8 @@ jobs:
           pip-install: ".[dev]"
 
       - name: Run tests
-        run: tox -e tests-report
+        run: tox -e report
+
       - name: Check test durations
         run: |
           python .github/scripts/check_test_durations.py

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ lockfiles/
 
 # pycharm project files
 .idea/
+
+
+# custom CI setup 
+report.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    "pytest-json-report",
     "pytest-random-order",
     "ruff",
     "sphinx<7.4.6",              #  pinned due to https://github.com/sphinx-doc/sphinx/issues/12660
@@ -156,6 +157,7 @@ commands =
     type-checking: pyright src tests {posargs}
     pre-commit: pre-commit run --all-files --show-diff-on-failure {posargs}
     docs: sphinx-{posargs:build -E} -T docs build/html
+    tests-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-resport --json-report-file=report.json {posargs}
 """
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,8 @@ commands =
     type-checking: pyright src tests {posargs}
     pre-commit: pre-commit run --all-files --show-diff-on-failure {posargs}
     docs: sphinx-{posargs:build -E} -T docs build/html
-    report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=report.json {posargs}
+    unit-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=unit-report.json tests {posargs}
+    system-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=system-report.json system_tests {posargs}
 """
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ legacy_tox_ini = """
 [tox]
 skipsdist=True
 
-[testenv:{pre-commit,type-checking,tests,docs,report}]
+[testenv:{pre-commit,type-checking,tests,docs,unit-report,system-report}]
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ legacy_tox_ini = """
 [tox]
 skipsdist=True
 
-[testenv:{pre-commit,type-checking,tests,docs}]
+[testenv:{pre-commit,type-checking,tests,docs,tests-report}]
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ commands =
     type-checking: pyright src tests {posargs}
     pre-commit: pre-commit run --all-files --show-diff-on-failure {posargs}
     docs: sphinx-{posargs:build -E} -T docs build/html
-    tests-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-resport --json-report-file=report.json {posargs}
+    tests-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=report.json {posargs}
 """
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,8 +157,8 @@ commands =
     type-checking: pyright src tests {posargs}
     pre-commit: pre-commit run --all-files --show-diff-on-failure {posargs}
     docs: sphinx-{posargs:build -E} -T docs build/html
-    unit-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=unit-report.json tests {posargs}
-    system-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=system-report.json system_tests {posargs}
+    unit-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:unit_cov.xml --json-report --json-report-file=unit-report.json tests {posargs}
+    system-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:system_cov.xml --json-report --json-report-file=system-report.json system_tests {posargs}
 """
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ legacy_tox_ini = """
 [tox]
 skipsdist=True
 
-[testenv:{pre-commit,type-checking,tests,docs,tests-report}]
+[testenv:{pre-commit,type-checking,tests,docs,report}]
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *
@@ -157,7 +157,7 @@ commands =
     type-checking: pyright src tests {posargs}
     pre-commit: pre-commit run --all-files --show-diff-on-failure {posargs}
     docs: sphinx-{posargs:build -E} -T docs build/html
-    tests-report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=report.json {posargs}
+    report: pytest -m 'not (s03 or adsim)' --cov=dodal --cov-report term --cov-report xml:cov.xml --json-report --json-report-file=report.json {posargs}
 """
 
 [tool.ruff]


### PR DESCRIPTION
Fixes #1003

### Instructions to reviewer on how to test:
1. Check the tests 
2. Confirm thing `print("✅ All tests ran within the acceptable time limit.")` or  `    print("❌ The following tests exceeded the 1s threshold:")` happened

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
