### PR TITLE
Add zebra and pilatus for i23

### DIFF
--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -1,5 +1,15 @@
-from dodal.common.beamlines.beamline_utils import device_factory
+from pathlib import Path
+
+from ophyd_async.epics.adpilatus import PilatusDetector
+
+from dodal.common.beamlines.beamline_utils import (
+    device_factory,
+    get_path_provider,
+    set_path_provider,
+)
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.beamlines.device_helpers import HDF5_SUFFIX
+from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.motors import SixAxisGonio
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.zebra.zebra import Zebra
@@ -14,6 +24,14 @@ from dodal.utils import BeamlinePrefix, get_beamline_name, get_hostname
 BL = get_beamline_name("i23")
 set_log_beamline(BL)
 set_utils_beamline(BL)
+
+set_path_provider(
+    StaticVisitPathProvider(
+        BL,
+        Path("/tmp"),
+        client=LocalDirectoryServiceClient(),
+    )
+)
 
 PREFIX = BeamlinePrefix(BL)
 
@@ -63,10 +81,11 @@ def zebra() -> Zebra:
 
 
 @device_factory()
-def zebra() -> Zebra:
-    """Get the i23 zebra"""
-    return Zebra(
-        name="zebra",
-        prefix=f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:ZEBRA:",
-        mapping=I23_ZEBRA_MAPPING,
+def pilatus() -> PilatusDetector:
+    """Get the i23 pilatus"""
+    return PilatusDetector(
+        prefix=f"{PREFIX.beamline_prefix}-EA-PILAT-01:",
+        path_provider=get_path_provider(),
+        drv_suffix="cam1:",
+        fileio_suffix=HDF5_SUFFIX,
     )

--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -2,6 +2,12 @@ from dodal.common.beamlines.beamline_utils import device_factory
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.devices.motors import SixAxisGonio
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
+from dodal.devices.zebra.zebra import Zebra
+from dodal.devices.zebra.zebra_constants_mapping import (
+    ZebraMapping,
+    ZebraSources,
+    ZebraTTLOutputs,
+)
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import BeamlinePrefix, get_beamline_name, get_hostname
 
@@ -10,6 +16,12 @@ set_log_beamline(BL)
 set_utils_beamline(BL)
 
 PREFIX = BeamlinePrefix(BL)
+
+I23_ZEBRA_MAPPING = ZebraMapping(
+    outputs=ZebraTTLOutputs(TTL_DETECTOR=1, TTL_SHUTTER=4),
+    sources=ZebraSources(),
+    AND_GATE_FOR_AUTO_SHUTTER=2,
+)
 
 
 def _is_i23_machine():
@@ -37,4 +49,24 @@ def gonio() -> SixAxisGonio:
 
     return SixAxisGonio(
         f"{PREFIX.beamline_prefix}-MO-GONIO-01:",
+    )
+
+
+@device_factory()
+def zebra() -> Zebra:
+    """Get the i23 zebra"""
+    return Zebra(
+        name="zebra",
+        prefix=f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:ZEBRA:",
+        mapping=I23_ZEBRA_MAPPING,
+    )
+
+
+@device_factory()
+def zebra() -> Zebra:
+    """Get the i23 zebra"""
+    return Zebra(
+        name="zebra",
+        prefix=f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:ZEBRA:",
+        mapping=I23_ZEBRA_MAPPING,
     )

--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -54,7 +54,7 @@ def _is_i23_machine():
 
 @device_factory(skip=lambda: not _is_i23_machine())
 def oav_pin_tip_detection() -> PinTipDetection:
-    """Get the i23 OAV pin-tip detection device"""
+    """Get the i23 OAV pin-tip detection device."""
 
     return PinTipDetection(
         f"{PREFIX.beamline_prefix}-DI-OAV-01:",
@@ -64,7 +64,7 @@ def oav_pin_tip_detection() -> PinTipDetection:
 
 @device_factory()
 def shutter() -> ZebraShutter:
-    """Get the i23 zebra controlled shutter"""
+    """Get the i23 zebra controlled shutter."""
     return ZebraShutter(f"{PREFIX.beamline_prefix}-EA-SHTR-01:", "shutter")
 
 

--- a/src/dodal/devices/zebra/zebra.py
+++ b/src/dodal/devices/zebra/zebra.py
@@ -51,6 +51,10 @@ class I24Axes:
     VGON_YH = EncEnum.ENC4
 
 
+class I23Axes:
+    OMEGA = EncEnum.ENC1
+
+
 class RotationDirection(StrictEnum):
     """
     Defines for a swept angle whether the scan width (sweep) is to be added or subtracted from


### PR DESCRIPTION
Fixes #1181 and fixes #1182

Connections taken from https://confluence.diamond.ac.uk/display/MXTech/I23+Zebra+connections

### Instructions to reviewer on how to test:
1. Confirm `dodal connect i23` connects (with the caveat of https://github.com/bluesky/ophyd-async/issues/860)

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
