### PR TITLE
Add deferred moves into smargon

### DIFF
--- a/src/dodal/devices/smargon.py
+++ b/src/dodal/devices/smargon.py
@@ -107,12 +107,12 @@ class DeferMoves(StrictEnum):
 class CombinedMove(TypedDict):
     """A move on multiple axes at once using a deferred move"""
 
-    x: NotRequired[float]
-    y: NotRequired[float]
-    z: NotRequired[float]
-    omega: NotRequired[float]
-    phi: NotRequired[float]
-    chi: NotRequired[float]
+    x: NotRequired[float | None]
+    y: NotRequired[float | None]
+    z: NotRequired[float | None]
+    omega: NotRequired[float | None]
+    phi: NotRequired[float | None]
+    chi: NotRequired[float | None]
 
 
 class Smargon(StandardReadable, Movable):
@@ -168,7 +168,8 @@ class Smargon(StandardReadable, Movable):
         try:
             tasks = []
             for k, v in value.items():
-                tasks.append(getattr(self, k).set(v))
+                if v is not None:
+                    tasks.append(getattr(self, k).set(v))
             await asyncio.gather(*tasks)
         finally:
             await self.defer_move.set(DeferMoves.OFF)

--- a/tests/devices/unit_tests/test_smargon.py
+++ b/tests/devices/unit_tests/test_smargon.py
@@ -100,6 +100,16 @@ async def test_given_set_with_single_value_then_that_motor_moves(smargon: Smargo
     )
 
 
+async def test_given_set_with_none_then_that_motor_does_not_move(smargon: Smargon):
+    await smargon.set(CombinedMove(x=10, y=None))
+
+    get_mock_put(smargon.x.user_setpoint).assert_called_once_with(10, wait=True)
+    get_mock_put(smargon.y.user_setpoint).assert_not_called()
+    get_mock_put(smargon.defer_move).assert_has_calls(
+        [call(DeferMoves.ON, wait=True), call(DeferMoves.OFF, wait=True)]
+    )
+
+
 async def test_given_set_with_all_values_then_motors_move(smargon: Smargon):
     await smargon.set(CombinedMove(x=10, y=20, z=30, omega=5, chi=15, phi=25))
 


### PR DESCRIPTION
See https://github.com/DiamondLightSource/mx-bluesky/issues/1049

### Instructions to reviewer on how to test:
1. Confirm tests pass
2. Confirm `dodal connect i03` still connects

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
