### PR TITLE
Extended timeout of pmac collection time to 1 hour

### DIFF
--- a/src/dodal/devices/i24/pmac.py
+++ b/src/dodal/devices/i24/pmac.py
@@ -217,7 +217,7 @@ class PMAC(StandardReadable):
         # A couple of soft signals for running a collection: program number to send to
         # the PMAC_STRING and expected collection time.
         self.program_number = soft_signal_rw(int)
-        self.collection_time = soft_signal_rw(float, initial_value=600.0, units="s")
+        self.collection_time = soft_signal_rw(float, initial_value=3600.0, units="s")
 
         self.run_program = ProgramRunner(
             self.pmac_string,


### PR DESCRIPTION
Fixes #1104 

Changed the initial value from 10 minutes to one hour. It'll default to one hour whenever a specific time isn't provided.

### Instructions to reviewer on how to test:
1. Confirm tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
