### PR TITLE
Update to work with ophyd-async main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async@git+https://github.com/bluesky/ophyd-async.git@main",
+    "ophyd-async@git+https://github.com/bluesky/ophyd-async.git@main", # Pin needed until https://github.com/bluesky/ophyd-async/pull/852 is released
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async@git+https://github.com/bluesky/ophyd-async.git@main", # Pin needed until https://github.com/bluesky/ophyd-async/pull/852 is released
+    "ophyd-async>=0.10.0a3",
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async>=0.10.0a1",
+    "ophyd-async@git+https://github.com/bluesky/ophyd-async.git@main",
     "bluesky",
     "pyepics",
     "dataclasses-json",

--- a/src/dodal/devices/i13_1/merlin.py
+++ b/src/dodal/devices/i13_1/merlin.py
@@ -23,10 +23,9 @@ class Merlin(StandardDetector):
         super().__init__(
             MerlinController(self.drv),
             adcore.ADHDFWriter(
-                self.hdf,
-                path_provider,
-                lambda: self.name,
-                adcore.ADBaseDatasetDescriber(self.drv),
+                fileio=self.hdf,
+                path_provider=path_provider,
+                dataset_describer=adcore.ADBaseDatasetDescriber(self.drv),
             ),
             config_sigs=(self.drv.acquire_period, self.drv.acquire_time),
             name=name,

--- a/src/dodal/devices/i13_1/merlin_controller.py
+++ b/src/dodal/devices/i13_1/merlin_controller.py
@@ -37,7 +37,7 @@ class MerlinController(ADBaseController):
             DEFAULT_TIMEOUT + await self.driver.acquire_time.get_value()
         )
         await asyncio.gather(
-            self.driver.num_images.set(trigger_info.total_number_of_triggers),
+            self.driver.num_images.set(trigger_info.total_number_of_exposures),
             self.driver.image_mode.set(ADImageMode.MULTIPLE),
         )
 

