### PR TITLE
FGS device sends stop command on 'complete' timeout

### DIFF
--- a/src/dodal/devices/fast_grid_scan.py
+++ b/src/dodal/devices/fast_grid_scan.py
@@ -262,7 +262,8 @@ class FastGridScanCommon(StandardReadable, Flyable, ABC, Generic[ParamType]):
             await wait_for_value(self.status, 0, self.COMPLETE_STATUS)
         except asyncio.TimeoutError:
             LOGGER.error(
-                "Hyperion timed out waiting for FGS motion to complete. This may have been caused by a goniometer stage getting stuck"
+                "Hyperion timed out waiting for FGS motion to complete. This may have been caused by a goniometer stage getting stuck.\n\
+                Forcably stopping the FGS motion program...def"
             )
             await self.stop_cmd.trigger()
             raise

--- a/src/dodal/devices/fast_grid_scan.py
+++ b/src/dodal/devices/fast_grid_scan.py
@@ -263,7 +263,7 @@ class FastGridScanCommon(StandardReadable, Flyable, ABC, Generic[ParamType]):
         except asyncio.TimeoutError:
             LOGGER.error(
                 "Hyperion timed out waiting for FGS motion to complete. This may have been caused by a goniometer stage getting stuck.\n\
-                Forcably stopping the FGS motion program...def"
+                Forcibly stopping the FGS motion program..."
             )
             await self.stop_cmd.trigger()
             raise

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -392,3 +392,4 @@ async def test_timeout_on_complete_triggers_stop_and_logs_error(
     with pytest.raises(asyncio.TimeoutError):
         await zebra_fast_grid_scan.complete()
     mock_log_error.assert_called_once()
+    zebra_fast_grid_scan.stop_cmd.trigger.assert_awaited_once()


### PR DESCRIPTION
Fixes [mx-bluesky #824](https://github.com/DiamondLightSource/mx-bluesky/issues/824)

### Instructions to reviewer on how to test:
1. Confirm changes address https://github.com/DiamondLightSource/mx-bluesky/issues/824#issuecomment-2665195087
2. Tests pass against

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
