### PR TITLE
Correct test function for mocking timeout.

### DIFF
--- a/tests/devices/unit_tests/test_apple2_undulator.py
+++ b/tests/devices/unit_tests/test_apple2_undulator.py
@@ -124,7 +124,7 @@ async def test_given_gate_never_closes_then_setting_gaps_times_out(
         mock_id_gap.user_setpoint,
         lambda *_, **__: set_mock_value(mock_id_gap.gate, UndulatorGateStatus.OPEN),
     )
-    mock_id_gap._cal_timeout = AsyncMock(return_value=0.01)
+    mock_id_gap.get_timeout = AsyncMock(return_value=0.01)
     with pytest.raises(asyncio.TimeoutError):
         await mock_id_gap.set("2")
 
@@ -173,7 +173,7 @@ async def test_given_gate_never_closes_then_setting_phases_times_out(
         mock_phaseAxes.top_outer.user_setpoint,
         lambda *_, **__: set_mock_value(mock_phaseAxes.gate, UndulatorGateStatus.OPEN),
     )
-    mock_phaseAxes._cal_timeout = AsyncMock(return_value=0.01)
+    mock_phaseAxes.get_timeout = AsyncMock(return_value=0.01)
 
     with pytest.raises(asyncio.TimeoutError):
         await mock_phaseAxes.set(setValue)
@@ -299,7 +299,7 @@ async def test_given_gate_never_closes_then_setting_jaw_phases_times_out(
         mock_jaw_phase.jaw_phase.user_setpoint,
         lambda *_, **__: set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.OPEN),
     )
-    mock_jaw_phase._cal_timeout = AsyncMock(return_value=0.01)
+    mock_jaw_phase.get_timeout = AsyncMock(return_value=0.01)
     with pytest.raises(asyncio.TimeoutError):
         await mock_jaw_phase.set(2)
 


### PR DESCRIPTION
Fixes #1060 
Unblock #1033 
### Instructions to reviewer on how to test:
1. run: tox -e tests -- --durations=10 tests/devices/unit_tests/test_apple2_undulator.py 
2. Confirm timeout is less than 1s

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
