### PR TITLE
Mx bluesky 136 get murko results

### DIFF
--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -353,7 +353,7 @@ def oav_to_redis_forwarder() -> OAVToRedisForwarder:
         name="oav_to_redis_forwarder",
         redis_host=REDIS_HOST,
         redis_password=REDIS_PASSWORD,
-        redis_db=7,
+        db=7,
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -17,6 +17,7 @@ from dodal.devices.diamond_filter import DiamondFilter, I04Filters
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import ZebraFastGridScan
 from dodal.devices.flux import Flux
+from dodal.devices.i04.murko_results import MurkoResultsDevice
 from dodal.devices.i04.transfocator import Transfocator
 from dodal.devices.ipin import IPin
 from dodal.devices.motors import XYZPositioner
@@ -349,6 +350,20 @@ def oav_to_redis_forwarder() -> OAVToRedisForwarder:
     """
     return OAVToRedisForwarder(
         f"{PREFIX.beamline_prefix}-DI-OAV-01:",
+        name="oav_to_redis_forwarder",
+        redis_host=REDIS_HOST,
+        redis_password=REDIS_PASSWORD,
+        redis_db=7,
+    )
+
+
+@device_factory()
+def murko_results() -> MurkoResultsDevice:
+    """Get the i04 OAV to redis forwarder, instantiate it if it hasn't already been.
+    If this is called when already instantiated in i04, it will return the existing object.
+    """
+    return MurkoResultsDevice(
+        "",
         name="oav_to_redis_forwarder",
         redis_host=REDIS_HOST,
         redis_password=REDIS_PASSWORD,

--- a/src/dodal/devices/i04/murko_results.py
+++ b/src/dodal/devices/i04/murko_results.py
@@ -103,8 +103,6 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
         omega: float,
         search_angle: float,
     ) -> np.ndarray | None:
-        print(omega)
-        print(search_angle)
         LOGGER.info(f"Compare {omega}, {search_angle}, {self._last_omega}")
         if (  # if last omega is closest
             abs(omega - search_angle) >= abs(self._last_omega - search_angle)

--- a/src/dodal/devices/i04/murko_results.py
+++ b/src/dodal/devices/i04/murko_results.py
@@ -35,10 +35,11 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
 
     def __init__(
         self,
+        prefix="",
         redis_host=REDIS_HOST,
         redis_password=REDIS_PASSWORD,
         db=MURKO_REDIS_DB,
-        redis_channel="murko",
+        name="",
     ):
         self.redis_client = StrictRedis(
             host=redis_host,
@@ -58,6 +59,7 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
             self.x_um, self._x_um_setter = soft_signal_r_and_setter(float | None)
             self.y_um, self._y_um_setter = soft_signal_r_and_setter(float | None)
             self.z_um, self._z_um_setter = soft_signal_r_and_setter(float | None)
+        super().__init__(name=name)
 
     @AsyncStatus.wrap
     async def stage(self):
@@ -66,7 +68,6 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
         self._x_um_setter(None)
         self._y_um_setter(None)
         self._z_um_setter(None)
-        self.found_90 = False
 
     @AsyncStatus.wrap
     async def unstage(self):

--- a/src/dodal/devices/i04/murko_results.py
+++ b/src/dodal/devices/i04/murko_results.py
@@ -1,0 +1,131 @@
+import json
+import pickle
+from typing import TypedDict
+
+from bluesky.protocols import Stageable, Triggerable
+from ophyd_async.core import (
+    AsyncStatus,
+    StandardReadable,
+    soft_signal_r_and_setter,
+    soft_signal_rw,
+)
+from redis import StrictRedis
+
+from dodal.beamlines.i04 import MURKO_REDIS_DB, REDIS_HOST, REDIS_PASSWORD
+from dodal.devices.oav.oav_calculations import camera_coordinates_to_xyz
+from dodal.log import LOGGER
+
+MurkoResult = dict
+FullMurkoResults = dict[str, list[MurkoResult]]
+
+
+class MurkoMetadata(TypedDict):
+    zoom_percentage: float
+    microns_per_x_pixel: float
+    microns_per_y_pixel: float
+    beam_centre_i: float
+    beam_centre_j: float
+    sample_id: str
+    omega_angle: float
+    uuid: str
+
+
+class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
+    TIMEOUT_S = 2
+
+    def __init__(
+        self,
+        redis_host=REDIS_HOST,
+        redis_password=REDIS_PASSWORD,
+        db=MURKO_REDIS_DB,
+        redis_channel="murko",
+    ):
+        self.redis_client = StrictRedis(
+            host=redis_host,
+            password=redis_password,
+            db=db,
+        )
+        self.pubsub = self.redis_client.pubsub()
+        self._last_omega = 0
+        self.sample_id = soft_signal_rw(str)  # Should get from redis
+        self.found_90 = False
+        self.current_x_y_z_um = soft_signal_rw(
+            tuple[float, float, float]
+        )  # Should get from redis
+
+        with self.add_children_as_readables():
+            # Diffs from current x/y/z
+            self.x_um, self._x_um_setter = soft_signal_r_and_setter(float | None)
+            self.y_um, self._y_um_setter = soft_signal_r_and_setter(float | None)
+            self.z_um, self._z_um_setter = soft_signal_r_and_setter(float | None)
+
+    @AsyncStatus.wrap
+    async def stage(self):
+        # Subscribe to redis pub/
+        self.pubsub.subscribe("murko-results")
+        self._x_um_setter(None)
+        self._y_um_setter(None)
+        self._z_um_setter(None)
+        self.found_90 = False
+
+    @AsyncStatus.wrap
+    async def unstage(self):
+        # Unsubscribe
+        self.pubsub.unsubscribe()
+
+    def get_coords_if_at_angle(
+        self,
+        metadata: MurkoMetadata,
+        result: MurkoResult,
+        omega: float,
+        search_angle: float,
+    ):
+        if abs(omega - search_angle) > abs(self._last_omega - search_angle):
+            coords = result["most_likely_click"]
+            shape = result["original_image_shape"]
+            centre_px = (coords[1] * shape[1], coords[0] * shape[0])
+            LOGGER.info(
+                f"Using image taken at {omega}, which found xtal at {centre_px}"
+            )
+
+            return camera_coordinates_to_xyz(
+                centre_px[0],
+                centre_px[1],
+                omega,
+                metadata["microns_per_x_pixel"],
+                metadata["microns_per_y_pixel"],
+            )
+        return None
+
+    @AsyncStatus.wrap
+    async def trigger(self):
+        # May be better as kickoff/complete?
+        # Wait for results
+        sample_id = self.sample_id.get_value()
+        while not self.z_um.get_value():
+            message = self.pubsub.get_message(timeout=self.TIMEOUT_S)
+            results = pickle.loads(message)
+            assert isinstance(results, FullMurkoResults)
+            # Get metadata
+            for uuid, result in results:
+                metadata_str = self.redis_client.hget(
+                    f"murko:{sample_id}:metadata", uuid
+                )
+                LOGGER.info(f"Got result {uuid}, {metadata_str}, {result}")
+                metadata = MurkoMetadata(json.loads(metadata_str))
+                omega_angle = metadata["omega_angle"]
+                if not self.y_um.get_value():
+                    # Find closest to 90
+                    if movement := self.get_coords_if_at_angle(
+                        metadata, result, omega_angle, 90
+                    ):
+                        self._x_um_setter(movement[0])
+                        self._y_um_setter(movement[1])
+                else:
+                    if movement := self.get_coords_if_at_angle(
+                        metadata, result, omega_angle, 180
+                    ):
+                        self._x_um_setter(movement[0])
+                        self._z_um_setter(movement[2])
+
+                self._last_omega = omega_angle

--- a/src/dodal/devices/i04/murko_results.py
+++ b/src/dodal/devices/i04/murko_results.py
@@ -1,7 +1,10 @@
 import json
 import pickle
+from collections import OrderedDict
+from enum import Enum
 from typing import TypedDict
 
+import numpy as np
 from bluesky.protocols import Stageable, Triggerable
 from ophyd_async.core import (
     AsyncStatus,
@@ -9,10 +12,13 @@ from ophyd_async.core import (
     soft_signal_r_and_setter,
     soft_signal_rw,
 )
-from redis import StrictRedis
+from redis.asynio import StrictRedis
 
 from dodal.beamlines.i04 import MURKO_REDIS_DB, REDIS_HOST, REDIS_PASSWORD
-from dodal.devices.oav.oav_calculations import camera_coordinates_to_xyz
+from dodal.devices.oav.oav_calculations import (
+    calculate_beam_distance,
+    camera_coordinates_to_xyz,
+)
 from dodal.log import LOGGER
 
 MurkoResult = dict
@@ -28,6 +34,12 @@ class MurkoMetadata(TypedDict):
     sample_id: str
     omega_angle: float
     uuid: str
+
+
+class Coord(Enum):
+    x = 0
+    y = 1
+    z = 2
 
 
 class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
@@ -49,22 +61,26 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
         self.pubsub = self.redis_client.pubsub()
         self._last_omega = 0
         self.sample_id = soft_signal_rw(str)  # Should get from redis
-        self.found_90 = False
+        self.coords = {"x": {}, "y": {}, "z": {}}
+        self.search_angles = OrderedDict(
+            [(90, ("x", "z")), (180, ("x", "y")), (270, ())]
+        )
+        self.angles_to_search = list(self.search_angles.keys())
         self.current_x_y_z_um = soft_signal_rw(
             tuple[float, float, float]
         )  # Should get from redis
 
         with self.add_children_as_readables():
             # Diffs from current x/y/z
-            self.x_um, self._x_um_setter = soft_signal_r_and_setter(float | None)
-            self.y_um, self._y_um_setter = soft_signal_r_and_setter(float | None)
-            self.z_um, self._z_um_setter = soft_signal_r_and_setter(float | None)
+            self.x_um, self._x_um_setter = soft_signal_r_and_setter(float)
+            self.y_um, self._y_um_setter = soft_signal_r_and_setter(float)
+            self.z_um, self._z_um_setter = soft_signal_r_and_setter(float)
         super().__init__(name=name)
 
     @AsyncStatus.wrap
     async def stage(self):
         # Subscribe to redis pub/
-        self.pubsub.subscribe("murko-results")
+        await self.pubsub.subscribe("murko-results")
         self._x_um_setter(None)
         self._y_um_setter(None)
         self._z_um_setter(None)
@@ -72,7 +88,7 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
     @AsyncStatus.wrap
     async def unstage(self):
         # Unsubscribe
-        self.pubsub.unsubscribe()
+        await self.pubsub.unsubscribe()
 
     def get_coords_if_at_angle(
         self,
@@ -80,18 +96,27 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
         result: MurkoResult,
         omega: float,
         search_angle: float,
-    ):
+    ) -> np.ndarray | None:
+        LOGGER.info(f"Compare {omega}, {search_angle}, {self._last_omega}")
         if abs(omega - search_angle) > abs(self._last_omega - search_angle):
-            coords = result["most_likely_click"]
-            shape = result["original_image_shape"]
+            coords = result[
+                "most_likely_click"
+            ]  # As proportion from top, left of image
+            shape = result["original_shape"]  # Dimensions of image in pixels
             centre_px = (coords[1] * shape[1], coords[0] * shape[0])
             LOGGER.info(
                 f"Using image taken at {omega}, which found xtal at {centre_px}"
             )
 
-            return camera_coordinates_to_xyz(
+            beam_dist_px = calculate_beam_distance(
+                (442, 363),
                 centre_px[0],
-                centre_px[1],
+                centre_px[1],  # Not sure where this number comes from
+            )
+
+            return camera_coordinates_to_xyz(
+                beam_dist_px[0],
+                beam_dist_px[1],
                 omega,
                 metadata["microns_per_x_pixel"],
                 metadata["microns_per_y_pixel"],
@@ -102,31 +127,48 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
     async def trigger(self):
         # May be better as kickoff/complete?
         # Wait for results
-        sample_id = self.sample_id.get_value()
-        while not self.z_um.get_value():
-            message = self.pubsub.get_message(timeout=self.TIMEOUT_S)
-            results = pickle.loads(message)
-            assert isinstance(results, FullMurkoResults)
-            # Get metadata
-            for uuid, result in results:
-                metadata_str = self.redis_client.hget(
-                    f"murko:{sample_id}:metadata", uuid
-                )
-                LOGGER.info(f"Got result {uuid}, {metadata_str}, {result}")
-                metadata = MurkoMetadata(json.loads(metadata_str))
-                omega_angle = metadata["omega_angle"]
-                if not self.y_um.get_value():
-                    # Find closest to 90
-                    if movement := self.get_coords_if_at_angle(
-                        metadata, result, omega_angle, 90
-                    ):
-                        self._x_um_setter(movement[0])
-                        self._y_um_setter(movement[1])
-                else:
-                    if movement := self.get_coords_if_at_angle(
-                        metadata, result, omega_angle, 180
-                    ):
-                        self._x_um_setter(movement[0])
-                        self._z_um_setter(movement[2])
+        sample_id = await self.sample_id.get_value()
+        next_angle = self.angles_to_search.pop(0)
+        while next_angle:  # Goes round in a loop until 270 degrees is found
+            message = await self.pubsub.get_message(timeout=self.TIMEOUT_S)
+            if message and message["type"] == "message":
+                batch_results = pickle.loads(
+                    message["data"]
+                )  # waits here for next batch to be recieved (10 scans?). pickle deserialises results
+                for results in batch_results:
+                    print(f"Got {results} from redis")
+                    assert isinstance(results, dict)
+                    for uuid, result in results.items():
+                        metadata_str = await self.redis_client.hget(
+                            f"murko:{sample_id}:metadata", uuid
+                        )
+                        if metadata_str:
+                            next_angle = self.process_result(
+                                result, uuid, metadata_str, next_angle
+                            )
+        self._x_um_setter(np.mean(self.coords["x"].values()))
+        self._y_um_setter(np.mean(self.coords["y"].values()))
+        self._z_um_setter(np.mean(self.coords["z"].values()))
 
-                self._last_omega = omega_angle
+    def process_result(self, result: dict, uuid, metadata_str, angle):
+        metadata = MurkoMetadata(
+            json.loads(metadata_str)
+        )  # Metadata is JSON but data is pickle?
+        omega_angle = metadata["omega_angle"]
+        LOGGER.info(f"Got angle {omega_angle}")
+        # Find closest to next search angle
+        if (
+            movement := self.get_coords_if_at_angle(
+                metadata, result, omega_angle, angle
+            )
+        ) is not None:
+            LOGGER.info(f"Using result {uuid}, {metadata_str}, {result}")
+            for coord in self.search_angles[angle]:
+                self.coords[coord][omega_angle] = movement[Coord[coord].value]
+            if self.angles_to_search:
+                angle = self.angles_to_search.pop(0)
+            else:
+                angle = None
+            LOGGER.info(f"Setting {angle} to {movement}")
+        self._last_omega = omega_angle
+        return angle

--- a/src/dodal/devices/oav/oav_calculations.py
+++ b/src/dodal/devices/oav/oav_calculations.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def camera_coordinates_to_xyz(
+def camera_coordinates_to_xyz_mm(
     horizontal: float,
     vertical: float,
     omega: float,

--- a/src/dodal/devices/oav/utils.py
+++ b/src/dodal/devices/oav/utils.py
@@ -7,7 +7,7 @@ from bluesky.utils import Msg
 
 from dodal.devices.oav.oav_calculations import (
     calculate_beam_distance,
-    camera_coordinates_to_xyz,
+    camera_coordinates_to_xyz_mm,
 )
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
@@ -90,7 +90,7 @@ def calculate_x_y_z_of_pixel(
     """Get the x, y, z position of a pixel in mm"""
     beam_distance_px: Pixel = calculate_beam_distance(beam_centre, *pixel)
 
-    return current_x_y_z + camera_coordinates_to_xyz(
+    return current_x_y_z + camera_coordinates_to_xyz_mm(
         beam_distance_px[0],
         beam_distance_px[1],
         current_omega,

--- a/tests/devices/i04/test_murko_results.py
+++ b/tests/devices/i04/test_murko_results.py
@@ -4,12 +4,14 @@ import pickle
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 from ophyd_async.core import (
     init_devices,
     wait_for_value,
 )
 from ophyd_async.testing import set_mock_value
+from pytest import approx
 
 from dodal.devices.i04.murko_results import MurkoResultsDevice
 
@@ -29,10 +31,18 @@ async def fake_setters(
     mock_x_setter = MagicMock()
     mock_y_setter = MagicMock()
     mock_z_setter = MagicMock()
-    fake_murko_results._x_um_setter = mock_x_setter
-    fake_murko_results._y_um_setter = mock_y_setter
-    fake_murko_results._z_um_setter = mock_z_setter
+    fake_murko_results._x_mm_setter = mock_x_setter
+    fake_murko_results._y_mm_setter = mock_y_setter
+    fake_murko_results._z_mm_setter = mock_z_setter
     return mock_x_setter, mock_y_setter, mock_z_setter
+
+
+def abs_cos(degrees):
+    return abs(np.cos(np.radians(degrees)))
+
+
+def abs_sin(degrees):
+    return abs(np.sin(np.radians(degrees)))
 
 
 def pickled_messages(messages) -> list:
@@ -50,7 +60,8 @@ def get_messages(
     start_y: float = 0.5,
     step_x: float = 0,
     step_y: float = 0,
-    shape: tuple[int, int] = (100, 100),
+    shape_x: int = 100,
+    shape_y: int = 100,
 ) -> list:
     messages = []
     uuid = 0
@@ -61,10 +72,10 @@ def get_messages(
             for _ in range(images_per_message):
                 data_point[uuid] = {
                     "most_likely_click": (
+                        start_y + step_y * uuid,  # Murko returns coords as y, x
                         start_x + step_x * uuid,
-                        start_y + step_y * uuid,
                     ),
-                    "original_shape": shape,
+                    "original_shape": (shape_y, shape_x),  # (y, x) to match Murko
                 }
                 uuid += 1
             data.append(data_point)
@@ -82,34 +93,6 @@ def json_metadata(n, start=90, step=1, microns_pxp=10, microns_pyp=10) -> dict:
         }
         metadatas[i] = json.dumps(metadata)
     return metadatas
-
-
-# @patch("dodal.devices.i04.murko_results.StrictRedis")
-# async def test_complete_calls_get_message_and_hget(
-#     fake_strict_redis,
-#     fake_murko_results,
-# ):
-#     messages = iter(pickled_messages(get_messages()))
-#     metadata = iter(json_metadata(2, start=90, step=90))
-#     with (
-#         patch.object(
-#             fake_strict_redis.pubsub,
-#             "get_message",
-#             new_callable=AsyncMock,
-#             side_effect=lambda *args, **kwargs: next(messages),
-#         ) as mock_get_message,
-#         patch.object(
-#             fake_strict_redis,
-#             "hget",
-#             new_callable=AsyncMock,
-#             side_effect=lambda *args, **kwargs: next(metadata),
-#         ) as mock_hget,
-#     ):
-#         fake_murko_results.pubsub.get_message = mock_get_message
-#         fake_murko_results.redis_client.hget = mock_hget
-#         await fake_murko_results.trigger()
-#         assert fake_murko_results.pubsub.get_message.call_count == 6
-#     assert fake_murko_results.redis_client.hget.call_count == 100
 
 
 @patch("dodal.devices.i04.murko_results.StrictRedis")
@@ -130,7 +113,7 @@ async def test_no_movement_given_sample_centre_matches_beam_centre(
             fake_strict_redis,
             "hget",
             new_callable=AsyncMock,
-            side_effect=lambda blah, uuid: metadata[uuid],
+            side_effect=lambda _, uuid: metadata[uuid],
         ) as mock_hget,
         patch.object(
             fake_murko_results,
@@ -165,7 +148,7 @@ async def test_given_correct_movement_given_90_and_180_angles(  # Need a better 
             fake_strict_redis,
             "hget",
             new_callable=AsyncMock,
-            side_effect=lambda blah, uuid: metadata[uuid],
+            side_effect=lambda _, uuid: metadata[uuid],
         ) as mock_hget,
         patch.object(
             fake_murko_results,
@@ -177,21 +160,23 @@ async def test_given_correct_movement_given_90_and_180_angles(  # Need a better 
         fake_murko_results.redis_client.hget = mock_hget
         fake_murko_results.get_beam_centre = mock_get_beam_centre
         await fake_murko_results.trigger()
-    # (sample_centre_x * shape[0] - beam_centre_x) / microns_pxp -> (0.5 * 100 - 75) / 10
+    # (sample_centre_x * shape[1] - beam_centre_x) * microns_pxp / 1000 -> (0.5 * 100 - 75) / 100
     assert mock_x_setter.call_args[0][0] == -0.25
-    # (sample_centre_y * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
+    # (sample_centre_y * shape[0] - beam_centre_y) * microns_pyp / 1000 -> (0.5 * 100 - 70) / 100
     assert mock_y_setter.call_args[0][0] == 0.2
-    # (sample_centre_z * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
+    # (sample_centre_z * shape[0] - beam_centre_y) * microns_pyp / 1000 -> (0.5 * 100 - 70) / 100
     assert mock_z_setter.call_args[0][0] == 0.2
 
 
 @patch("dodal.devices.i04.murko_results.StrictRedis")
-async def test_given_correct_movement_given_30_and_210_angles(  # Need a better name
+async def test_correct_movement_given_90_180_degrees(
     fake_strict_redis, fake_murko_results, fake_setters
 ):
     mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
-    messages = iter(pickled_messages(get_messages()))  # 2 messages, both (0.5, 0.5)
-    metadata = json_metadata(2, start=30, step=190)  # at exactly 90, 180 degrees
+    messages = iter(
+        pickled_messages(get_messages(start_y=0.6, step_y=0.1))
+    )  # 2 messages, (0.6, 0.5) and (0.7, 0.5) - (z, x), (y, x)
+    metadata = json_metadata(2, start=90, step=90)  # at 90, 180 degrees
     with (
         patch.object(
             fake_strict_redis.pubsub,
@@ -203,7 +188,42 @@ async def test_given_correct_movement_given_30_and_210_angles(  # Need a better 
             fake_strict_redis,
             "hget",
             new_callable=AsyncMock,
-            side_effect=lambda blah, uuid: metadata[uuid],
+            side_effect=lambda _, uuid: metadata[uuid],
+        ) as mock_hget,
+        patch.object(
+            fake_murko_results,
+            "get_beam_centre",
+            side_effect=lambda *args, **kwargs: (90, 40),  # 0.9, 0.4 of (100, 100)
+        ) as mock_get_beam_centre,
+    ):
+        fake_murko_results.pubsub.get_message = mock_get_message
+        fake_murko_results.redis_client.hget = mock_hget
+        fake_murko_results.get_beam_centre = mock_get_beam_centre
+        await fake_murko_results.trigger()
+    assert mock_x_setter.call_args[0][0] == -0.4  # - (0.9 - 0.5)
+    assert mock_y_setter.call_args[0][0] == -0.3  # 0.4 - 0.7
+    assert mock_z_setter.call_args[0][0] == -0.2  # 0.4 - 0.6
+
+
+@patch("dodal.devices.i04.murko_results.StrictRedis")
+async def test_correct_movement_given_45_and_135_angles(  # Need a better name
+    fake_strict_redis, fake_murko_results, fake_setters
+):
+    mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
+    messages = iter(pickled_messages(get_messages()))  # 2 messages, both (0.5, 0.5)
+    metadata = json_metadata(2, start=45, step=90)  # at 45, 135 degrees
+    with (
+        patch.object(
+            fake_strict_redis.pubsub,
+            "get_message",
+            new_callable=AsyncMock,
+            side_effect=lambda *args, **kwargs: next(messages),
+        ) as mock_get_message,
+        patch.object(
+            fake_strict_redis,
+            "hget",
+            new_callable=AsyncMock,
+            side_effect=lambda _, uuid: metadata[uuid],
         ) as mock_hget,
         patch.object(
             fake_murko_results,
@@ -215,22 +235,84 @@ async def test_given_correct_movement_given_30_and_210_angles(  # Need a better 
         fake_murko_results.redis_client.hget = mock_hget
         fake_murko_results.get_beam_centre = mock_get_beam_centre
         await fake_murko_results.trigger()
-    # (sample_centre_x * shape[0] - beam_centre_x) / microns_pxp -> (0.5 * 100 - 75) / 10
     assert mock_x_setter.call_args[0][0] == -0.25
+    expected_y = 0.2 * abs_cos(135)
+    assert mock_y_setter.call_args[0][0] == approx(expected_y)
+    expected_z = 0.2 * abs_sin(45)
+    assert mock_z_setter.call_args[0][0] == approx(expected_z)
+
+
+@patch("dodal.devices.i04.murko_results.StrictRedis")
+async def test_correct_movement_given_30_and_120_angles(  # Need a better name
+    fake_strict_redis, fake_murko_results, fake_setters
+):
+    mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
+    messages = iter(pickled_messages(get_messages()))  # 2 messages, both (0.5, 0.5)
+    metadata = json_metadata(2, start=30, step=90)  # at 30, 120 degrees
+    with (
+        patch.object(
+            fake_strict_redis.pubsub,
+            "get_message",
+            new_callable=AsyncMock,
+            side_effect=lambda *args, **kwargs: next(messages),
+        ) as mock_get_message,
+        patch.object(
+            fake_strict_redis,
+            "hget",
+            new_callable=AsyncMock,
+            side_effect=lambda _, uuid: metadata[uuid],
+        ) as mock_hget,
+        patch.object(
+            fake_murko_results,
+            "get_beam_centre",
+            side_effect=lambda *args, **kwargs: (75, 70),
+        ) as mock_get_beam_centre,
+    ):
+        fake_murko_results.pubsub.get_message = mock_get_message
+        fake_murko_results.redis_client.hget = mock_hget
+        fake_murko_results.get_beam_centre = mock_get_beam_centre
+        await fake_murko_results.trigger()
+    assert mock_x_setter.call_args[0][0] == -0.25, "x value incorrect"
     # (sample_centre_y * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
-    assert mock_y_setter.call_args[0][0] == 0.2
+    expected_y = 0.2 * abs_cos(120)
+    assert mock_y_setter.call_args[0][0] == approx(expected_y), "y value incorrect"
     # (sample_centre_z * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
-    assert mock_z_setter.call_args[0][0] == 0.2
+    expected_z = 0.2 * abs_cos(30)
+    assert mock_z_setter.call_args[0][0] == approx(expected_z), "z value incorrect"
 
 
-# async def test_complete_ends_once_last_search_angle_is_found(fake_murko_results):
-#     fake_murko_results.angles_to_search = fake_murko_results.angles_to_search[:-1]
-#     await fake_murko_results.trigger()
-#     assert fake_murko_results.pubsub.get_message.call_count == 4
-#     assert fake_murko_results.redis_client.hget.call_count == 80
-
-
-# async def test_complete_xyz_set_value(fake_murko_results, fake_setters):
-#     mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
-#     await fake_murko_results.trigger()
-#     assert mock_x_setter.call_args[0][0] == 10
+@patch("dodal.devices.i04.murko_results.StrictRedis")
+async def test_complete_calls_get_message_and_hget(
+    fake_strict_redis,
+    fake_murko_results,
+):
+    messages = iter(
+        pickled_messages(
+            get_messages(
+                batches=4,
+                messages_per_batch=3,
+                images_per_message=2,
+            )
+        )
+    )
+    metadata = json_metadata(24, start=80, step=5)  # 24 scans 5° apart
+    with (
+        patch.object(
+            fake_strict_redis.pubsub,
+            "get_message",
+            new_callable=AsyncMock,
+            side_effect=lambda *args, **kwargs: next(messages),
+        ) as mock_get_message,
+        patch.object(
+            fake_strict_redis,
+            "hget",
+            new_callable=AsyncMock,
+            side_effect=lambda _, uuid: metadata[uuid],
+        ) as mock_hget,
+    ):
+        fake_murko_results.pubsub.get_message = mock_get_message
+        fake_murko_results.redis_client.hget = mock_hget
+        await fake_murko_results.trigger()
+    assert fake_murko_results.pubsub.get_message.call_count == 5
+    # last batch is run twice, 4 * 6 + 6
+    assert fake_murko_results.redis_client.hget.call_count == 30

--- a/tests/devices/i04/test_murko_results.py
+++ b/tests/devices/i04/test_murko_results.py
@@ -1,0 +1,236 @@
+import asyncio
+import json
+import pickle
+from typing import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from ophyd_async.core import (
+    init_devices,
+    wait_for_value,
+)
+from ophyd_async.testing import set_mock_value
+
+from dodal.devices.i04.murko_results import MurkoResultsDevice
+
+
+@pytest.fixture
+# @patch("dodal.devices.i04.murko_results.soft_signal_rw")
+@patch("dodal.devices.i04.murko_results.StrictRedis")
+async def fake_murko_results(fake_strict_redis) -> MurkoResultsDevice:
+    murko_results = MurkoResultsDevice(prefix="", name="murko_results")
+    return murko_results
+
+
+@pytest.fixture
+async def fake_setters(
+    fake_murko_results: MurkoResultsDevice,
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    mock_x_setter = MagicMock()
+    mock_y_setter = MagicMock()
+    mock_z_setter = MagicMock()
+    fake_murko_results._x_um_setter = mock_x_setter
+    fake_murko_results._y_um_setter = mock_y_setter
+    fake_murko_results._z_um_setter = mock_z_setter
+    return mock_x_setter, mock_y_setter, mock_z_setter
+
+
+def pickled_messages(messages) -> list:
+    for message in messages:
+        message["data"] = pickle.dumps(message["data"])
+    messages.append(None)
+    return messages
+
+
+def get_messages(
+    batches: int = 2,
+    messages_per_batch: int = 1,
+    images_per_message: int = 1,
+    start_x: float = 0.5,
+    start_y: float = 0.5,
+    step_x: float = 0,
+    step_y: float = 0,
+    shape: tuple[int, int] = (100, 100),
+) -> list:
+    messages = []
+    uuid = 0
+    for _ in range(batches):
+        data = []
+        for _ in range(messages_per_batch):
+            data_point = {}
+            for _ in range(images_per_message):
+                data_point[uuid] = {
+                    "most_likely_click": (
+                        start_x + step_x * uuid,
+                        start_y + step_y * uuid,
+                    ),
+                    "original_shape": shape,
+                }
+                uuid += 1
+            data.append(data_point)
+        messages.append({"type": "message", "data": data})
+    return messages
+
+
+def json_metadata(n, start=90, step=1, microns_pxp=10, microns_pyp=10) -> dict:
+    metadatas = {}
+    for i in range(n):
+        metadata = {
+            "omega_angle": start + step * i,
+            "microns_per_x_pixel": microns_pxp,
+            "microns_per_y_pixel": microns_pyp,
+        }
+        metadatas[i] = json.dumps(metadata)
+    return metadatas
+
+
+# @patch("dodal.devices.i04.murko_results.StrictRedis")
+# async def test_complete_calls_get_message_and_hget(
+#     fake_strict_redis,
+#     fake_murko_results,
+# ):
+#     messages = iter(pickled_messages(get_messages()))
+#     metadata = iter(json_metadata(2, start=90, step=90))
+#     with (
+#         patch.object(
+#             fake_strict_redis.pubsub,
+#             "get_message",
+#             new_callable=AsyncMock,
+#             side_effect=lambda *args, **kwargs: next(messages),
+#         ) as mock_get_message,
+#         patch.object(
+#             fake_strict_redis,
+#             "hget",
+#             new_callable=AsyncMock,
+#             side_effect=lambda *args, **kwargs: next(metadata),
+#         ) as mock_hget,
+#     ):
+#         fake_murko_results.pubsub.get_message = mock_get_message
+#         fake_murko_results.redis_client.hget = mock_hget
+#         await fake_murko_results.trigger()
+#         assert fake_murko_results.pubsub.get_message.call_count == 6
+#     assert fake_murko_results.redis_client.hget.call_count == 100
+
+
+@patch("dodal.devices.i04.murko_results.StrictRedis")
+async def test_no_movement_given_sample_centre_matches_beam_centre(
+    fake_strict_redis, fake_murko_results, fake_setters
+):
+    mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
+    messages = iter(pickled_messages(get_messages()))  # 2 messages, both (0.5, 0.5)
+    metadata = json_metadata(2, start=90, step=90)  # at exactly 90, 180 degrees
+    with (
+        patch.object(
+            fake_strict_redis.pubsub,
+            "get_message",
+            new_callable=AsyncMock,
+            side_effect=lambda *args, **kwargs: next(messages),
+        ) as mock_get_message,
+        patch.object(
+            fake_strict_redis,
+            "hget",
+            new_callable=AsyncMock,
+            side_effect=lambda blah, uuid: metadata[uuid],
+        ) as mock_hget,
+        patch.object(
+            fake_murko_results,
+            "get_beam_centre",
+            side_effect=lambda *args, **kwargs: (50, 50),
+        ) as mock_get_beam_centre,
+    ):
+        fake_murko_results.pubsub.get_message = mock_get_message
+        fake_murko_results.redis_client.hget = mock_hget
+        fake_murko_results.get_beam_centre = mock_get_beam_centre
+        await fake_murko_results.trigger()
+    assert mock_x_setter.call_args[0][0] == 0
+    assert mock_y_setter.call_args[0][0] == 0
+    assert mock_z_setter.call_args[0][0] == 0
+
+
+@patch("dodal.devices.i04.murko_results.StrictRedis")
+async def test_given_correct_movement_given_90_and_180_angles(  # Need a better name
+    fake_strict_redis, fake_murko_results, fake_setters
+):
+    mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
+    messages = iter(pickled_messages(get_messages()))  # 2 messages, both (0.5, 0.5)
+    metadata = json_metadata(2, start=90, step=90)  # at exactly 90, 180 degrees
+    with (
+        patch.object(
+            fake_strict_redis.pubsub,
+            "get_message",
+            new_callable=AsyncMock,
+            side_effect=lambda *args, **kwargs: next(messages),
+        ) as mock_get_message,
+        patch.object(
+            fake_strict_redis,
+            "hget",
+            new_callable=AsyncMock,
+            side_effect=lambda blah, uuid: metadata[uuid],
+        ) as mock_hget,
+        patch.object(
+            fake_murko_results,
+            "get_beam_centre",
+            side_effect=lambda *args, **kwargs: (75, 70),
+        ) as mock_get_beam_centre,
+    ):
+        fake_murko_results.pubsub.get_message = mock_get_message
+        fake_murko_results.redis_client.hget = mock_hget
+        fake_murko_results.get_beam_centre = mock_get_beam_centre
+        await fake_murko_results.trigger()
+    # (sample_centre_x * shape[0] - beam_centre_x) / microns_pxp -> (0.5 * 100 - 75) / 10
+    assert mock_x_setter.call_args[0][0] == -0.25
+    # (sample_centre_y * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
+    assert mock_y_setter.call_args[0][0] == 0.2
+    # (sample_centre_z * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
+    assert mock_z_setter.call_args[0][0] == 0.2
+
+
+@patch("dodal.devices.i04.murko_results.StrictRedis")
+async def test_given_correct_movement_given_30_and_210_angles(  # Need a better name
+    fake_strict_redis, fake_murko_results, fake_setters
+):
+    mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
+    messages = iter(pickled_messages(get_messages()))  # 2 messages, both (0.5, 0.5)
+    metadata = json_metadata(2, start=30, step=190)  # at exactly 90, 180 degrees
+    with (
+        patch.object(
+            fake_strict_redis.pubsub,
+            "get_message",
+            new_callable=AsyncMock,
+            side_effect=lambda *args, **kwargs: next(messages),
+        ) as mock_get_message,
+        patch.object(
+            fake_strict_redis,
+            "hget",
+            new_callable=AsyncMock,
+            side_effect=lambda blah, uuid: metadata[uuid],
+        ) as mock_hget,
+        patch.object(
+            fake_murko_results,
+            "get_beam_centre",
+            side_effect=lambda *args, **kwargs: (75, 70),
+        ) as mock_get_beam_centre,
+    ):
+        fake_murko_results.pubsub.get_message = mock_get_message
+        fake_murko_results.redis_client.hget = mock_hget
+        fake_murko_results.get_beam_centre = mock_get_beam_centre
+        await fake_murko_results.trigger()
+    # (sample_centre_x * shape[0] - beam_centre_x) / microns_pxp -> (0.5 * 100 - 75) / 10
+    assert mock_x_setter.call_args[0][0] == -0.25
+    # (sample_centre_y * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
+    assert mock_y_setter.call_args[0][0] == 0.2
+    # (sample_centre_z * shape[1] - beam_centre_y) / microns_pyp -> (0.5 * 100 - 70) / 10
+    assert mock_z_setter.call_args[0][0] == 0.2
+
+
+# async def test_complete_ends_once_last_search_angle_is_found(fake_murko_results):
+#     fake_murko_results.angles_to_search = fake_murko_results.angles_to_search[:-1]
+#     await fake_murko_results.trigger()
+#     assert fake_murko_results.pubsub.get_message.call_count == 4
+#     assert fake_murko_results.redis_client.hget.call_count == 80
+
+
+# async def test_complete_xyz_set_value(fake_murko_results, fake_setters):
+#     mock_x_setter, mock_y_setter, mock_z_setter = fake_setters
+#     await fake_murko_results.trigger()
+#     assert mock_x_setter.call_args[0][0] == 10


### PR DESCRIPTION
Fixes #[136](https://github.com/DiamondLightSource/mx-bluesky/issues/136) from mx-bluesky

### Instructions to reviewer on how to test:
1. Run tests
2. Check they pass
3. If possible, run on the beamline to get actual results from murko.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
