### PR TITLE
(#1106) Docs page missing example code

### DIFF
--- a/docs/how-to/create-beamline.rst
+++ b/docs/how-to/create-beamline.rst
@@ -24,6 +24,7 @@ The following example creates a fictitious beamline ``w41``, with a simulated tw
 ``s41`` has a simulated clone of the AdAravisDetector, but not of the Synchrotron machine.
 
 .. code-block:: python
+
     from ophyd_async.epics.adaravis import AravisDetector
 
     from dodal.common.beamlines.beamline_utils import (


### PR DESCRIPTION
Fixes #1106 

### Instructions to reviewer on how to test:
1. Build docs and go to 'Creating a new beamline' page in the 'How to' guides.
2. See that the example in the code block is visible.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
