### PR TITLE
Add HDF suffix and use it in simulated detector

### DIFF
--- a/src/dodal/beamlines/adsim.py
+++ b/src/dodal/beamlines/adsim.py
@@ -8,7 +8,7 @@ from dodal.common.beamlines.beamline_utils import (
     set_path_provider,
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.beamlines.device_helpers import DET_SUFFIX, HDF5_SUFFIX
+from dodal.common.beamlines.device_helpers import DET_SUFFIX, HDF_SUFFIX
 from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.adsim import SimStage
 from dodal.log import set_beamline as set_log_beamline
@@ -72,5 +72,5 @@ def det() -> SimDetector:
         f"{PREFIX.beamline_prefix}-DI-CAM-01:",
         path_provider=get_path_provider(),
         drv_suffix=DET_SUFFIX,
-        fileio_suffix=HDF5_SUFFIX,
+        fileio_suffix=HDF_SUFFIX,
     )

--- a/src/dodal/common/beamlines/device_helpers.py
+++ b/src/dodal/common/beamlines/device_helpers.py
@@ -3,6 +3,7 @@ from dodal.devices.slits import Slits
 from dodal.utils import skip_device
 
 HDF5_SUFFIX = "HDF5:"
+HDF_SUFFIX = "HDF:"
 CAM_SUFFIX = "CAM:"
 DET_SUFFIX = "DET:"
 


### PR DESCRIPTION
Fixes #1136 

### Instructions to reviewer on how to test:
1. Set up simulated beamline according to https://epics-containers.github.io/main/tutorials/launch_example.html
2. Confirm that adsim detector is connected to all PVs.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
