### PR TITLE
Add undulator check as preprocessor

### DIFF
--- a/src/dodal/plans/preprocessors/verify_undulator_gap.py
+++ b/src/dodal/plans/preprocessors/verify_undulator_gap.py
@@ -1,0 +1,49 @@
+from bluesky.preprocessors import plan_mutator
+from bluesky.utils import Msg, MsgGenerator, make_decorator
+
+from dodal.plans.verify_undulator_gap import CheckUndulatorDevices, verify_undulator_gap
+
+
+def verify_undulator_gap_before_run_wrapper(
+    plan: MsgGenerator,
+    devices: CheckUndulatorDevices,
+    run_key_to_wrap: str | None = None,
+):
+    """
+    Modifies the wrapped plan so that it checks the undulator gap before the specified run is opened and sets it to the correct value if needed.
+
+    After a beam dump, the undulator gap may not return correctly, scientists have often requested that this check is done before collections.
+
+    Args:
+        plan: The plan performing the run.
+        devices (CheckUndulatorDevices): Any device composite including the DCM and undulator
+        run_key_to_wrap: (str | None): The plan to verify the undulator gap is inserted after the 'open_run' message is seen with
+        the matching run key. If not specified, instead wrap the first run encountered.
+    """
+
+    # If no run_key specified, make sure we only do check on first run encountered
+    _wrapped_run_name: None | str = None
+
+    def head(msg: Msg):
+        yield from verify_undulator_gap(devices)
+        yield msg
+
+    def insert_plans(msg: Msg):
+        nonlocal _wrapped_run_name
+
+        match msg.command:
+            case "open_run":
+                if (
+                    not (run_key_to_wrap or _wrapped_run_name)
+                    or run_key_to_wrap is msg.run
+                ):
+                    _wrapped_run_name = msg.run if msg.run else "unnamed_run"
+                    return head(msg), None
+        return None, None
+
+    return plan_mutator(plan, insert_plans)
+
+
+verify_undulator_gap_before_run_decorator = make_decorator(
+    verify_undulator_gap_before_run_wrapper
+)

--- a/src/dodal/plans/verify_undulator_gap.py
+++ b/src/dodal/plans/verify_undulator_gap.py
@@ -1,0 +1,19 @@
+from typing import Protocol, runtime_checkable
+
+from bluesky import plan_stubs as bps
+
+from dodal.devices.dcm import DCM
+from dodal.devices.undulator import Undulator
+
+
+@runtime_checkable
+class CheckUndulatorDevices(Protocol):
+    undulator: Undulator
+    dcm: DCM
+
+
+def verify_undulator_gap(devices: CheckUndulatorDevices):
+    """Verify Undulator gap is correct - it may not be after a beam dump"""
+
+    energy_in_kev = yield from bps.rd(devices.dcm.energy_in_kev.user_readback)
+    yield from bps.abs_set(devices.undulator, energy_in_kev, wait=True)

--- a/system_tests/test_undulator_system.py
+++ b/system_tests/test_undulator_system.py
@@ -1,13 +1,10 @@
 import pytest
 from ophyd_async.core import init_devices
+from tests.constants import UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
 
 from dodal.devices.undulator import Undulator
 
 SIM_INSERTION_PREFIX = "SR03S"
-
-ID_GAP_LOOKUP_TABLE_PATH: str = (
-    "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"
-)
 
 
 @pytest.mark.s03
@@ -15,5 +12,5 @@ def test_undulator_connects():
     with init_devices():
         undulator = Undulator(  # noqa: F841
             f"{SIM_INSERTION_PREFIX}-MO-SERVC-01:",
-            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
+            id_gap_lookup_table_path=UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH,
         )

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,3 @@
+UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH: str = (
+    "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"
+)

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -15,10 +15,7 @@ from dodal.devices.undulator import (
     UndulatorGapAccess,
     _get_closest_gap_for_energy,
 )
