### PR TITLE
Increase eiger timeout

### DIFF
--- a/src/dodal/devices/eiger.py
+++ b/src/dodal/devices/eiger.py
@@ -35,7 +35,7 @@ class InternalEigerTriggerMode(Enum):
 AVAILABLE_TIMEOUTS = {
     "i03": EigerTimeouts(
         stale_params_timeout=60,
-        general_status_timeout=10,
+        general_status_timeout=20,
         meta_file_ready_timeout=30,
         all_frames_timeout=120,  # Long timeout for meta file to compensate for filesystem issues
         arming_timeout=60,


### PR DESCRIPTION
Part of https://github.com/DiamondLightSource/mx-bluesky/issues/967

### Instructions to reviewer on how to test:
1.Confirm eiger timeout increased as in `hyperion_stable`

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
