### PR TITLE
Additional `opposite` property for RotationDirection

### DIFF
--- a/src/dodal/devices/zebra/zebra.py
+++ b/src/dodal/devices/zebra/zebra.py
@@ -68,6 +68,14 @@ class RotationDirection(StrictEnum):
     def multiplier(self):
         return 1 if self == RotationDirection.POSITIVE else -1
 
+    @property
+    def opposite(self) -> RotationDirection:
+        return (
+            RotationDirection.POSITIVE
+            if self == RotationDirection.NEGATIVE
+            else RotationDirection.NEGATIVE
+        )
+
 
 class ArmDemand(Enum):
     ARM = 1

--- a/tests/devices/unit_tests/test_zebra.py
+++ b/tests/devices/unit_tests/test_zebra.py
@@ -154,3 +154,8 @@ def test_logic_gate_configuration_with_too_many_sources_then_error():
 def test_direction_multiplier():
     assert RotationDirection.NEGATIVE.multiplier == -1
     assert RotationDirection.POSITIVE.multiplier == 1
+
+
+def test_opposite():
+    assert RotationDirection.POSITIVE.opposite == RotationDirection.NEGATIVE
+    assert RotationDirection.NEGATIVE.opposite == RotationDirection.POSITIVE


### PR DESCRIPTION
Required for 
* DiamondLightSource/mx-bluesky#1034

Fixes
* DiamondLightSource/mx-bluesky#839

Adds the `opposite` property to the RotationDirection as a convenience.


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
