### PR TITLE
(mx-bluesky#894) Add goniometer device

### DIFF
--- a/src/dodal/beamlines/aithre.py
+++ b/src/dodal/beamlines/aithre.py
@@ -1,9 +1,9 @@
 from dodal.common.beamlines.beamline_utils import device_factory
 from dodal.devices.aithre_lasershaping.goniometer import Goniometer
 
-PREFIX = "LA18L-MO-LSR-01:"
+PREFIX = "LA18L"
 
 
 @device_factory()
 def goniometer() -> Goniometer:
-    return Goniometer(PREFIX, "aithre")
+    return Goniometer(f"{PREFIX}-MO-LSR-01:", "goniometer")

--- a/src/dodal/beamlines/aithre.py
+++ b/src/dodal/beamlines/aithre.py
@@ -1,0 +1,9 @@
+from dodal.common.beamlines.beamline_utils import device_factory
+from dodal.devices.aithre_lasershaping.goniometer import Goniometer
+
+PREFIX = "LA18L-MO-LSR-01:"
+
+
+@device_factory()
+def goniometer() -> Goniometer:
+    return Goniometer(PREFIX, "aithre")

--- a/src/dodal/devices/aithre_lasershaping/goniometer.py
+++ b/src/dodal/devices/aithre_lasershaping/goniometer.py
@@ -1,10 +1,10 @@
 from ophyd_async.core import StandardReadable
 from ophyd_async.epics.motor import Motor
 
-"""Goniometer and the stages it sits on"""
-
 
 class Goniometer(StandardReadable):
+    """Goniometer and the stages it sits on"""
+
     def __init__(self, prefix: str, name: str = "") -> None:
         self.x = Motor(prefix + "X")
         self.y = Motor(prefix + "Y")

--- a/src/dodal/devices/aithre_lasershaping/goniometer.py
+++ b/src/dodal/devices/aithre_lasershaping/goniometer.py
@@ -1,0 +1,15 @@
+from ophyd_async.core import StandardReadable
+from ophyd_async.epics.motor import Motor
+
+"""Goniometer and the stages it sits on"""
+
+
+class Goniometer(StandardReadable):
+    def __init__(self, prefix: str, name: str = "") -> None:
+        self.x = Motor(prefix + "X")
+        self.y = Motor(prefix + "Y")
+        self.z = Motor(prefix + "Z")
+        self.sampy = Motor(prefix + "SAMPY")
+        self.sampz = Motor(prefix + "SAMPZ")
+        self.omega = Motor(prefix + "OMEGA")
+        super().__init__(name)


### PR DESCRIPTION
Fixes [mx-bluesky#894](https://github.com/DiamondLightSource/mx-bluesky/issues/894)

### Instructions to reviewer on how to test:
1. On lab PC (ws581) run `dodal connect aithre`
2. Check that the connection is made

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
