### PR TITLE
Pin ophyd-async to 0.9.0 until compatibility issues are fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async >= 0.9.0a2",
+    # Pinned due to https://github.com/DiamondLightSource/dodal/issues/1141
+    "ophyd-async == 0.9.0",
     "bluesky",
     "pyepics",
     "dataclasses-json",


### PR DESCRIPTION
Temporarily pin ophyd-async until issues with new ophyd-async in #1141 are fixed


