### PR TITLE
Make attach_data_session_metadata_wrapper a no-op if there is no path provider

### DIFF
--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -162,3 +162,8 @@ def set_path_provider(provider: PathProvider):
 
 def get_path_provider() -> PathProvider:
     return PATH_PROVIDER
+
+
+def clear_path_provider() -> None:
+    global PATH_PROVIDER
+    del PATH_PROVIDER

--- a/tests/plan_stubs/test_data_session.py
+++ b/tests/plan_stubs/test_data_session.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 from bluesky.run_engine import RunEngine
 from bluesky.utils import MsgGenerator
 
+from dodal.common.beamlines.beamline_utils import clear_path_provider
 from dodal.plan_stubs.data_session import attach_data_session_metadata_wrapper
 
 
@@ -28,6 +29,7 @@ def test_attach_data_session_metadata_wrapper_with_no_provider_is_noop(
     def fake_plan() -> MsgGenerator[None]:
         yield from []
 
+    clear_path_provider()
     plan = attach_data_session_metadata_wrapper(plan=fake_plan())
     RE(plan)
 

--- a/tests/plan_stubs/test_data_session.py
+++ b/tests/plan_stubs/test_data_session.py
@@ -20,3 +20,15 @@ def test_attach_data_session_metadata_wrapper(caplog, RE: RunEngine):
         f"{path_provider} is not an UpdatingPathProvider, {attach_data_session_metadata_wrapper.__name__} will have no effect"
         in caplog.text
     )
+
+
+def test_attach_data_session_metadata_wrapper_with_no_provider_is_noop(
+    caplog, RE: RunEngine
+):
+    def fake_plan() -> MsgGenerator[None]:
+        yield from []
+
+    plan = attach_data_session_metadata_wrapper(plan=fake_plan())
+    RE(plan)
+
+    assert f"There is no PathProvider set, {attach_data_session_metadata_wrapper.__name__} will have no effect"


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/dodal/issues/1191

