### PR TITLE
Fix broken tests due to pytest-asyncio update

### DIFF
--- a/tests/common/beamlines/test_beamline_utils.py
+++ b/tests/common/beamlines/test_beamline_utils.py
@@ -19,7 +19,8 @@ from dodal.utils import DeviceInitializationController
 
 
 @pytest.fixture(autouse=True)
-def flush_event_loop_on_finish(event_loop):
+def flush_event_loop_on_finish():
+    event_loop = asyncio.get_event_loop()
     # wait for the test function to complete
     yield None
 

--- a/tests/devices/unit_tests/i03/test_undulator_dcm.py
+++ b/tests/devices/unit_tests/i03/test_undulator_dcm.py
@@ -16,7 +16,8 @@ from tests.constants import UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
 
 
 @pytest.fixture(autouse=True)
-def flush_event_loop_on_finish(event_loop):
+def flush_event_loop_on_finish():
+    event_loop = asyncio.get_event_loop()
     # wait for the test function to complete
     yield None
 


### PR DESCRIPTION
Fixes broken tests, issue was https://github.com/pytest-dev/pytest-asyncio/issues/1106

### Instructions to reviewer on how to test:
1. Reinstall the dev environement
2. Confirm tests pass on this branch but fail on main

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
