### PR TITLE
(#256) Remove walrus operator from asserts

### DIFF
--- a/src/dodal/devices/oav/snapshots/snapshot_with_grid.py
+++ b/src/dodal/devices/oav/snapshots/snapshot_with_grid.py
@@ -34,9 +34,10 @@ class SnapshotWithGrid(MJPG):
         box_width = await self.box_width.get_value()
         num_boxes_x = await self.num_boxes_x.get_value()
         num_boxes_y = await self.num_boxes_y.get_value()
-
-        assert isinstance(filename_str := await self.filename.get_value(), str)
-        assert isinstance(directory_str := await self.directory.get_value(), str)
+        filename_str = await self.filename.get_value()
+        assert isinstance(filename_str, str)
+        directory_str = await self.directory.get_value()
+        assert isinstance(directory_str, str)
 
         add_grid_border_overlay_to_image(
             image, int(top_left_x), int(top_left_y), box_width, num_boxes_x, num_boxes_y


### PR DESCRIPTION
Fixes #[256](https://github.com/DiamondLightSource/mx-bluesky/issues/256) in MXB

### Instructions to reviewer on how to test:
1. Look for walrus operators in the codebase
2. Check none occur within an assert statement, other than in tests
3. If possible, run tests with the -O flag to see that they now pass (possibly using [dissert](https://github.com/boothby/dissert)).

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
