### PR TITLE
add path provider to i20-1

### DIFF
--- a/src/dodal/beamlines/i20_1.py
+++ b/src/dodal/beamlines/i20_1.py
@@ -1,5 +1,12 @@
-from dodal.common.beamlines.beamline_utils import device_factory
+from pathlib import Path
+
+from dodal.common.beamlines.beamline_utils import (
+    device_factory,
+    set_path_provider,
+)
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.visit import RemoteDirectoryServiceClient, StaticVisitPathProvider
+from dodal.devices.synchrotron import Synchrotron
 from dodal.devices.turbo_slit import TurboSlit
 from dodal.devices.xspress3.xspress3 import Xspress3
 from dodal.log import set_beamline as set_log_beamline
@@ -9,6 +16,20 @@ BL = get_beamline_name("i20-1")
 PREFIX = BeamlinePrefix(BL, suffix="J")
 set_log_beamline(BL)
 set_utils_beamline(BL)
+
+
+# Currently we must hard-code the visit, determining the visit at runtime requires
+# infrastructure that is still WIP.
+# Communication with GDA is also WIP so for now we determine an arbitrary scan number
+# locally and write the commissioning directory. The scan number is not guaranteed to
+# be unique and the data is at risk - this configuration is for testing only.
+set_path_provider(
+    StaticVisitPathProvider(
+        BL,
+        Path("/dls/i20-1/data/2023/cm33897-5/bluesky"),
+        client=RemoteDirectoryServiceClient("http://i20-1-control:8088/api"),
+    )
+)
 
 
 @device_factory()
@@ -30,3 +51,8 @@ def xspress3() -> Xspress3:
         f"{PREFIX.beamline_prefix}-EA-DET-03:",
         num_channels=16,
     )
+
+
+@device_factory()
+def synchrotron() -> Synchrotron:
+    return Synchrotron()


### PR DESCRIPTION
Fixes #1045

### Instructions to reviewer on how to test:
1. try running a count plan over Readable synchrotron
https://j20-blueapi.diamond.ac.uk/docs#/default/set_active_task_worker_task_put

2. Confirm thing blueapi logs acknowedge and start the task

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
