### PR TITLE
Add XYZ positioner as sample stage to ViSR

### DIFF
--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -10,6 +10,7 @@ from dodal.common.beamlines.beamline_utils import (
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import CAM_SUFFIX, HDF5_SUFFIX
+from dodal.devices.motors import XYZPositioner
 from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.synchrotron import Synchrotron
 from dodal.log import set_beamline as set_log_beamline
@@ -48,7 +49,7 @@ def panda() -> HDFPanda:
 
 
 @device_factory()
-def synchrotron() -> Synchrotron:
+def synchrotron_test() -> Synchrotron:
     return Synchrotron()
 
 
@@ -60,3 +61,12 @@ def manta() -> AravisDetector:
         drv_suffix=CAM_SUFFIX,
         fileio_suffix=HDF5_SUFFIX,
     )
+
+
+@device_factory()
+def stage_positioner() -> XYZPositioner:
+    return XYZPositioner(
+        f"{PREFIX.beamline_prefix}-MO-PPMAC-01:",
+        path_provider=get_path_provider(),
+    )
+

--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -10,8 +10,8 @@ from dodal.common.beamlines.beamline_utils import (
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import CAM_SUFFIX, HDF5_SUFFIX
-from dodal.devices.motors import XYZPositioner
 from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
+from dodal.devices.motors import XYZPositioner
 from dodal.devices.synchrotron import Synchrotron
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import BeamlinePrefix
@@ -68,4 +68,3 @@ def sample_stage() -> XYZPositioner:
     return XYZPositioner(
         f"{PREFIX.beamline_prefix}-MO-PPMAC-01:",
     )
-

--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -49,7 +49,7 @@ def panda() -> HDFPanda:
 
 
 @device_factory()
-def synchrotron_test() -> Synchrotron:
+def synchrotron() -> Synchrotron:
     return Synchrotron()
 
 
@@ -67,6 +67,5 @@ def manta() -> AravisDetector:
 def stage_positioner() -> XYZPositioner:
     return XYZPositioner(
         f"{PREFIX.beamline_prefix}-MO-PPMAC-01:",
-        path_provider=get_path_provider(),
     )
 

--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -64,7 +64,7 @@ def manta() -> AravisDetector:
 
 
 @device_factory()
-def stage_positioner() -> XYZPositioner:
+def sample_stage() -> XYZPositioner:
     return XYZPositioner(
         f"{PREFIX.beamline_prefix}-MO-PPMAC-01:",
     )


### PR DESCRIPTION
Fixes #ISSUE

### Instructions to reviewer on how to test:
1. Run Dodal connect b01_1
2. Confirm all 4 devices: panda, synchrotron, manta, and sample_stage connect

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
