### PR TITLE
(mx-bluesky#632) changes to fake zocalo to enable containerised system tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "black",
     "diff-cover",
     "import-linter",
+    "ispyb",
     "mypy",
     # Commented out due to dependency version conflict with pydantic 1.x
     # "copier",

--- a/tests/fake_zocalo/__main__.py
+++ b/tests/fake_zocalo/__main__.py
@@ -152,7 +152,12 @@ def main() -> None:
     channel.queue_declare(
         queue="processing_recipe",
         durable=True,
-        arguments={"x-single-active-consumer": False, "x-queue-type": "quorum"},
+        arguments={
+            "x-single-active-consumer": False,
+            "x-queue-type": "quorum",
+            "x-dead-letter-exchange": "",
+            "x-dead-letter-routing-key": "dlq.processing_recipe",
+        },
     )
 
     # Route messages from the 'results' exchange to the 'xrc.i03' channel

--- a/tests/fake_zocalo/__main__.py
+++ b/tests/fake_zocalo/__main__.py
@@ -148,6 +148,12 @@ def main() -> None:
         durable=True,
         arguments={"x-single-active-consumer": False, "x-queue-type": "quorum"},
     )
+    # Also create the processing_recipe queue
+    channel.queue_declare(
+        queue="processing_recipe",
+        durable=True,
+        arguments={"x-single-active-consumer": False, "x-queue-type": "quorum"},
+    )
 
     # Route messages from the 'results' exchange to the 'xrc.i03' channel
     channel.queue_bind(exchange="results", queue="xrc.i03", routing_key="xrc.i03")


### PR DESCRIPTION
Part of
* DiamondLightSource/mx-bluesky#632

See also mx-bluesky PR
* DiamondLightSource/mx-bluesky#802

GitLab Merge Request
* https://gitlab.diamond.ac.uk/MX-GDA/hyperion-system-testing/-/merge_requests/2

These changes make alterations to the fake zocalo utility script that is used both in  dodal system tests and in mx-bluesky system tests, so that it can be launched inside a docker container.

* Adds a missing development dependency on ispyb
* Additional logic to wait for rabbitmq to come up when started
* Additional logic to create the `processing_recipe` queue if it is missing (this is needed since the test rabbitmq has much more minimal configuration compared to the development config in `/dls_sw`

