### PR TITLE
make turbo slit have readable children

### DIFF
--- a/src/dodal/devices/turbo_slit.py
+++ b/src/dodal/devices/turbo_slit.py
@@ -2,7 +2,7 @@ from ophyd_async.core import Device, StandardReadable
 from ophyd_async.epics.motor import Motor
 
 
-class TurboSlit(StandardReadable, Device):
+class TurboSlit(StandardReadable):
     """
     This collection of motors coordinates time resolved XAS experiments.
     It selects a beam out of the polychromatic fan.

--- a/src/dodal/devices/turbo_slit.py
+++ b/src/dodal/devices/turbo_slit.py
@@ -1,8 +1,8 @@
-from ophyd_async.core import Device
+from ophyd_async.core import Device, StandardReadable
 from ophyd_async.epics.motor import Motor
 
 
-class TurboSlit(Device):
+class TurboSlit(StandardReadable, Device):
     """
     This collection of motors coordinates time resolved XAS experiments.
     It selects a beam out of the polychromatic fan.
@@ -18,7 +18,8 @@ class TurboSlit(Device):
     """
 
     def __init__(self, prefix: str, name: str = ""):
-        self.gap = Motor(prefix=prefix + "GAP")
-        self.arc = Motor(prefix=prefix + "ARC")
-        self.xfine = Motor(prefix=prefix + "XFINE")
+        with self.add_children_as_readables():
+            self.gap = Motor(prefix=prefix + "GAP")
+            self.arc = Motor(prefix=prefix + "ARC")
+            self.xfine = Motor(prefix=prefix + "XFINE")
         super().__init__(name=name)

--- a/src/dodal/devices/turbo_slit.py
+++ b/src/dodal/devices/turbo_slit.py
@@ -1,4 +1,4 @@
-from ophyd_async.core import Device, StandardReadable
+from ophyd_async.core import StandardReadable
 from ophyd_async.epics.motor import Motor
 
 


### PR DESCRIPTION
Fixes #1051 

### Instructions to reviewer on how to test:
1. Do those steps on the device https://github.com/DiamondLightSource/i20-1-bluesky/issues/8#issuecomment-2647784884
2. Confirm correct even documents are sent into the RMQ

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