--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -244,10 +244,9 @@ class TetrammDetector(StandardDetector):
         super().__init__(
             controller,
             ADHDFWriter(
-                self.hdf,
-                path_provider,
-                lambda: self.name,
-                TetrammDatasetDescriber(controller),
+                fileio=self.hdf,
+                path_provider=path_provider,
+                dataset_describer=TetrammDatasetDescriber(controller),
                 plugins=plugins,
             ),
             config_signals,

--- a/tests/devices/i13_1/test_merlin.py
+++ b/tests/devices/i13_1/test_merlin.py
@@ -16,8 +16,8 @@ from dodal.devices.i13_1.merlin import Merlin
 @pytest.fixture
 def one_shot_trigger_info() -> TriggerInfo:
     return TriggerInfo(
-        frame_timeout=None,
-        number_of_triggers=1,
+        exposure_timeout=None,
+        number_of_events=1,
         trigger=DetectorTrigger.INTERNAL,
         deadtime=0.0,
         livetime=None,
@@ -76,7 +76,6 @@ async def test_can_collect(
     assert stream_resource["uri"] == "file://localhost/foo/bar.hdf"
     assert stream_resource["parameters"] == {
         "dataset": "/entry/data/data",
-        "multiplier": 1,
         "chunk_shape": (1, 20, 10),
     }
     assert docs[1][0] == "stream_datum"
@@ -97,7 +96,7 @@ async def test_can_decribe_collect(merlin: Merlin, one_shot_trigger_info: Trigge
     assert (await merlin.describe_collect()) == {
         "merlin": {
             "source": "mock+ca://BL13J-EA-DET-04HDF5:FullFileName_RBV",
-            "shape": [20, 10],
+            "shape": [1, 20, 10],
             "dtype": "array",
             "dtype_numpy": "|i1",
             "external": "STREAM:",

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -198,7 +198,7 @@ async def test_sample_rate_scales_with_exposure_time(
             trigger=DetectorTrigger.EDGE_TRIGGER,
             deadtime=2e-5,
             livetime=exposure,
-            frame_timeout=None,
+            exposure_timeout=None,
         )
     )
     values_per_reading = await tetramm.drv.values_per_reading.get_value()

--- a/tests/devices/unit_tests/test_tetramm.py
+++ b/tests/devices/unit_tests/test_tetramm.py
@@ -51,11 +51,11 @@ async def tetramm(static_path_provider: PathProvider) -> TetrammDetector:
 @pytest.fixture
 def supported_trigger_info() -> TriggerInfo:
     return TriggerInfo(
-        number_of_triggers=1,
+        number_of_events=1,
         trigger=DetectorTrigger.CONSTANT_GATE,
         deadtime=1.0,
         livetime=0.02,
-        frame_timeout=None,
+        exposure_timeout=None,
     )
 
 
@@ -64,7 +64,7 @@ async def test_max_frame_rate_is_calculated_correctly(
 ):
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=2.0
+            number_of_events=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=2.0
         )
     )
 
@@ -107,7 +107,7 @@ async def test_min_exposure_is_calculated_correctly(
     # 100_000 / 17 ~ 5800; 5800 * 0.01 = 58; 58 << tetramm_controller.maximum_readings_per_frame
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.01
+            number_of_events=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.01
         )
     )
     assert tetramm_controller.readings_per_frame == int(readings_per_time * 0.01)
@@ -115,7 +115,7 @@ async def test_min_exposure_is_calculated_correctly(
     # 100_000 / 17 ~ 5800; 5800 * 0.2 = 1160; 1160 > tetramm_controller.maximum_readings_per_frame
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.2
+            number_of_events=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.2
         )
     )
     assert (
@@ -127,7 +127,7 @@ async def test_min_exposure_is_calculated_correctly(
     tetramm_controller.maximum_readings_per_frame = 1200
     await tetramm_controller.prepare(
         TriggerInfo(
-            number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.1
+            number_of_events=1, trigger=DetectorTrigger.EDGE_TRIGGER, livetime=0.1
         )
     )
     assert tetramm_controller.readings_per_frame == int(readings_per_time * 0.1)
@@ -164,7 +164,7 @@ async def test_set_invalid_exposure_for_number_of_values_per_reading(
     ):
         await tetramm_controller.prepare(
             TriggerInfo(
-                number_of_triggers=0,
+                number_of_events=0,
                 trigger=DetectorTrigger.EDGE_TRIGGER,
                 livetime=4e-5,
             )
@@ -194,7 +194,7 @@ async def test_sample_rate_scales_with_exposure_time(
 
     await tetramm.prepare(
         TriggerInfo(
-            number_of_triggers=100,
+            number_of_events=100,
             trigger=DetectorTrigger.EDGE_TRIGGER,
             deadtime=2e-5,
             livetime=exposure,
@@ -228,7 +228,7 @@ async def test_arm_raises_value_error_for_invalid_trigger_type(
     ):
         await tetramm_controller.prepare(
             TriggerInfo(
-                number_of_triggers=0,
+                number_of_events=0,
                 trigger=trigger_type,
                 livetime=VALID_TEST_EXPOSURE_TIME,
                 deadtime=VALID_TEST_DEADTIME,
@@ -249,7 +249,7 @@ async def test_arm_sets_signals_correctly_given_valid_inputs(
 ):
     await tetramm.prepare(
         TriggerInfo(
-            number_of_triggers=0,
+            number_of_events=0,
             trigger=trigger_type,
             livetime=VALID_TEST_EXPOSURE_TIME,
             deadtime=VALID_TEST_DEADTIME,
@@ -266,7 +266,7 @@ async def test_disarm_disarms_driver(
     assert (await tetramm_driver.acquire.get_value()) == 0
     await tetramm.prepare(
         TriggerInfo(
-            number_of_triggers=0,
+            number_of_events=0,
             trigger=DetectorTrigger.EDGE_TRIGGER,
             livetime=VALID_TEST_EXPOSURE_TIME,
             deadtime=VALID_TEST_DEADTIME,
@@ -291,11 +291,11 @@ async def test_prepare_with_too_low_a_deadtime_raises_error(
     ):
         await tetramm.prepare(
             TriggerInfo(
-                number_of_triggers=5,
+                number_of_events=5,
                 trigger=DetectorTrigger.EDGE_TRIGGER,
                 deadtime=1.0 / 100_000.0,
                 livetime=VALID_TEST_EXPOSURE_TIME,
-                frame_timeout=None,
+                exposure_timeout=None,
             )
         )
 
@@ -306,11 +306,11 @@ async def test_prepare_arms_tetramm(
     set_mock_value(tetramm.hdf.file_path_exists, True)
     await tetramm.prepare(
         TriggerInfo(
-            number_of_triggers=5,
+            number_of_events=5,
             trigger=DetectorTrigger.EDGE_TRIGGER,
             deadtime=0.1,
             livetime=VALID_TEST_EXPOSURE_TIME,
-            frame_timeout=None,
+            exposure_timeout=None,
         )
     )
     await assert_armed(tetramm.drv)
@@ -343,7 +343,7 @@ async def test_stage_sets_up_accurate_describe_output(
     assert await tetramm.describe() == {
         TEST_TETRAMM_NAME: {
             "source": "mock+ca://MY-TETRAMM:HDF5:FullFileName_RBV",
-            "shape": [11, 400],
+            "shape": [1, 11, 400],
             "dtype_numpy": "<f8",
             "dtype": "array",
             "external": "STREAM:",
@@ -354,7 +354,7 @@ async def test_stage_sets_up_accurate_describe_output(
 async def test_error_if_armed_without_exposure(tetramm_controller: TetrammController):
     with pytest.raises(ValueError):
         await tetramm_controller.prepare(
-            TriggerInfo(number_of_triggers=10, trigger=DetectorTrigger.INTERNAL)
+            TriggerInfo(number_of_events=10, trigger=DetectorTrigger.INTERNAL)
         )
 
 
@@ -366,7 +366,7 @@ async def test_pilatus_controller(
     driver = tetramm.drv
     await controller.prepare(
         TriggerInfo(
-            number_of_triggers=1,
+            number_of_events=1,
             trigger=DetectorTrigger.CONSTANT_GATE,
             livetime=VALID_TEST_EXPOSURE_TIME,
             deadtime=VALID_TEST_DEADTIME,


### PR DESCRIPTION
Fixes #1184 

Dodal was broken against ophyd-async main for the following reasons:

- Changes to `TriggerInfo`, where `frame_timeout` was renamed to `exposure_timeout`, `number_of_triggers` was renamed to `number_of_events`, and `multiplier -> frames_per_event` is now the first dimension in `DataKey.shape` in [#726](https://github.com/bluesky/ophyd-async/pull/726)
- `name_provider` was removed from `ADHDFWriter.__init__()` in [#842](https://github.com/bluesky/ophyd-async/pull/842).

EDIT: new ophyd_async pre-release needed to pass issue requirements.

### Instructions to reviewer on how to test:
1. Check that amended tests are still as expected.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