-
-ID_GAP_LOOKUP_TABLE_PATH: str = (
-    "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"
-)
+from tests.constants import UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
 
 
 @pytest.fixture
@@ -29,7 +26,7 @@ async def undulator() -> Undulator:
             name="undulator",
             poles=80,
             length=2.0,
-            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
+            id_gap_lookup_table_path=UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH,
         )
     return undulator
 
@@ -101,7 +98,7 @@ async def test_poles_not_propagated_if_not_supplied():
             "UND-01",
             name="undulator",
             length=2.0,
-            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
+            id_gap_lookup_table_path=UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH,
         )
     assert undulator.poles is None
     assert "undulator-poles" not in (await undulator.read_configuration())
@@ -113,7 +110,7 @@ async def test_length_not_propagated_if_not_supplied():
             "UND-01",
             name="undulator",
             poles=80,
-            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
+            id_gap_lookup_table_path=UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH,
         )
     assert undulator.length is None
     assert "undulator-length" not in (await undulator.read_configuration())

--- a/tests/devices/unit_tests/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/test_undulator_dcm.py
@@ -12,10 +12,7 @@ from dodal.devices.undulator import AccessError, Undulator, UndulatorGapAccess
 from dodal.devices.undulator_dcm import UndulatorDCM
 from dodal.devices.util.test_utils import patch_motor
 from dodal.log import LOGGER
-
-ID_GAP_LOOKUP_TABLE_PATH: str = (
-    "./tests/devices/unit_tests/test_beamline_undulator_to_gap_lookup_table.txt"
-)
+from tests.constants import UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
 
 
 @pytest.fixture(autouse=True)
@@ -35,7 +32,7 @@ async def fake_undulator_dcm() -> UndulatorDCM:
             "UND-01",
             name="undulator",
             poles=80,
-            id_gap_lookup_table_path=ID_GAP_LOOKUP_TABLE_PATH,
+            id_gap_lookup_table_path=UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH,
             length=2.0,
         )
         dcm = DCM("DCM-01", name="dcm")
