### PR TITLE
Add new path provider to use numtracker with blueapi

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -5,6 +5,7 @@ from ophyd_async.epics.adpilatus import PilatusDetector
 from ophyd_async.fastcs.panda import HDFPanda
 
 from dodal.common.beamlines.beamline_utils import (
+    StartDocumentBasedPathProvider,
     device_factory,
     get_path_provider,
     set_path_provider,
@@ -34,19 +35,7 @@ BL = get_beamline_name("i22")
 PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
-
-# Currently we must hard-code the visit, determining the visit at runtime requires
-# infrastructure that is still WIP.
-# Communication with GDA is also WIP so for now we determine an arbitrary scan number
-# locally and write the commissioning directory. The scan number is not guaranteed to
-# be unique and the data is at risk - this configuration is for testing only.
-set_path_provider(
-    StaticVisitPathProvider(
-        BL,
-        Path("/dls/i22/data/2024/cm37271-2/bluesky"),
-        client=RemoteDirectoryServiceClient("http://i22-control:8088/api"),
-    )
-)
+set_path_provider(StartDocumentBasedPathProvider())
 
 
 @device_factory()

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -5,7 +5,6 @@ from ophyd_async.epics.adpilatus import PilatusDetector
 from ophyd_async.fastcs.panda import HDFPanda
 
 from dodal.common.beamlines.beamline_utils import (
-    StartDocumentBasedPathProvider,
     device_factory,
     get_path_provider,
     set_path_provider,
@@ -35,7 +34,19 @@ BL = get_beamline_name("i22")
 PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
-set_path_provider(StartDocumentBasedPathProvider())
+
+# Currently we must hard-code the visit, determining the visit at runtime requires
+# infrastructure that is still WIP.
+# Communication with GDA is also WIP so for now we determine an arbitrary scan number
+# locally and write the commissioning directory. The scan number is not guaranteed to
+# be unique and the data is at risk - this configuration is for testing only.
+set_path_provider(
+    StaticVisitPathProvider(
+        BL,
+        Path("/dls/i22/data/2024/cm37271-2/bluesky"),
+        client=RemoteDirectoryServiceClient("http://i22-control:8088/api"),
+    )
+)
 
 
 @device_factory()

--- a/src/dodal/beamlines/training_rig.py
+++ b/src/dodal/beamlines/training_rig.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from ophyd_async.epics.adaravis import AravisDetector
 from ophyd_async.fastcs.panda import HDFPanda
 
@@ -10,7 +8,7 @@ from dodal.common.beamlines.beamline_utils import (
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import DET_SUFFIX, HDF5_SUFFIX
-from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
+from dodal.common.visit import StartDocumentBasedPathProvider
 from dodal.devices.training_rig.sample_stage import TrainingRigSampleStage
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import BeamlinePrefix, get_beamline_name
@@ -31,13 +29,18 @@ PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
 
-set_path_provider(
-    StaticVisitPathProvider(
-        BL,
-        Path("/exports/mybeamline/data/2025"),
-        client=LocalDirectoryServiceClient(),
-    )
-)
+# Leave the old path provider so it can be uncommented and used in the meantime while
+# we transition
+
+# set_path_provider(
+#     StaticVisitPathProvider(
+#         BL,
+#         Path("/exports/mybeamline/data/2025"),
+#         client=LocalDirectoryServiceClient(),
+#     )
+# )
+
+set_path_provider(StartDocumentBasedPathProvider())
 
 
 @device_factory()

--- a/src/dodal/beamlines/training_rig.py
+++ b/src/dodal/beamlines/training_rig.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ophyd_async.epics.adaravis import AravisDetector
 from ophyd_async.fastcs.panda import HDFPanda
 
@@ -8,7 +10,10 @@ from dodal.common.beamlines.beamline_utils import (
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import DET_SUFFIX, HDF5_SUFFIX
-from dodal.common.visit import StartDocumentBasedPathProvider
+from dodal.common.visit import (
+    LocalDirectoryServiceClient,
+    StaticVisitPathProvider,
+)
 from dodal.devices.training_rig.sample_stage import TrainingRigSampleStage
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import BeamlinePrefix, get_beamline_name
@@ -29,18 +34,14 @@ PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
 
-# Leave the old path provider so it can be uncommented and used in the meantime while
-# we transition
 
-# set_path_provider(
-#     StaticVisitPathProvider(
-#         BL,
-#         Path("/exports/mybeamline/data/2025"),
-#         client=LocalDirectoryServiceClient(),
-#     )
-# )
-
-set_path_provider(StartDocumentBasedPathProvider())
+set_path_provider(
+    StaticVisitPathProvider(
+        BL,
+        Path("/exports/mybeamline/data/2025"),
+        client=LocalDirectoryServiceClient(),
+    )
+)
 
 
 @device_factory()

--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -25,6 +25,7 @@ DEFAULT_CONNECTION_TIMEOUT: Final[float] = 5.0
 ACTIVE_DEVICES: dict[str, AnyDevice] = {}
 BL = ""
 
+
 def set_beamline(beamline: str):
     global BL
     BL = beamline

--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -157,13 +157,35 @@ DEFAULT_TEMPLATE = "{device_name}-{instrument}-{scan_id}"
 
 
 class StartDocumentBasedPathProvider(PathProvider):
+    """A PathProvider that sources from metadata in a RunStart document.
+
+    This uses metadata a RunStart document to determine file names and data session
+    directories. The file naming defaults to "{device_name}-{instrument}-{scan_id}", so
+    the file name is incremented by scan number. A template can be included in the
+    StartDocument to allow for custom naming conventions.
+
+    """
+
     def __init__(self) -> None:
         self._doc = {}
 
     def update_run(self, name: str, start_doc: RunStart) -> None:
-        self._doc = start_doc
+        """Cache a start document.
+
+        This can be plugged into the run engines subscribe method.
+        """
+        if name == "start":
+            self._doc = start_doc
 
     def __call__(self, device_name: str | None = None) -> PathInfo:
+        """Returns the directory path and filename for a given data_session.
+
+        The default template for file naming is: "{device_name}-{instrument}-{scan_id}"
+        however, this can be changed by providing a template in the start document. For
+        example: "template": "custom-{device_name}--{scan_id}".
+
+        If you do not provide a data_session_directory it will default to "/tmp".
+        """
         template = self._doc.get("template", DEFAULT_TEMPLATE)
         sub_path = template.format_map(self._doc | {"device_name": device_name})
         data_session_directory = Path(self._doc.get("data_session_directory", "/tmp"))

--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -156,7 +156,7 @@ class StaticVisitPathProvider(UpdatingPathProvider):
 DEFAULT_TEMPLATE = "{device_name}-{instrument}-{scan_id}"
 
 
-class StartDocumentBasedPathProvider(PathProvider):
+class StartDocumentPathProvider(PathProvider):
     """A PathProvider that sources from metadata in a RunStart document.
 
     This uses metadata a RunStart document to determine file names and data session

--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -164,10 +164,7 @@ class StartDocumentBasedPathProvider(PathProvider):
         self._doc = start_doc
 
     def __call__(self, device_name: str | None = None) -> PathInfo:
-
         template = self._doc.get("template", DEFAULT_TEMPLATE)
         sub_path = template.format_map(self._doc | {"device_name": device_name})
         data_session_directory = Path(self._doc.get("data_session_directory", "/tmp"))
-        return PathInfo(
-            directory_path=data_session_directory, filename=sub_path
-        )
+        return PathInfo(directory_path=data_session_directory, filename=sub_path)

--- a/src/dodal/common/visit.py
+++ b/src/dodal/common/visit.py
@@ -159,7 +159,7 @@ DEFAULT_TEMPLATE = "{device_name}-{instrument}-{scan_id}"
 class StartDocumentPathProvider(PathProvider):
     """A PathProvider that sources from metadata in a RunStart document.
 
-    This uses metadata a RunStart document to determine file names and data session
+    This uses metadata from a RunStart document to determine file names and data session
     directories. The file naming defaults to "{device_name}-{instrument}-{scan_id}", so
     the file name is incremented by scan number. A template can be included in the
     StartDocument to allow for custom naming conventions.
@@ -172,7 +172,7 @@ class StartDocumentPathProvider(PathProvider):
     def update_run(self, name: str, start_doc: RunStart) -> None:
         """Cache a start document.
 
-        This can be plugged into the run engines subscribe method.
+        This can be plugged into the run engine's subscribe method.
         """
         if name == "start":
             self._doc = start_doc

--- a/src/dodal/plan_stubs/data_session.py
+++ b/src/dodal/plan_stubs/data_session.py
@@ -42,7 +42,7 @@ def attach_data_session_metadata_wrapper(
         # As part of 452, write each dataCollection into their own folder, then can use resource_dir directly
         yield from bpp.inject_md_wrapper(plan, md={DATA_SESSION: data_session})
     else:
-        logging.warn(
+        logging.warning(
             f"{provider} is not an UpdatingPathProvider, {attach_data_session_metadata_wrapper.__name__} will have no effect"
         )
         yield from plan

--- a/src/dodal/plan_stubs/data_session.py
+++ b/src/dodal/plan_stubs/data_session.py
@@ -31,7 +31,14 @@ def attach_data_session_metadata_wrapper(
         Iterator[Msg]: Plan messages
     """
     if provider is None:
-        provider = get_path_provider()
+        p = get_path_provider()
+        if isinstance(p, UpdatingPathProvider):
+            provider = p
+        else:
+            raise ValueError(
+                "UpdatingPathProvider required for using the attach_data_session_metadata_wrapper"
+            )
+
     yield from bps.wait_for([provider.update])
     ress = yield from bps.wait_for([provider.data_session])
     data_session = ress[0].result()

--- a/src/dodal/plan_stubs/data_session.py
+++ b/src/dodal/plan_stubs/data_session.py
@@ -1,6 +1,9 @@
+import logging
+
 from bluesky import plan_stubs as bps
 from bluesky import preprocessors as bpp
 from bluesky.utils import MsgGenerator, make_decorator
+from ophyd_async.core import PathProvider
 
 from dodal.common.beamlines.beamline_utils import get_path_provider
 from dodal.common.types import UpdatingPathProvider
@@ -10,7 +13,7 @@ DATA_GROUPS = "data_groups"
 
 
 def attach_data_session_metadata_wrapper(
-    plan: MsgGenerator, provider: UpdatingPathProvider | None = None
+    plan: MsgGenerator, provider: PathProvider | None = None
 ) -> MsgGenerator:
     """
     Attach data session metadata to the runs within a plan and make it correlate
@@ -30,21 +33,19 @@ def attach_data_session_metadata_wrapper(
     Yields:
         Iterator[Msg]: Plan messages
     """
-    if provider is None:
-        p = get_path_provider()
-        if isinstance(p, UpdatingPathProvider):
-            provider = p
-        else:
-            raise ValueError(
-                "UpdatingPathProvider required for using the attach_data_session_metadata_wrapper"
-            )
-
-    yield from bps.wait_for([provider.update])
-    ress = yield from bps.wait_for([provider.data_session])
-    data_session = ress[0].result()
-    # https://github.com/DiamondLightSource/dodal/issues/452
-    # As part of 452, write each dataCollection into their own folder, then can use resource_dir directly
-    yield from bpp.inject_md_wrapper(plan, md={DATA_SESSION: data_session})
+    provider = provider or get_path_provider()
+    if isinstance(provider, UpdatingPathProvider):
+        yield from bps.wait_for([provider.update])
+        ress = yield from bps.wait_for([provider.data_session])
+        data_session = ress[0].result()
+        # https://github.com/DiamondLightSource/dodal/issues/452
+        # As part of 452, write each dataCollection into their own folder, then can use resource_dir directly
+        yield from bpp.inject_md_wrapper(plan, md={DATA_SESSION: data_session})
+    else:
+        logging.warn(
+            f"{provider} is not an UpdatingPathProvider, {attach_data_session_metadata_wrapper.__name__} will have no effect"
+        )
+        yield from plan
 
 
 attach_data_session_metadata_decorator = make_decorator(

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -124,7 +124,73 @@ def test_start_document_based_path_provider_with_custom_template_returns_correct
     assert path == PathInfo(directory_path=PosixPath('/p01/ab123'), filename='det-p01-22-custom', create_dir_depth=0)
 
 
-def test_start_document_based_path_provider_fails_with_missing_keys(start_doc_missing_keys: RunStart):
-    """Raise exception with sensible error"""
-    ...
+@pytest.fixture
+def start_doc_missing_instrument() -> dict:
+    return {
+        "uid": "27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+        "time": 1741264729.96875,
+        "versions": {"ophyd": "1.10.0", "bluesky": "1.13"},
+        "data_session": "ab123",
+        "data_session_directory": "/p01/ab123",
+        "scan_id": 22,
+        "plan_type": "generator",
+        "plan_name": "count",
+        "detectors": ["det"],
+        "num_points": 1,
+        "num_intervals": 0,
+        "plan_args": {
+            "detectors": [
+                "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
+            ],
+            "num": 1,
+            "delay": 0.0,
+        },
+        "hints": {"dimensions": [[["time"], "primary"]]},
+        "shape": [1],
+    }
 
+
+def test_start_document_based_path_provider_fails_with_missing_instrument(
+    start_doc_missing_instrument: RunStart,
+):
+    pp = StartDocumentBasedPathProvider()
+    pp.update_run(name="start", start_doc=start_doc_missing_instrument)
+
+    with pytest.raises(KeyError, match="'instrument'"):
+        pp("det")
+
+
+@pytest.fixture
+def start_doc_missing_scan_id() -> dict:
+    return {
+        "uid": "27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+        "time": 1741264729.96875,
+        "versions": {"ophyd": "1.10.0", "bluesky": "1.13"},
+        "data_session": "ab123",
+        "instrument": "p01",
+        "data_session_directory": "/p01/ab123",
+        "plan_type": "generator",
+        "plan_name": "count",
+        "detectors": ["det"],
+        "num_points": 1,
+        "num_intervals": 0,
+        "plan_args": {
+            "detectors": [
+                "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
+            ],
+            "num": 1,
+            "delay": 0.0,
+        },
+        "hints": {"dimensions": [[["time"], "primary"]]},
+        "shape": [1],
+    }
+
+
+def test_start_document_based_path_provider_fails_with_missing_scan_id(
+    start_doc_missing_scan_id: RunStart,
+):
+    pp = StartDocumentBasedPathProvider()
+    pp.update_run(name="start", start_doc=start_doc_missing_scan_id)
+
+    with pytest.raises(KeyError, match="'scan_id'"):
+        pp("det")

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -40,88 +40,87 @@ async def test_when_get_current_collection_called_on_remote_directory_service_cl
     mock_request.assert_called_with("GET", f"{test_url}/numtracker")
 
 
-
 @pytest.fixture
 def start_doc_default_template() -> dict:
     return {
-            "uid":"27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
-            "time":1741264729.96875,
-            "versions":{
-                "ophyd":"1.10.0",
-                "bluesky":"1.13"
-            },
-            "data_session":"ab123",
-            "instrument":"p01",
-            "data_session_directory":"/p01/ab123",
-            "scan_id":22,
-            "plan_type":"generator",
-            "plan_name":"count",
-            "detectors":[
-                "det"
+        "uid": "27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+        "time": 1741264729.96875,
+        "versions": {"ophyd": "1.10.0", "bluesky": "1.13"},
+        "data_session": "ab123",
+        "instrument": "p01",
+        "data_session_directory": "/p01/ab123",
+        "scan_id": 22,
+        "plan_type": "generator",
+        "plan_name": "count",
+        "detectors": ["det"],
+        "num_points": 1,
+        "num_intervals": 0,
+        "plan_args": {
+            "detectors": [
+                "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
             ],
-            "num_points":1,
-            "num_intervals":0,
-            "plan_args":{
-                "detectors":[
-                    "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
-                ],
-                "num":1,
-                "delay":0.0
-            },
-            "hints":{
-                "dimensions":[[["time"],"primary"]]
-            },
-            "shape":[1]
+            "num": 1,
+            "delay": 0.0,
+        },
+        "hints": {"dimensions": [[["time"], "primary"]]},
+        "shape": [1],
     }
 
-def test_start_document_based_path_provider_with_default_template_returns_correct_path_info(start_doc_default_template: RunStart):
+
+def test_start_document_based_path_provider_with_default_template_returns_correct_path_info(
+    start_doc_default_template: RunStart,
+):
     pp = StartDocumentBasedPathProvider()
-    pp.update_run(name = "start", start_doc = start_doc_default_template)
+    pp.update_run(name="start", start_doc=start_doc_default_template)
     path = pp("det")
 
-    assert path == PathInfo(directory_path=PosixPath('/p01/ab123'), filename='det-p01-22', create_dir_depth=0)
+    assert path == PathInfo(
+        directory_path=PosixPath("/p01/ab123"),
+        filename="det-p01-22",
+        create_dir_depth=0,
+    )
 
 
 @pytest.fixture
 def start_doc_custom_template() -> dict:
     return {
-            "uid":"27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
-            "time":1741264729.96875,
-            "versions":{
-                "ophyd":"1.10.0",
-                "bluesky":"1.13"
-            },
-            "data_session":"ab123",
-            "instrument":"p01",
-            "data_session_directory":"/p01/ab123",
-            "scan_id":22,
-            "template": "{device_name}-{instrument}-{scan_id}-custom",
-            "plan_type":"generator",
-            "plan_name":"count",
-            "detectors":[
-                "det"
+        "uid": "27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+        "time": 1741264729.96875,
+        "versions": {"ophyd": "1.10.0", "bluesky": "1.13"},
+        "data_session": "ab123",
+        "instrument": "p01",
+        "data_session_directory": "/p01/ab123",
+        "scan_id": 22,
+        "template": "{device_name}-{instrument}-{scan_id}-custom",
+        "plan_type": "generator",
+        "plan_name": "count",
+        "detectors": ["det"],
+        "num_points": 1,
+        "num_intervals": 0,
+        "plan_args": {
+            "detectors": [
+                "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
             ],
-            "num_points":1,
-            "num_intervals":0,
-            "plan_args":{
-                "detectors":[
-                    "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
-                ],
-                "num":1,
-                "delay":0.0
-            },
-            "hints":{
-                "dimensions":[[["time"],"primary"]]
-            },
-            "shape":[1]
+            "num": 1,
+            "delay": 0.0,
+        },
+        "hints": {"dimensions": [[["time"], "primary"]]},
+        "shape": [1],
     }
 
-def test_start_document_based_path_provider_with_custom_template_returns_correct_path_info(start_doc_custom_template: RunStart):
+
+def test_start_document_based_path_provider_with_custom_template_returns_correct_path_info(
+    start_doc_custom_template: RunStart,
+):
     pp = StartDocumentBasedPathProvider()
-    pp.update_run(name = "start", start_doc = start_doc_custom_template)
+    pp.update_run(name="start", start_doc=start_doc_custom_template)
     path = pp("det")
 
-    assert path == PathInfo(directory_path=PosixPath('/p01/ab123'), filename='det-p01-22-custom', create_dir_depth=0)
+    assert path == PathInfo(
+        directory_path=PosixPath("/p01/ab123"),
+        filename="det-p01-22-custom",
+        create_dir_depth=0,
+    )
 
 
 @pytest.fixture
@@ -199,40 +198,36 @@ def test_start_document_based_path_provider_fails_with_missing_scan_id(
 @pytest.fixture
 def start_doc_default_data_session_directory() -> dict:
     return {
-            "uid":"27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
-            "time":1741264729.96875,
-            "versions":{
-                "ophyd":"1.10.0",
-                "bluesky":"1.13"
-            },
-            "data_session":"ab123",
-            "instrument":"p01",
-            "scan_id":22,
-            "plan_type":"generator",
-            "plan_name":"count",
-            "detectors":[
-                "det"
+        "uid": "27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+        "time": 1741264729.96875,
+        "versions": {"ophyd": "1.10.0", "bluesky": "1.13"},
+        "data_session": "ab123",
+        "instrument": "p01",
+        "scan_id": 22,
+        "plan_type": "generator",
+        "plan_name": "count",
+        "detectors": ["det"],
+        "num_points": 1,
+        "num_intervals": 0,
+        "plan_args": {
+            "detectors": [
+                "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
             ],
-            "num_points":1,
-            "num_intervals":0,
-            "plan_args":{
-                "detectors":[
-                    "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
-                ],
-                "num":1,
-                "delay":0.0
-            },
-            "hints":{
-                "dimensions":[[["time"],"primary"]]
-            },
-            "shape":[1]
+            "num": 1,
+            "delay": 0.0,
+        },
+        "hints": {"dimensions": [[["time"], "primary"]]},
+        "shape": [1],
     }
 
 
-def test_start_document_based_path_provider_sets_data_session_directory_default_to_tmp(start_doc_default_data_session_directory: RunStart):
+def test_start_document_based_path_provider_sets_data_session_directory_default_to_tmp(
+    start_doc_default_data_session_directory: RunStart,
+):
     pp = StartDocumentBasedPathProvider()
-    pp.update_run(name = "start", start_doc = start_doc_default_data_session_directory)
+    pp.update_run(name="start", start_doc=start_doc_default_data_session_directory)
     path = pp("det")
 
-    assert path == PathInfo(directory_path=PosixPath('/tmp'), filename='det-p01-22', create_dir_depth=0)
-
+    assert path == PathInfo(
+        directory_path=PosixPath("/tmp"), filename="det-p01-22", create_dir_depth=0
+    )

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -67,7 +67,7 @@ def start_doc_default_template() -> dict:
     }
 
 
-def test_start_document_based_path_provider_with_default_template_returns_correct_path_info(
+def test_start_document_path_provider_with_default_template_returns_correct_path_info(
     start_doc_default_template: RunStart,
 ):
     pp = StartDocumentPathProvider()
@@ -109,7 +109,7 @@ def start_doc_custom_template() -> dict:
     }
 
 
-def test_start_document_based_path_provider_with_custom_template_returns_correct_path_info(
+def test_start_document_path_provider_with_custom_template_returns_correct_path_info(
     start_doc_custom_template: RunStart,
 ):
     pp = StartDocumentPathProvider()
@@ -149,7 +149,7 @@ def start_doc_missing_instrument() -> dict:
     }
 
 
-def test_start_document_based_path_provider_fails_with_missing_instrument(
+def test_start_document_path_provider_fails_with_missing_instrument(
     start_doc_missing_instrument: RunStart,
 ):
     pp = StartDocumentPathProvider()
@@ -185,7 +185,7 @@ def start_doc_missing_scan_id() -> dict:
     }
 
 
-def test_start_document_based_path_provider_fails_with_missing_scan_id(
+def test_start_document_path_provider_fails_with_missing_scan_id(
     start_doc_missing_scan_id: RunStart,
 ):
     pp = StartDocumentPathProvider()
@@ -221,7 +221,7 @@ def start_doc_default_data_session_directory() -> dict:
     }
 
 
-def test_start_document_based_path_provider_sets_data_session_directory_default_to_tmp(
+def test_start_document_path_provider_sets_data_session_directory_default_to_tmp(
     start_doc_default_data_session_directory: RunStart,
 ):
     pp = StartDocumentPathProvider()
@@ -233,7 +233,7 @@ def test_start_document_based_path_provider_sets_data_session_directory_default_
     )
 
 
-def test_start_document_based_path_provider_update_called_with_different_document_skips(
+def test_start_document_path_provider_update_called_with_different_document_skips(
     start_doc_default_template: RunStart,
 ):
     pp = StartDocumentPathProvider()

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -81,8 +81,48 @@ def test_start_document_based_path_provider_with_default_template_returns_correc
 
     assert path == PathInfo(directory_path=PosixPath('/p01/ab123'), filename='det-p01-22', create_dir_depth=0)
 
+
+@pytest.fixture
+def start_doc_custom_template() -> dict:
+    return {
+            "uid":"27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+            "time":1741264729.96875,
+            "versions":{
+                "ophyd":"1.10.0",
+                "bluesky":"1.13"
+            },
+            "data_session":"ab123",
+            "instrument":"p01",
+            "data_session_directory":"/p01/ab123",
+            "scan_id":22,
+            "template": "{device_name}-{instrument}-{scan_id}-custom",
+            "plan_type":"generator",
+            "plan_name":"count",
+            "detectors":[
+                "det"
+            ],
+            "num_points":1,
+            "num_intervals":0,
+            "plan_args":{
+                "detectors":[
+                    "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
+                ],
+                "num":1,
+                "delay":0.0
+            },
+            "hints":{
+                "dimensions":[[["time"],"primary"]]
+            },
+            "shape":[1]
+    }
+
 def test_start_document_based_path_provider_with_custom_template_returns_correct_path_info(start_doc_custom_template: RunStart):
-    ...
+    pp = StartDocumentBasedPathProvider()
+    pp.update_run(name = "start", start_doc = start_doc_custom_template)
+    path = pp("det")
+
+    assert path == PathInfo(directory_path=PosixPath('/p01/ab123'), filename='det-p01-22-custom', create_dir_depth=0)
+
 
 def test_start_document_based_path_provider_fails_with_missing_keys(start_doc_missing_keys: RunStart):
     """Raise exception with sensible error"""

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -194,3 +194,45 @@ def test_start_document_based_path_provider_fails_with_missing_scan_id(
 
     with pytest.raises(KeyError, match="'scan_id'"):
         pp("det")
+
+
+@pytest.fixture
+def start_doc_default_data_session_directory() -> dict:
+    return {
+            "uid":"27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+            "time":1741264729.96875,
+            "versions":{
+                "ophyd":"1.10.0",
+                "bluesky":"1.13"
+            },
+            "data_session":"ab123",
+            "instrument":"p01",
+            "scan_id":22,
+            "plan_type":"generator",
+            "plan_name":"count",
+            "detectors":[
+                "det"
+            ],
+            "num_points":1,
+            "num_intervals":0,
+            "plan_args":{
+                "detectors":[
+                    "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
+                ],
+                "num":1,
+                "delay":0.0
+            },
+            "hints":{
+                "dimensions":[[["time"],"primary"]]
+            },
+            "shape":[1]
+    }
+
+
+def test_start_document_based_path_provider_sets_data_session_directory_default_to_tmp(start_doc_default_data_session_directory: RunStart):
+    pp = StartDocumentBasedPathProvider()
+    pp.update_run(name = "start", start_doc = start_doc_default_data_session_directory)
+    path = pp("det")
+
+    assert path == PathInfo(directory_path=PosixPath('/tmp'), filename='det-p01-22', create_dir_depth=0)
+

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -231,3 +231,12 @@ def test_start_document_based_path_provider_sets_data_session_directory_default_
     assert path == PathInfo(
         directory_path=PosixPath("/tmp"), filename="det-p01-22", create_dir_depth=0
     )
+
+
+def test_start_document_based_path_provider_update_called_with_different_document_skips(
+    start_doc_default_template: RunStart,
+):
+    pp = StartDocumentBasedPathProvider()
+    pp.update_run(name="descriptor", start_doc=start_doc_default_template)
+
+    assert pp._doc == {}

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -7,7 +7,7 @@ from ophyd_async.core import PathInfo
 
 from dodal.common.visit import (
     RemoteDirectoryServiceClient,
-    StartDocumentBasedPathProvider,
+    StartDocumentPathProvider,
 )
 
 
@@ -70,7 +70,7 @@ def start_doc_default_template() -> dict:
 def test_start_document_based_path_provider_with_default_template_returns_correct_path_info(
     start_doc_default_template: RunStart,
 ):
-    pp = StartDocumentBasedPathProvider()
+    pp = StartDocumentPathProvider()
     pp.update_run(name="start", start_doc=start_doc_default_template)
     path = pp("det")
 
@@ -112,7 +112,7 @@ def start_doc_custom_template() -> dict:
 def test_start_document_based_path_provider_with_custom_template_returns_correct_path_info(
     start_doc_custom_template: RunStart,
 ):
-    pp = StartDocumentBasedPathProvider()
+    pp = StartDocumentPathProvider()
     pp.update_run(name="start", start_doc=start_doc_custom_template)
     path = pp("det")
 
@@ -152,7 +152,7 @@ def start_doc_missing_instrument() -> dict:
 def test_start_document_based_path_provider_fails_with_missing_instrument(
     start_doc_missing_instrument: RunStart,
 ):
-    pp = StartDocumentBasedPathProvider()
+    pp = StartDocumentPathProvider()
     pp.update_run(name="start", start_doc=start_doc_missing_instrument)
 
     with pytest.raises(KeyError, match="'instrument'"):
@@ -188,7 +188,7 @@ def start_doc_missing_scan_id() -> dict:
 def test_start_document_based_path_provider_fails_with_missing_scan_id(
     start_doc_missing_scan_id: RunStart,
 ):
-    pp = StartDocumentBasedPathProvider()
+    pp = StartDocumentPathProvider()
     pp.update_run(name="start", start_doc=start_doc_missing_scan_id)
 
     with pytest.raises(KeyError, match="'scan_id'"):
@@ -224,7 +224,7 @@ def start_doc_default_data_session_directory() -> dict:
 def test_start_document_based_path_provider_sets_data_session_directory_default_to_tmp(
     start_doc_default_data_session_directory: RunStart,
 ):
-    pp = StartDocumentBasedPathProvider()
+    pp = StartDocumentPathProvider()
     pp.update_run(name="start", start_doc=start_doc_default_data_session_directory)
     path = pp("det")
 
@@ -236,7 +236,7 @@ def test_start_document_based_path_provider_sets_data_session_directory_default_
 def test_start_document_based_path_provider_update_called_with_different_document_skips(
     start_doc_default_template: RunStart,
 ):
-    pp = StartDocumentBasedPathProvider()
+    pp = StartDocumentPathProvider()
     pp.update_run(name="descriptor", start_doc=start_doc_default_template)
 
     assert pp._doc == {}

--- a/tests/common/test_visit.py
+++ b/tests/common/test_visit.py
@@ -1,6 +1,14 @@
+from pathlib import PosixPath
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from dodal.common.visit import RemoteDirectoryServiceClient
+import pytest
+from event_model.documents import RunStart
+from ophyd_async.core import PathInfo
+
+from dodal.common.visit import (
+    RemoteDirectoryServiceClient,
+    StartDocumentBasedPathProvider,
+)
 
 
 def create_valid_response(mock_request):
@@ -30,3 +38,53 @@ async def test_when_get_current_collection_called_on_remote_directory_service_cl
     collection = await client.get_current_collection()
     assert collection.collectionNumber == 1
     mock_request.assert_called_with("GET", f"{test_url}/numtracker")
+
+
+
+@pytest.fixture
+def start_doc_default_template() -> dict:
+    return {
+            "uid":"27c48d2f-d8c6-4ac0-8146-fedf467ce11f",
+            "time":1741264729.96875,
+            "versions":{
+                "ophyd":"1.10.0",
+                "bluesky":"1.13"
+            },
+            "data_session":"ab123",
+            "instrument":"p01",
+            "data_session_directory":"/p01/ab123",
+            "scan_id":22,
+            "plan_type":"generator",
+            "plan_name":"count",
+            "detectors":[
+                "det"
+            ],
+            "num_points":1,
+            "num_intervals":0,
+            "plan_args":{
+                "detectors":[
+                    "<ophyd_async.epics.adaravis._aravis.AravisDetector object at 0x7f74c02b8710>"
+                ],
+                "num":1,
+                "delay":0.0
+            },
+            "hints":{
+                "dimensions":[[["time"],"primary"]]
+            },
+            "shape":[1]
+    }
+
+def test_start_document_based_path_provider_with_default_template_returns_correct_path_info(start_doc_default_template: RunStart):
+    pp = StartDocumentBasedPathProvider()
+    pp.update_run(name = "start", start_doc = start_doc_default_template)
+    path = pp("det")
+
+    assert path == PathInfo(directory_path=PosixPath('/p01/ab123'), filename='det-p01-22', create_dir_depth=0)
+
+def test_start_document_based_path_provider_with_custom_template_returns_correct_path_info(start_doc_custom_template: RunStart):
+    ...
+
+def test_start_document_based_path_provider_fails_with_missing_keys(start_doc_missing_keys: RunStart):
+    """Raise exception with sensible error"""
+    ...
+

--- a/tests/plan_stubs/test_data_session.py
+++ b/tests/plan_stubs/test_data_session.py
@@ -6,12 +6,16 @@ from dodal.plan_stubs.data_session import attach_data_session_metadata_wrapper
 
 
 def test_attach_data_session_metadata_wrapper(caplog, RE: RunEngine):
-
     def fake_plan() -> MsgGenerator[None]:
         yield from []
 
     path_provider = StartDocumentBasedPathProvider()
-    plan = attach_data_session_metadata_wrapper(plan = fake_plan(), provider = path_provider)
+    plan = attach_data_session_metadata_wrapper(
+        plan=fake_plan(), provider=path_provider
+    )
     RE(plan)
 
-    assert f"{path_provider} is not an UpdatingPathProvider, {attach_data_session_metadata_wrapper.__name__} will have no effect" in caplog.text
+    assert (
+        f"{path_provider} is not an UpdatingPathProvider, {attach_data_session_metadata_wrapper.__name__} will have no effect"
+        in caplog.text
+    )

--- a/tests/plan_stubs/test_data_session.py
+++ b/tests/plan_stubs/test_data_session.py
@@ -1,7 +1,7 @@
 from bluesky.run_engine import RunEngine
 from bluesky.utils import MsgGenerator
 
-from dodal.common.visit import StartDocumentBasedPathProvider
+from dodal.common.visit import StartDocumentPathProvider
 from dodal.plan_stubs.data_session import attach_data_session_metadata_wrapper
 
 
@@ -9,7 +9,7 @@ def test_attach_data_session_metadata_wrapper(caplog, RE: RunEngine):
     def fake_plan() -> MsgGenerator[None]:
         yield from []
 
-    path_provider = StartDocumentBasedPathProvider()
+    path_provider = StartDocumentPathProvider()
     plan = attach_data_session_metadata_wrapper(
         plan=fake_plan(), provider=path_provider
     )

--- a/tests/plan_stubs/test_data_session.py
+++ b/tests/plan_stubs/test_data_session.py
@@ -1,0 +1,17 @@
+from bluesky.run_engine import RunEngine
+from bluesky.utils import MsgGenerator
+
+from dodal.common.visit import StartDocumentBasedPathProvider
+from dodal.plan_stubs.data_session import attach_data_session_metadata_wrapper
+
+
+def test_attach_data_session_metadata_wrapper(caplog, RE: RunEngine):
+
+    def fake_plan() -> MsgGenerator[None]:
+        yield from []
+
+    path_provider = StartDocumentBasedPathProvider()
+    plan = attach_data_session_metadata_wrapper(plan = fake_plan(), provider = path_provider)
+    RE(plan)
+
+    assert f"{path_provider} is not an UpdatingPathProvider, {attach_data_session_metadata_wrapper.__name__} will have no effect" in caplog.text


### PR DESCRIPTION
Fixes #991 

Needs https://github.com/DiamondLightSource/blueapi/pull/845 and https://github.com/DiamondLightSource/blueapi/pull/846 to be used

### Instructions to reviewer on how to test:
1. See https://github.com/DiamondLightSource/blueapi/pull/846

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`

TODO:
- Write unit tests for the new path provider
- add a test for the restructured metadata wrapper
