### PR TITLE
Correct ADR numbering

### DIFF
--- a/docs/explanations/decisions/0004-make-devices-factory.md
+++ b/docs/explanations/decisions/0004-make-devices-factory.md
@@ -1,4 +1,4 @@
-# 3. Add device factory decorator with lazy connect support
+# 4. Add device factory decorator with lazy connect support
 
 Date: 2024-04-26
 


### PR DESCRIPTION
Fixes our ADR numbering not being unique, meaning it was confusing to refer to one by number or know where to continue counting from. 

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
