### PR TITLE
(mx-bluesky#289) Add units to exposure_time parameter name

### DIFF
--- a/src/dodal/devices/detector/detector.py
+++ b/src/dodal/devices/detector/detector.py
@@ -32,7 +32,7 @@ class DetectorParams(BaseModel):
     # Must use model_dump(by_alias=True) if serialising!
 
     expected_energy_ev: float | None = None
-    exposure_time: float
+    exposure_time_s: float
     directory: str  # : Path https://github.com/DiamondLightSource/dodal/issues/774
     prefix: str
     detector_distance: float

--- a/src/dodal/devices/eiger.py
+++ b/src/dodal/devices/eiger.py
@@ -221,11 +221,11 @@ class EigerDetector(Device, Stageable):
     def set_cam_pvs(self) -> AndStatus:
         assert self.detector_params is not None
         status = self.cam.acquire_time.set(
-            self.detector_params.exposure_time,
+            self.detector_params.exposure_time_s,
             timeout=self.timeouts.general_status_timeout,
         )
         status &= self.cam.acquire_period.set(
-            self.detector_params.exposure_time,
+            self.detector_params.exposure_time_s,
             timeout=self.timeouts.general_status_timeout,
         )
         status &= self.cam.num_exposures.set(

--- a/system_tests/test_eiger_system.py
+++ b/system_tests/test_eiger_system.py
@@ -10,7 +10,7 @@ from dodal.devices.eiger import DetectorParams, EigerDetector
 def eiger(tmp_path: Path):
     detector_params: DetectorParams = DetectorParams(
         expected_energy_ev=100,
-        exposure_time=0.1,
+        exposure_time_s=0.1,
         directory=str(tmp_path),
         prefix="file_name",
         detector_distance=100.0,

--- a/tests/devices/unit_tests/detector/test_det_resolution.py
+++ b/tests/devices/unit_tests/detector/test_det_resolution.py
@@ -15,7 +15,7 @@ from dodal.devices.detector.det_resolution import (
 def detector_params(request, tmp_path: Path):
     return DetectorParams(
         expected_energy_ev=100,
-        exposure_time=1.0,
+        exposure_time_s=1.0,
         directory=str(tmp_path),
         prefix="test",
         run_number=0,

--- a/tests/devices/unit_tests/detector/test_detector.py
+++ b/tests/devices/unit_tests/detector/test_detector.py
@@ -11,7 +11,7 @@ from dodal.devices.detector.det_dim_constants import EIGER2_X_16M_SIZE
 def create_det_params_with_dir_and_prefix(directory: str | Path, prefix="test"):
     return DetectorParams(
         expected_energy_ev=100,
-        exposure_time=1.0,
+        exposure_time_s=1.0,
         directory=directory,  # type: ignore
         prefix=prefix,
         detector_distance=1.0,
@@ -52,7 +52,7 @@ def test_correct_det_dist_to_beam_converter_path_passed_in(
 ):
     params = DetectorParams(
         expected_energy_ev=100,
-        exposure_time=1.0,
+        exposure_time_s=1.0,
         directory=str(tmp_path),
         prefix="test",
         run_number=0,
@@ -74,7 +74,7 @@ def test_correct_det_dist_to_beam_converter_path_passed_in(
 def test_run_number_correct_when_not_specified(mocked_parse_table, tmp_path):
     params = DetectorParams(
         expected_energy_ev=100,
-        exposure_time=1.0,
+        exposure_time_s=1.0,
         directory=str(tmp_path),
         prefix="test",
         detector_distance=1.0,
@@ -95,7 +95,7 @@ def test_run_number_correct_when_not_specified(mocked_parse_table, tmp_path):
 def test_run_number_correct_when_specified(mocked_parse_table, tmp_path):
     params = DetectorParams(
         expected_energy_ev=100,
-        exposure_time=1.0,
+        exposure_time_s=1.0,
         directory=str(tmp_path),
         run_number=6,
         prefix="test",
@@ -114,7 +114,7 @@ def test_run_number_correct_when_specified(mocked_parse_table, tmp_path):
 def test_detector_params_is_serialisable(tmp_path):
     params = DetectorParams(
         expected_energy_ev=100,
-        exposure_time=1.0,
+        exposure_time_s=1.0,
         directory=str(tmp_path),
         prefix="test",
         detector_distance=1.0,
@@ -140,7 +140,7 @@ def test_detector_params_deserialisation_unchanged(tmp_path: Path):
     # `directory` parameter can accept either a string or a `Path` object, and it is used to set the
     # `directory` attribute of the `DetectorParams` instance.
     json = f'{{"expected_energy_ev": 100.0, \
-    "exposure_time": 1.0, \
+    "exposure_time_s": 1.0, \
     "directory": "{tmp_path}", \
     "prefix": "test", \
     "detector_distance": 1.0, \

--- a/tests/devices/unit_tests/test_eiger.py
+++ b/tests/devices/unit_tests/test_eiger.py
@@ -39,7 +39,7 @@ class StatusException(Exception):
 def params(tmp_path: Path) -> DetectorParams:
     return DetectorParams(
         expected_energy_ev=TEST_EXPECTED_ENERGY,
-        exposure_time=TEST_EXPOSURE_TIME,
+        exposure_time_s=TEST_EXPOSURE_TIME,
         directory=str(tmp_path),
         prefix=TEST_PREFIX,
         run_number=TEST_RUN_NUMBER,


### PR DESCRIPTION
Fixes [mx-bluesky#289](https://github.com/DiamondLightSource/mx-bluesky/issues/289)

### Instructions to reviewer on how to test:
1. Search repo for `exposure_time` variable
2. Ensure there are no occurrences that aren't renamed to `exposure_time_s`

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
