### PR TITLE
Allow nested lists in beamline parameters

### DIFF
--- a/src/dodal/common/beamlines/beamline_parameters.py
+++ b/src/dodal/common/beamlines/beamline_parameters.py
@@ -73,8 +73,23 @@ class GDABeamlineParameters:
             return float(value)
 
     @classmethod
-    def find_first_index(cls, s: str, chars: Iterable):
-        return min((s.find(c) for c in chars if c in s), default=-1)
+    def find_first_index(cls, value: str, chars: Iterable):
+        return min((value.find(c) for c in chars if c in value), default=-1)
+
+    @classmethod
+    def find_close_square_bracket(cls, value: str):
+        index = 0
+        open = 1
+        close = 0
+        if not value[0] == "[":
+            raise ValueError(f"List must start with '[': {value}")
+        while open > close:
+            index += 1
+            if value[index] == "[":
+                open += 1
+            elif value[index] == "]":
+                close += 1
+        return index
 
     @classmethod
     def parse_list(cls, value: str):
@@ -89,7 +104,7 @@ class GDABeamlineParameters:
             if remaining[i] == ",":
                 remaining = remaining[i + 1 :].lstrip()
             elif remaining[i] == "[":
-                j = remaining.index("]")
+                j = cls.find_close_square_bracket(remaining[i:])
                 list_output.append(cls.parse_list(remaining[i + 1 : j + 1]))
                 remaining = remaining[j + 1 :].lstrip()
         if (i := remaining.find("]")) != -1:

--- a/src/dodal/common/beamlines/beamline_parameters.py
+++ b/src/dodal/common/beamlines/beamline_parameters.py
@@ -1,3 +1,4 @@
+import ast
 from collections.abc import Iterable
 from typing import Any, cast
 
@@ -58,62 +59,7 @@ class GDABeamlineParameters:
 
     @classmethod
     def parse_value(cls, value: str):
-        if value[0] == "[":
-            return cls.parse_list(value[1:].strip())
-        else:
-            return cls.parse_list_element(value)
-
-    @classmethod
-    def parse_list_element(cls, value: str):
-        if value == "Yes":
-            return True
-        elif value == "No":
-            return False
-        else:
-            return float(value)
-
-    @classmethod
-    def find_first_index(cls, value: str, chars: Iterable):
-        return min((value.find(c) for c in chars if c in value), default=-1)
-
-    @classmethod
-    def find_close_square_bracket(cls, value: str):
-        index = 0
-        open = 1
-        close = 0
-        if not value[0] == "[":
-            raise ValueError(f"List must start with '[': {value}")
-        while open > close:
-            index += 1
-            if value[index] == "[":
-                open += 1
-            elif value[index] == "]":
-                close += 1
-        return index
-
-    @classmethod
-    def parse_list(cls, value: str):
-        list_output = []
-        remaining = value.strip()
-        if remaining[0] == ",":
-            raise ValueError(f"List has a leading comma: {value}.")
-        i = 0
-        while (i := cls.find_first_index(remaining, (",", "["))) != -1:
-            if remaining[:i]:
-                list_output.append(cls.parse_list_element(remaining[:i]))
-            if remaining[i] == ",":
-                remaining = remaining[i + 1 :].lstrip()
-            elif remaining[i] == "[":
-                j = cls.find_close_square_bracket(remaining[i:])
-                list_output.append(cls.parse_list(remaining[i + 1 : j + 1]))
-                remaining = remaining[j + 1 :].lstrip()
-        if (i := remaining.find("]")) != -1:
-            if remaining[:i]:
-                list_output.append(cls.parse_list_element(remaining[:i]))
-                remaining = remaining[i + 1 :].lstrip()
-        else:
-            raise ValueError("Missing closing ']' in list expression")
-        return list_output
+        return ast.literal_eval(value.replace("Yes", "True").replace("No", "False"))
 
 
 def get_beamline_parameters(beamline_param_path: str | None = None):

--- a/src/dodal/common/beamlines/beamline_parameters.py
+++ b/src/dodal/common/beamlines/beamline_parameters.py
@@ -1,5 +1,4 @@
 import ast
-from collections.abc import Iterable
 from typing import Any, cast
 
 from dodal.log import LOGGER

--- a/tests/common/beamlines/test_beamline_parameters.py
+++ b/tests/common/beamlines/test_beamline_parameters.py
@@ -124,6 +124,11 @@ def test_leading_comma_in_list_causes_error():
         GDABeamlineParameters.parse_value("[[1, 2], [ ,3, 4]]")
 
 
+def test_find_close_bracket_raises_error():
+    with pytest.raises(ValueError):
+        GDABeamlineParameters.find_close_square_bracket("a[")
+
+
 @pytest.fixture(autouse=True)
 def i03_beamline_parameters():
     with patch.dict(

--- a/tests/common/beamlines/test_beamline_parameters.py
+++ b/tests/common/beamlines/test_beamline_parameters.py
@@ -61,7 +61,7 @@ def test_parse_list():
 
 
 def test_parse_list_raises_exception():
-    with pytest.raises(ValueError):
+    with pytest.raises(SyntaxError):
         GDABeamlineParameters.parse_value("[1, 2")
 
 
@@ -118,15 +118,17 @@ def test_parse_nested_nested_list():
 
 
 def test_leading_comma_in_list_causes_error():
-    with pytest.raises(ValueError):
+    with pytest.raises(SyntaxError):
         GDABeamlineParameters.parse_value("[,1, 2, 3, 4]")
-    with pytest.raises(ValueError):
+    with pytest.raises(SyntaxError):
         GDABeamlineParameters.parse_value("[[1, 2], [ ,3, 4]]")
 
 
-def test_find_close_bracket_raises_error():
-    with pytest.raises(ValueError):
-        GDABeamlineParameters.find_close_square_bracket("a[")
+def test_Yes_and_No_replaced_with_bool_values():
+    value = "[Yes, No, True, False, 0, 1]"
+    expected = [True, False, True, False, 0, 1]
+    actual = GDABeamlineParameters.parse_value(value)
+    assert actual == expected
 
 
 @pytest.fixture(autouse=True)

--- a/tests/common/beamlines/test_beamline_parameters.py
+++ b/tests/common/beamlines/test_beamline_parameters.py
@@ -105,6 +105,25 @@ def test_get_beamline_parameters_raises_error_when_beamline_not_found(
         get_beamline_parameters()
 
 
+def test_parse_nested_list():
+    actual = GDABeamlineParameters.parse_value("[[1, 2], [3, 4]]")
+    expected = [[1, 2], [3, 4]]
+    assert actual == expected
+
+
+def test_parse_nested_nested_list():
+    actual = GDABeamlineParameters.parse_value("[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]")
+    expected = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+    assert actual == expected
+
+
+def test_leading_comma_in_list_causes_error():
+    with pytest.raises(ValueError):
+        GDABeamlineParameters.parse_value("[,1, 2, 3, 4]")
+    with pytest.raises(ValueError):
+        GDABeamlineParameters.parse_value("[[1, 2], [ ,3, 4]]")
+
+
 @pytest.fixture(autouse=True)
 def i03_beamline_parameters():
     with patch.dict(


### PR DESCRIPTION
Fixes #1233

Allows nested lists in beamline parameters file, which the parser couldn't previously deal with.

### Instructions to reviewer on how to test:
1. Pass beamline parameters file containing nested lists
2. Confirm all lines are parsed correctly with no warnings or errors

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
