### PR TITLE
i23 Laser shaping OAV

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,7 @@ mock_attributes_table = {
     "s04": mock_paths,
     "i19_1": mock_paths,
     "i24": mock_paths,
+    "aithre": mock_paths,
 }
 
 BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]

--- a/src/dodal/beamlines/aithre.py
+++ b/src/dodal/beamlines/aithre.py
@@ -1,5 +1,10 @@
 from dodal.common.beamlines.beamline_utils import device_factory
 from dodal.devices.aithre_lasershaping.goniometer import Goniometer
+from dodal.devices.oav.oav_detector import NullZoomController, OAVBeamCentreFile
+from dodal.devices.oav.oav_parameters import OAVConfigBeamCentre
+
+ZOOM_PARAMS_FILE = "/dls_sw/i23/software/aithre/aithre_oav.xml"
+DISPLAY_CONFIG = "/dls_sw/i23/software/aithre/aithre_display.configuration"
 
 PREFIX = "LA18L"
 
@@ -7,3 +12,13 @@ PREFIX = "LA18L"
 @device_factory()
 def goniometer() -> Goniometer:
     return Goniometer(f"{PREFIX}-MO-LSR-01:", "goniometer")
+
+
+@device_factory()
+def oav(params: OAVConfigBeamCentre | None = None) -> OAVBeamCentreFile:
+    return OAVBeamCentreFile(
+        prefix=f"{PREFIX}-DI-OAV-01:",
+        config=params or OAVConfigBeamCentre(ZOOM_PARAMS_FILE, DISPLAY_CONFIG),
+        name="oav",
+        zoom_controller=NullZoomController(),
+    )

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -6,10 +6,16 @@ from ophyd_async.testing import set_mock_value
 from dodal.devices.oav.oav_detector import (
     OAV,
     Cam,
+    NullZoomController,
     OAVBeamCentreFile,
     OAVBeamCentrePV,
+    OAVConfigBeamCentre,
     ZoomController,
 )
+
+OAV_CENTRING_JSON = "tests/devices/unit_tests/test_OAVCentring.json"
+DISPLAY_CONFIGURATION = "tests/devices/unit_tests/test_display.configuration"
+ZOOM_LEVELS_XML = "tests/devices/unit_tests/test_jCameraManZoomLevels.xml"
 
 
 async def test_zoom_controller():
@@ -153,3 +159,18 @@ async def test_beam_centre_signals_have_same_names(
         reading = await specific_oav.read()
         assert "oav-beam_centre_i" in reading.keys()
         assert "oav-beam_centre_j" in reading.keys()
+
+
+async def test_oav_with_null_zoom_controller():
+    null_controller = NullZoomController()
+    oav_config = OAVConfigBeamCentre(ZOOM_LEVELS_XML, DISPLAY_CONFIGURATION)
+    oav = OAVBeamCentreFile("", oav_config, "", zoom_controller=null_controller)
+
+    assert await oav.zoom_controller.level.get_value() == "1.0x"
+
+
+def test_setting_null_zoom_controller_raises_exception():
+    null_controller = NullZoomController()
+    with pytest.raises(Exception) as exc:
+        null_controller.set("2.0x")
+    assert str(exc.value) == "Attempting to set zoom level of a null zoom controller"

--- a/tests/devices/unit_tests/oav/test_oav.py
+++ b/tests/devices/unit_tests/oav/test_oav.py
@@ -18,6 +18,11 @@ DISPLAY_CONFIGURATION = "tests/devices/unit_tests/test_display.configuration"
 ZOOM_LEVELS_XML = "tests/devices/unit_tests/test_jCameraManZoomLevels.xml"
 
 
+@pytest.fixture()
+def null_controller() -> NullZoomController:
+    return NullZoomController()
+
+
 async def test_zoom_controller():
     zoom_controller = ZoomController("", "zoom_controller")
     await zoom_controller.connect(mock=True)
@@ -161,16 +166,16 @@ async def test_beam_centre_signals_have_same_names(
         assert "oav-beam_centre_j" in reading.keys()
 
 
-async def test_oav_with_null_zoom_controller():
-    null_controller = NullZoomController()
+async def test_oav_with_null_zoom_controller(null_controller: NullZoomController):
     oav_config = OAVConfigBeamCentre(ZOOM_LEVELS_XML, DISPLAY_CONFIGURATION)
     oav = OAVBeamCentreFile("", oav_config, "", zoom_controller=null_controller)
 
     assert await oav.zoom_controller.level.get_value() == "1.0x"
 
 
-def test_setting_null_zoom_controller_raises_exception():
-    null_controller = NullZoomController()
+def test_setting_null_zoom_controller_raises_exception(
+    null_controller: NullZoomController,
+):
     with pytest.raises(Exception) as exc:
         null_controller.set("2.0x")
     assert str(exc.value) == "Attempting to set zoom level of a null zoom controller"


### PR DESCRIPTION
Fixes [#896](https://github.com/DiamondLightSource/mx-bluesky/issues/896)

Adds the option to use a `NullZoomController` when creating OAV devices in order to lock them at 1.0x zoom.

### Instructions to reviewer on how to test:
1. Run `dodal connect aithre` on `ws581`
2. Confirm `oav` connects

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