@@ -52,7 +49,7 @@ async def fake_undulator_dcm() -> UndulatorDCM:
 def test_lookup_table_paths_passed(fake_undulator_dcm: UndulatorDCM):
     assert (
         fake_undulator_dcm.undulator_ref().id_gap_lookup_table_path
-        == ID_GAP_LOOKUP_TABLE_PATH
+        == UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
     )
     assert (
         fake_undulator_dcm.pitch_energy_table_path

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -5,6 +5,27 @@ import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import PathProvider, StandardDetector, init_devices
 from ophyd_async.sim import PatternDetector, SimMotor
+from tests.constants import UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
+
+from dodal.devices.dcm import DCM
+from dodal.devices.undulator import Undulator
+
+
+class UndulatorGapCheckDevices:
+    def __init__(self, undulator: Undulator, dcm: DCM):
+        self.undulator = undulator
+        self.dcm = dcm
+
+
+@pytest.fixture
+async def mock_undulator_and_dcm() -> UndulatorGapCheckDevices:
+    async with init_devices(mock=True):
+        undulator = Undulator(
+            "",
+            id_gap_lookup_table_path=UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH,
+        )
+        dcm = DCM("")
+    return UndulatorGapCheckDevices(undulator, dcm)
 
 
 @pytest.fixture

--- a/tests/plans/test_preprocessors/test_verify_undulator_gap.py
+++ b/tests/plans/test_preprocessors/test_verify_undulator_gap.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+
+import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
+from bluesky.run_engine import RunEngine
+from tests.plans.conftest import UndulatorGapCheckDevices
+
+from dodal.plans.preprocessors.verify_undulator_gap import (
+    verify_undulator_gap_before_run_decorator,
+)
+
+RUN_KEY = "test_run"
+
+
+@patch("dodal.plans.verify_undulator_gap.verify_undulator_gap")
+def test_verify_undulator_gap_decorator_does_nothing_on_wrong_run(
+    mock_verify: MagicMock,
+    RE: RunEngine,
+    mock_undulator_and_dcm: UndulatorGapCheckDevices,
+):
+    @verify_undulator_gap_before_run_decorator(
+        devices=mock_undulator_and_dcm, run_key_to_wrap=RUN_KEY
+    )
+    def boring_plan():
+        yield from bps.null()
+
+    RE(boring_plan())
+    mock_verify.assert_not_called()
+
+
+@patch("dodal.plans.preprocessors.verify_undulator_gap.verify_undulator_gap")
+def test_verify_undulator_gap_decorator_runs_on_run_key_only(
+    mock_verify: MagicMock,
+    RE: RunEngine,
+    mock_undulator_and_dcm: UndulatorGapCheckDevices,
+):
+    @verify_undulator_gap_before_run_decorator(
+        devices=mock_undulator_and_dcm, run_key_to_wrap=RUN_KEY
+    )
+    @bpp.run_decorator()
+    def outer_plan():
+        mock_verify.assert_not_called()
+        yield from plan_with_run_key()
+
+    @bpp.set_run_key_decorator(RUN_KEY)
+    @bpp.run_decorator()
+    def plan_with_run_key():
+        mock_verify.assert_called_once()
+        yield from inner_plan()
+
+    def inner_plan():
+        yield from bps.null()
+
+    RE(outer_plan())
+    mock_verify.assert_called_once()
+
+
+@patch("dodal.plans.preprocessors.verify_undulator_gap.verify_undulator_gap")
+def test_verify_undulator_gap_decorator_no_run_key_runs_on_first_run_only(
+    mock_verify: MagicMock,
+    RE: RunEngine,
+    mock_undulator_and_dcm: UndulatorGapCheckDevices,
+):
+    @verify_undulator_gap_before_run_decorator(devices=mock_undulator_and_dcm)
+    @bpp.run_decorator()
+    def outer_plan():
+        mock_verify.assert_called_once()
+        yield from plan_with_run()
+
+    @bpp.set_run_key_decorator(RUN_KEY)
+    @bpp.run_decorator()
+    def plan_with_run():
+        yield from inner_plan()
+
+    def inner_plan():
+        yield from bps.null()
+
+    RE(outer_plan())
+    mock_verify.assert_called_once()

--- a/tests/plans/test_verify_undulator_gap_plan.py
+++ b/tests/plans/test_verify_undulator_gap_plan.py
@@ -1,0 +1,17 @@
+from unittest.mock import AsyncMock, patch
+
+from bluesky.run_engine import RunEngine
+from ophyd_async.testing import set_mock_value
+from tests.plans.conftest import UndulatorGapCheckDevices
+
+from dodal.plans.verify_undulator_gap import verify_undulator_gap
+
+
+@patch("dodal.devices.undulator.Undulator._set_undulator_gap", new_callable=AsyncMock)
+def test_verify_undulator_gap(
+    mock_set: AsyncMock, mock_undulator_and_dcm: UndulatorGapCheckDevices, RE: RunEngine
+):
+    kev_val = 5
+    set_mock_value(mock_undulator_and_dcm.dcm.energy_in_kev.user_readback, kev_val)
+    RE(verify_undulator_gap(mock_undulator_and_dcm))
+    mock_set.assert_called_once_with(kev_val)


### PR DESCRIPTION
Fixes [mx-bluesky 891](https://github.com/DiamondLightSource/mx-bluesky/issues/891)

For now, this plan requires the "common" DCM, but there are a few different implementations of this.  https://github.com/DiamondLightSource/dodal/issues/592 will make this preprocessor more useful.

Also requires a change to mx-bluesky (PR in progress)

### Instructions to reviewer on how to test:
1. Confirm code meets issue requirements
2. Check tests and confirm they pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
