### PR TITLE
Add i19 optics beamline definition

### DIFF
--- a/src/dodal/beamlines/__init__.py
+++ b/src/dodal/beamlines/__init__.py
@@ -13,6 +13,7 @@ _BEAMLINE_NAME_OVERRIDES = {
     "i20-1": "i20_1",
     "i19-1": "i19_1",
     "i19-2": "i19_2",
+    "i19-optics": "i19_optics",
     "s03": "i03",
     "p46": "training_rig",
     "p47": "training_rig",

--- a/src/dodal/beamlines/i19_optics.py
+++ b/src/dodal/beamlines/i19_optics.py
@@ -1,0 +1,25 @@
+from dodal.common.beamlines.beamline_utils import (
+    device_factory,
+)
+from dodal.common.beamlines.beamline_utils import (
+    set_beamline as set_utils_beamline,
+)
+from dodal.devices.hutch_shutter import HutchShutter
+from dodal.log import set_beamline as set_log_beamline
+from dodal.utils import BeamlinePrefix
+
+BL = "i19-optics"
+PREFIX = BeamlinePrefix("i19", "I")
+set_log_beamline(BL)
+set_utils_beamline(BL)
+
+
+@device_factory()
+def shutter() -> HutchShutter:
+    """Get the i19 hutch shutter device, instantiate it if it hasn't already been.
+    If this is called when already instantiated, it will return the existing object.
+    """
+    return HutchShutter(
+        f"{PREFIX.beamline_prefix}-PS-SHTR-01:",
+        "shutter",
+    )


### PR DESCRIPTION
Fixes #1090 
See also [i19-bluesky#33](https://github.com/DiamondLightSource/i19-bluesky/issues/33)

### Instructions to reviewer on how to test:
1.Run `dodal connect i19-optics` and verify it connects

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
