### PR TITLE
Mx bluesky 908 ci check walrus in asserts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,14 +178,15 @@ lint.select = [
     "I",   # isort - https://docs.astral.sh/ruff/rules/#isort-i
     "UP",  # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "SLF", # self - https://docs.astral.sh/ruff/settings/#lintflake8-self
+    "RUF018" # walrus operators in asserts - https://docs.astral.sh/ruff/rules/assignment-in-assert/
 ]
 
 [tool.ruff.lint.per-file-ignores]
 # By default, private member access is allowed in tests
 # See https://github.com/DiamondLightSource/python-copier-template/issues/154
 # Remove this line to forbid private member access in tests
-"tests/**/*" = ["SLF001"]
-"system_tests/**/*" = ["SLF001"]
+"tests/**/*" = ["SLF001", "RUF018"]
+"system_tests/**/*" = ["SLF001", "RUF018"]
 
 [tool.importlinter]
 root_package = "dodal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ lint.select = [
 [tool.ruff.lint.per-file-ignores]
 # By default, private member access is allowed in tests
 # See https://github.com/DiamondLightSource/python-copier-template/issues/154
-# Remove this line to forbid private member access in tests
+# Remove this line to forbid private member access and walrus operators in asserts in tests 
 "tests/**/*" = ["SLF001", "RUF018"]
 "system_tests/**/*" = ["SLF001", "RUF018"]
 


### PR DESCRIPTION
Fixes #[908](https://github.com/DiamondLightSource/mx-bluesky/issues/908) in mx-bluesky.

### Instructions to reviewer on how to test:
1. Add in a walrus operator inside an assert
2. Check ruff shouts at you with `ruff check`
3. Add in a walrus operator inside an assert in /tests or /system_tests
4. Check ruff **doesn't** shout at you.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
