### PR TITLE
Fix errors from testing mx_bluesky

### DIFF
--- a/src/dodal/devices/eiger.py
+++ b/src/dodal/devices/eiger.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum
 
+from bluesky.protocols import Stageable
 from ophyd import Component, Device, EpicsSignalRO, Signal
 from ophyd.areadetector.cam import EigerDetectorCam
 from ophyd.status import AndStatus, Status, StatusBase
@@ -42,7 +43,7 @@ AVAILABLE_TIMEOUTS = {
 }
 
 
-class EigerDetector(Device):
+class EigerDetector(Device, Stageable):
     class ArmingSignal(Signal):
         def set(self, value, *, timeout=None, settle_time=None, **kwargs):
             assert isinstance(self.parent, EigerDetector)

--- a/src/dodal/devices/eiger.py
+++ b/src/dodal/devices/eiger.py
@@ -161,7 +161,7 @@ class EigerDetector(Device):
             status_ok = self.odin.check_and_wait_for_odin_state(
                 self.timeouts.general_status_timeout
             )
-            self.disable_roi_mode()
+            self.disable_roi_mode().wait(self.timeouts.general_status_timeout)
         self.disarming_status.set_finished()
         return status_ok
 

--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from bluesky.protocols import Movable
 from ophyd_async.core import (
     AsyncStatus,
+    Device,
     StandardReadable,
     StrictEnum,
     set_and_wait_for_value,
@@ -38,23 +39,36 @@ class PinMounted(StrictEnum):
     PIN_MOUNTED = "Pin Mounted"
 
 
+class ErrorStatus(Device):
+    def __init__(self, prefix: str) -> None:
+        self.str = epics_signal_r(str, prefix + "_ERR_MSG")
+        self.code = epics_signal_r(int, prefix + "_ERR_CODE")
+        super().__init__()
+
+    async def raise_if_error(self, raise_from: Exception):
+        error_code = await self.code.get_value()
+        if error_code:
+            error_string = await self.str.get_value()
+            raise RobotLoadFailed(int(error_code), error_string) from raise_from
+
+
 class BartRobot(StandardReadable, Movable):
     """The sample changing robot."""
 
     # How long to wait for the robot if it is busy soaking/drying
     NOT_BUSY_TIMEOUT = 5 * 60
+
     # How long to wait for the actual load to happen
     LOAD_TIMEOUT = 60
+
+    # Error codes that we do special things on
     NO_PIN_ERROR_CODE = 25
+    LIGHT_CURTAIN_TRIPPED = 40
 
     # How far the gonio position can be out before loading will fail
     LOAD_TOLERANCE_MM = 0.02
 
-    def __init__(
-        self,
-        name: str,
-        prefix: str,
-    ) -> None:
+    def __init__(self, name: str, prefix: str) -> None:
         self.barcode = epics_signal_r(str, prefix + "BARCODE")
         self.gonio_pin_sensor = epics_signal_r(PinMounted, prefix + "PIN_MOUNTED")
 
@@ -69,8 +83,10 @@ class BartRobot(StandardReadable, Movable):
         self.load = epics_signal_x(prefix + "LOAD.PROC")
         self.program_running = epics_signal_r(bool, prefix + "PROGRAM_RUNNING")
         self.program_name = epics_signal_r(str, prefix + "PROGRAM_NAME")
-        self.error_str = epics_signal_r(str, prefix + "PRG_ERR_MSG")
-        self.error_code = epics_signal_r(int, prefix + "PRG_ERR_CODE")
+
+        self.prog_error = ErrorStatus(prefix + "PRG")
+        self.controller_error = ErrorStatus(prefix + "CNTL")
+
         self.reset = epics_signal_x(prefix + "RESET.PROC")
         super().__init__(name=name)
 
@@ -81,7 +97,7 @@ class BartRobot(StandardReadable, Movable):
         """
 
         async def raise_if_no_pin():
-            await wait_for_value(self.error_code, self.NO_PIN_ERROR_CODE, None)
+            await wait_for_value(self.prog_error.code, self.NO_PIN_ERROR_CODE, None)
             raise RobotLoadFailed(self.NO_PIN_ERROR_CODE, "Pin was not detected")
 
         async def wfv():
@@ -108,6 +124,9 @@ class BartRobot(StandardReadable, Movable):
             raise
 
     async def _load_pin_and_puck(self, sample_location: SampleLocation):
+        if await self.controller_error.code.get_value() == self.LIGHT_CURTAIN_TRIPPED:
+            LOGGER.info("Light curtain tripped, trying again")
+            await self.reset.trigger()
         LOGGER.info(f"Loading pin {sample_location}")
         if await self.program_running.get_value():
             LOGGER.info(
@@ -137,6 +156,6 @@ class BartRobot(StandardReadable, Movable):
             )
         except (asyncio.TimeoutError, TimeoutError) as e:
             # Will only need to catch asyncio.TimeoutError after https://github.com/bluesky/ophyd-async/issues/572
-            error_code = await self.error_code.get_value()
-            error_string = await self.error_str.get_value()
-            raise RobotLoadFailed(int(error_code), error_string) from e
+            await self.prog_error.raise_if_error(e)
+            await self.controller_error.raise_if_error(e)
+            raise RobotLoadFailed(0, "Robot timed out") from e

--- a/tests/devices/unit_tests/test_bart_robot.py
+++ b/tests/devices/unit_tests/test_bart_robot.py
@@ -140,9 +140,9 @@ async def test_set_waits_for_both_timeouts(mock_wait_for: AsyncMock):
     mock_wait_for.assert_awaited_once_with(ANY, timeout=0.02)
 
 
-async def test_when_error_40_trying_to_move_the_robot_will_reset_it_first_but_still_throws_if_error_not_reset():
+async def test_moving_the_robot_will_reset_error_if_light_curtain_is_tripped_and_still_throw_if_error_not_cleared():
     device = await _get_bart_robot()
-    set_mock_value(device.controller_error.code, 40)
+    set_mock_value(device.controller_error.code, BartRobot.LIGHT_CURTAIN_TRIPPED)
 
     with pytest.raises(RobotLoadFailed) as e:
         await device.set(SampleLocation(1, 2))
@@ -158,9 +158,9 @@ async def test_when_error_40_trying_to_move_the_robot_will_reset_it_first_but_st
     )
 
 
-async def test_when_error_40_trying_to_move_the_robot_will_reset_it_and_pass_if_error_is_cleared():
+async def test_moving_the_robot_will_reset_error_if_light_curtain_is_tripped_and_continue_if_error_cleared():
     device = await _get_bart_robot()
-    set_mock_value(device.controller_error.code, 40)
+    set_mock_value(device.controller_error.code, BartRobot.LIGHT_CURTAIN_TRIPPED)
 
     callback_on_mock_put(
         device.reset,


### PR DESCRIPTION
With Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/769

Note:
See also https://github.com/DiamondLightSource/mx-bluesky/pull/796

### Instructions to reviewer on how to test:
1. Confirm tests pass and that with `mx_bluesky` changes addresses the issue

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
