### PR TITLE
Fix docs CI by pinning dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "redis",
     "deepdiff",
     "scanspec>=0.7.3",
+    "snowballstemmer<3" # Remove once https://github.com/sphinx-doc/sphinx/issues/13533 is resolved
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
Our docs were failing to build - see https://github.com/sphinx-doc/sphinx/issues/13533

### Instructions to reviewer on how to test:
1. Confirm CI passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
