### PR TITLE
Fix tests for latest bluesky version

### DIFF
--- a/tests/plan_stubs/test_wrapped_stubs.py
+++ b/tests/plan_stubs/test_wrapped_stubs.py
@@ -90,14 +90,14 @@ def test_move(x_axis: SimMotor, y_axis: SimMotor):
     msgs = list(move({x_axis: 0.5, y_axis: 1.0}))
     assert msgs[0] == Msg("set", x_axis, 0.5, group=ANY)
     assert msgs[1] == Msg("set", y_axis, 1.0, group=msgs[0].kwargs["group"])
-    assert msgs[2] == Msg("wait", group=msgs[0].kwargs["group"])
+    assert msgs[2] == Msg("wait", group=msgs[0].kwargs["group"], timeout=None)
 
 
 def test_move_group(x_axis: SimMotor, y_axis: SimMotor):
     msgs = list(move({x_axis: 0.5, y_axis: 1.0}, group="foo"))
     assert msgs[0] == Msg("set", x_axis, 0.5, group="foo")
     assert msgs[1] == Msg("set", y_axis, 1.0, group="foo")
-    assert msgs[2] == Msg("wait", group="foo")
+    assert msgs[2] == Msg("wait", group="foo", timeout=None)
 
 
 def test_move_relative(x_axis: SimMotor, y_axis: SimMotor):
@@ -107,7 +107,7 @@ def test_move_relative(x_axis: SimMotor, y_axis: SimMotor):
     group = msgs[1].kwargs["group"]
     assert msgs[2] == Msg("locate", y_axis)
     assert msgs[3] == Msg("set", y_axis, 1.0, group=group)
-    assert msgs[4] == Msg("wait", group=group)
+    assert msgs[4] == Msg("wait", group=group, timeout=None)
 
 
 def test_move_relative_group(x_axis: SimMotor, y_axis: SimMotor):
@@ -116,7 +116,7 @@ def test_move_relative_group(x_axis: SimMotor, y_axis: SimMotor):
     assert msgs[1] == Msg("set", x_axis, 0.5, group="foo")
     assert msgs[2] == Msg("locate", y_axis)
     assert msgs[3] == Msg("set", y_axis, 1.0, group="foo")
-    assert msgs[4] == Msg("wait", group="foo")
+    assert msgs[4] == Msg("wait", group="foo", timeout=None)
 
 
 def test_sleep():


### PR DESCRIPTION
### Instructions to reviewer on how to test:
1. Install the latest `bluesky`
2. Confirm tests pass


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
