### PR TITLE
Reorganise imports

### DIFF
--- a/src/dodal/devices/electron_analyser/__init__.py
+++ b/src/dodal/devices/electron_analyser/__init__.py
@@ -1,10 +1,15 @@
-from .abstract.base_detector import (
+from .detector import (
     ElectronAnalyserDetector,
     ElectronAnalyserRegionDetector,
     TElectronAnalyserDetector,
     TElectronAnalyserRegionDetector,
 )
-from .types import EnergyMode
+from .enums import EnergyMode
+from .types import (
+    ElectronAnalyserDetectorImpl,
+    GenericElectronAnalyserDetector,
+    GenericElectronAnalyserRegionDetector,
+)
 from .util import to_binding_energy, to_kinetic_energy
 
 __all__ = [
@@ -12,7 +17,10 @@ __all__ = [
     "to_kinetic_energy",
     "EnergyMode",
     "ElectronAnalyserDetector",
+    "ElectronAnalyserDetectorImpl",
     "TElectronAnalyserDetector",
     "ElectronAnalyserRegionDetector",
     "TElectronAnalyserRegionDetector",
+    "GenericElectronAnalyserDetector",
+    "GenericElectronAnalyserRegionDetector",
 ]

--- a/src/dodal/devices/electron_analyser/abstract/base_detector.py
+++ b/src/dodal/devices/electron_analyser/abstract/base_detector.py
@@ -44,8 +44,8 @@ class AbstractElectronAnalyserDetector(
 
     def __init__(
         self,
-        name: str,
         driver: TAbstractAnalyserDriverIO,
+        name: str = "",
     ):
         self.controller: ElectronAnalyserController = ElectronAnalyserController(
             driver=driver

--- a/src/dodal/devices/electron_analyser/abstract/base_driver_io.py
+++ b/src/dodal/devices/electron_analyser/abstract/base_driver_io.py
@@ -20,7 +20,7 @@ from ophyd_async.epics.motor import Motor
 from dodal.devices.electron_analyser.abstract.base_region import (
     TAbstractBaseRegion,
 )
-from dodal.devices.electron_analyser.types import EnergyMode
+from dodal.devices.electron_analyser.enums import EnergyMode
 from dodal.devices.electron_analyser.util import to_binding_energy, to_kinetic_energy
 
 

--- a/src/dodal/devices/electron_analyser/abstract/base_region.py
+++ b/src/dodal/devices/electron_analyser/abstract/base_region.py
@@ -5,7 +5,7 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel, Field, model_validator
 
-from dodal.devices.electron_analyser.types import EnergyMode
+from dodal.devices.electron_analyser.enums import EnergyMode
 
 
 def java_to_python_case(java_str: str) -> str:

--- a/src/dodal/devices/electron_analyser/detector.py
+++ b/src/dodal/devices/electron_analyser/detector.py
@@ -32,11 +32,14 @@ class ElectronAnalyserRegionDetector(
     """
 
     def __init__(
-        self, name: str, driver: TAbstractAnalyserDriverIO, region: TAbstractBaseRegion
+        self,
+        driver: TAbstractAnalyserDriverIO,
+        region: TAbstractBaseRegion,
+        name: str = "",
     ):
         self._driver_ref = Reference(driver)
         self.region = region
-        super().__init__(name, driver)
+        super().__init__(driver, name)
 
     @property
     def driver(self) -> TAbstractAnalyserDriverIO:
@@ -87,7 +90,7 @@ class ElectronAnalyserDetector(
         # Pass in driver
         self._driver = driver
         self._sequence_class = sequence_class
-        super().__init__(name, self.driver)
+        super().__init__(self.driver, name)
 
     @property
     def driver(self) -> TAbstractAnalyserDriverIO:
@@ -127,7 +130,7 @@ class ElectronAnalyserDetector(
         seq = self.load_sequence(filename)
         regions = seq.get_enabled_regions() if enabled_only else seq.regions
         return [
-            ElectronAnalyserRegionDetector(self.name + "_" + r.name, self.driver, r)
+            ElectronAnalyserRegionDetector(self.driver, r, self.name + "_" + r.name)
             for r in regions
         ]
 

--- a/src/dodal/devices/electron_analyser/detector.py
+++ b/src/dodal/devices/electron_analyser/detector.py
@@ -1,0 +1,138 @@
+from typing import Generic, TypeVar
+
+from bluesky.protocols import Preparable
+from ophyd_async.core import (
+    AsyncStatus,
+    Reference,
+)
+from ophyd_async.epics.motor import Motor
+
+from dodal.common.data_util import load_json_file_to_class
+from dodal.devices.electron_analyser.abstract.base_detector import (
+    AbstractElectronAnalyserDetector,
+)
+from dodal.devices.electron_analyser.abstract.base_driver_io import (
+    TAbstractAnalyserDriverIO,
+)
+from dodal.devices.electron_analyser.abstract.base_region import (
+    TAbstractBaseRegion,
+    TAbstractBaseSequence,
+)
+
+
+class ElectronAnalyserRegionDetector(
+    AbstractElectronAnalyserDetector[TAbstractAnalyserDriverIO],
+    Preparable,
+    Generic[TAbstractAnalyserDriverIO, TAbstractBaseRegion],
+):
+    """
+    Extends electron analyser detector to configure specific region settings before data
+    acqusition. This object must be passed in a driver and store it as a reference. It
+    is designed to only exist inside a plan.
+    """
+
+    def __init__(
+        self, name: str, driver: TAbstractAnalyserDriverIO, region: TAbstractBaseRegion
+    ):
+        self._driver_ref = Reference(driver)
+        self.region = region
+        super().__init__(name, driver)
+
+    @property
+    def driver(self) -> TAbstractAnalyserDriverIO:
+        # Store as a reference, this implementation will be given a driver so needs to
+        # make sure we don't get conflicting parents.
+        return self._driver_ref()
+
+    @AsyncStatus.wrap
+    async def prepare(self, value: Motor) -> None:
+        """
+        Prepare driver with the region stored and energy_source motor.
+
+        Args:
+            value: The excitation energy source that the region has selected.
+        """
+        excitation_energy_source = value
+        await self.driver.prepare(excitation_energy_source)
+        await self.driver.set(self.region)
+
+
+TElectronAnalyserRegionDetector = TypeVar(
+    "TElectronAnalyserRegionDetector",
+    bound=ElectronAnalyserRegionDetector,
+)
+
+
+class ElectronAnalyserDetector(
+    AbstractElectronAnalyserDetector[TAbstractAnalyserDriverIO],
+    Generic[
+        TAbstractAnalyserDriverIO,
+        TAbstractBaseSequence,
+        TAbstractBaseRegion,
+    ],
+):
+    """
+    Electron analyser detector with the additional functionality to load a sequence file
+    and create a list of temporary ElectronAnalyserRegionDetector objects. These will
+    setup configured region settings before data acquisition.
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        sequence_class: type[TAbstractBaseSequence],
+        driver: TAbstractAnalyserDriverIO,
+        name: str = "",
+    ):
+        # Pass in driver
+        self._driver = driver
+        self._sequence_class = sequence_class
+        super().__init__(name, self.driver)
+
+    @property
+    def driver(self) -> TAbstractAnalyserDriverIO:
+        # This implementation creates the driver and wants this to be the parent so it
+        # can be used with connect() method.
+        return self._driver
+
+    def load_sequence(self, filename: str) -> TAbstractBaseSequence:
+        """
+        Load the sequence data from a provided json file into a sequence class.
+
+        Args:
+            filename: Path to the sequence file containing the region data.
+
+        Returns:
+            Pydantic model representing the sequence file.
+        """
+        return load_json_file_to_class(self._sequence_class, filename)
+
+    def create_region_detector_list(
+        self, filename: str, enabled_only=True
+    ) -> list[
+        ElectronAnalyserRegionDetector[TAbstractAnalyserDriverIO, TAbstractBaseRegion]
+    ]:
+        """
+        Create a list of detectors equal to the number of regions in a sequence file.
+        Each detector is responsible for setting up a specific region.
+
+        Args:
+            filename:     Path to the sequence file containing the region data.
+            enabled_only: If true, only include the region if enabled is True.
+
+        Returns:
+            List of ElectronAnalyserRegionDetector, equal to the number of regions in
+            the sequence file.
+        """
+        seq = self.load_sequence(filename)
+        regions = seq.get_enabled_regions() if enabled_only else seq.regions
+        return [
+            ElectronAnalyserRegionDetector(self.name + "_" + r.name, self.driver, r)
+            for r in regions
+        ]
+
+
+TElectronAnalyserDetector = TypeVar(
+    "TElectronAnalyserDetector",
+    bound=ElectronAnalyserDetector,
+)

--- a/src/dodal/devices/electron_analyser/enums.py
+++ b/src/dodal/devices/electron_analyser/enums.py
@@ -1,0 +1,6 @@
+from ophyd_async.core import StrictEnum
+
+
+class EnergyMode(StrictEnum):
+    KINETIC = "Kinetic"
+    BINDING = "Binding"

--- a/src/dodal/devices/electron_analyser/specs/detector.py
+++ b/src/dodal/devices/electron_analyser/specs/detector.py
@@ -1,4 +1,4 @@
-from dodal.devices.electron_analyser.abstract.base_detector import (
+from dodal.devices.electron_analyser.detector import (
     ElectronAnalyserDetector,
 )
 from dodal.devices.electron_analyser.specs.driver_io import SpecsAnalyserDriverIO

--- a/src/dodal/devices/electron_analyser/types.py
+++ b/src/dodal/devices/electron_analyser/types.py
@@ -15,9 +15,11 @@ from dodal.devices.electron_analyser.vgscienta.detector import VGScientaDetector
 ElectronAnalyserDetectorImpl = VGScientaDetector | SpecsDetector
 
 GenericElectronAnalyserDetector = ElectronAnalyserDetector[
-    AbstractAnalyserDriverIO, AbstractBaseSequence, AbstractBaseRegion
+    AbstractAnalyserDriverIO[AbstractBaseRegion],
+    AbstractBaseSequence,
+    AbstractBaseRegion,
 ]
 
 GenericElectronAnalyserRegionDetector = ElectronAnalyserRegionDetector[
-    AbstractAnalyserDriverIO, AbstractBaseRegion
+    AbstractAnalyserDriverIO[AbstractBaseRegion], AbstractBaseRegion
 ]

--- a/src/dodal/devices/electron_analyser/types.py
+++ b/src/dodal/devices/electron_analyser/types.py
@@ -1,6 +1,23 @@
-from ophyd_async.core import StrictEnum
+from dodal.devices.electron_analyser.abstract.base_driver_io import (
+    AbstractAnalyserDriverIO,
+)
+from dodal.devices.electron_analyser.abstract.base_region import (
+    AbstractBaseRegion,
+    AbstractBaseSequence,
+)
+from dodal.devices.electron_analyser.detector import (
+    ElectronAnalyserDetector,
+    ElectronAnalyserRegionDetector,
+)
+from dodal.devices.electron_analyser.specs.detector import SpecsDetector
+from dodal.devices.electron_analyser.vgscienta.detector import VGScientaDetector
 
+ElectronAnalyserDetectorImpl = VGScientaDetector | SpecsDetector
 
-class EnergyMode(StrictEnum):
-    KINETIC = "Kinetic"
-    BINDING = "Binding"
+GenericElectronAnalyserDetector = ElectronAnalyserDetector[
+    AbstractAnalyserDriverIO, AbstractBaseSequence, AbstractBaseRegion
+]
+
+GenericElectronAnalyserRegionDetector = ElectronAnalyserRegionDetector[
+    AbstractAnalyserDriverIO, AbstractBaseRegion
+]

--- a/src/dodal/devices/electron_analyser/util.py
+++ b/src/dodal/devices/electron_analyser/util.py
@@ -1,4 +1,4 @@
-from dodal.devices.electron_analyser.types import EnergyMode
+from dodal.devices.electron_analyser.enums import EnergyMode
 
 
 def to_kinetic_energy(

--- a/src/dodal/devices/electron_analyser/vgscienta/detector.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/detector.py
@@ -1,4 +1,4 @@
-from dodal.devices.electron_analyser.abstract.base_detector import (
+from dodal.devices.electron_analyser.detector import (
     ElectronAnalyserDetector,
 )
 from dodal.devices.electron_analyser.vgscienta.driver_io import (

--- a/tests/devices/unit_tests/electron_analyser/abstract/test_base_detector.py
+++ b/tests/devices/unit_tests/electron_analyser/abstract/test_base_detector.py
@@ -5,13 +5,13 @@ from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from ophyd_async.epics.motor import Motor
 
-from dodal.devices.electron_analyser import ElectronAnalyserDetector
+from dodal.devices.electron_analyser import (
+    ElectronAnalyserDetector,
+    GenericElectronAnalyserDetector,
+)
 from dodal.devices.electron_analyser.specs import SpecsDetector
 from dodal.devices.electron_analyser.vgscienta import VGScientaDetector
-from tests.devices.unit_tests.electron_analyser.util import (
-    ElectronAnalyserDetectorImpl,
-    get_test_sequence,
-)
+from tests.devices.unit_tests.electron_analyser.util import get_test_sequence
 
 
 @pytest.fixture(params=[SpecsDetector, VGScientaDetector])
@@ -35,7 +35,7 @@ def test_analyser_detector_loads_sequence_correctly(
 
 
 def test_analyser_detector_creates_region_detectors(
-    sim_detector: ElectronAnalyserDetectorImpl,
+    sim_detector: GenericElectronAnalyserDetector,
     sequence_file_path: str,
 ) -> None:
     seq = sim_detector.load_sequence(sequence_file_path)
@@ -48,7 +48,7 @@ def test_analyser_detector_creates_region_detectors(
 
 
 def test_analyser_detector_has_driver_as_child_and_region_detector_does_not(
-    sim_detector: ElectronAnalyserDetectorImpl,
+    sim_detector: GenericElectronAnalyserDetector,
     sequence_file_path: str,
 ) -> None:
     # Remove parent name from driver name so it can be checked it exists in
@@ -68,7 +68,7 @@ def test_analyser_detector_has_driver_as_child_and_region_detector_does_not(
 
 
 def test_analyser_region_detector_stage_prepares_driver_with_region(
-    sim_detector: ElectronAnalyserDetectorImpl,
+    sim_detector: GenericElectronAnalyserDetector,
     sequence_file_path: str,
     sim_energy_source: Motor,
     RE: RunEngine,

--- a/tests/devices/unit_tests/electron_analyser/conftest.py
+++ b/tests/devices/unit_tests/electron_analyser/conftest.py
@@ -5,7 +5,10 @@ from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
 from ophyd_async.epics.motor import Motor
 
-from dodal.devices.electron_analyser import ElectronAnalyserDetector
+from dodal.devices.electron_analyser import (
+    ElectronAnalyserDetector,
+    ElectronAnalyserDetectorImpl,
+)
 from dodal.devices.electron_analyser.abstract import (
     AbstractAnalyserDriverIO,
     AbstractBaseSequence,
@@ -22,7 +25,6 @@ from dodal.devices.electron_analyser.vgscienta import (
     VGScientaSequence,
 )
 from tests.devices.unit_tests.electron_analyser.util import (
-    ElectronAnalyserDetectorImpl,
     get_test_sequence,
 )
 

--- a/tests/devices/unit_tests/electron_analyser/specs/test_driver_io.py
+++ b/tests/devices/unit_tests/electron_analyser/specs/test_driver_io.py
@@ -8,11 +8,11 @@ from ophyd_async.testing import (
     set_mock_value,
 )
 
+from dodal.devices.electron_analyser import EnergyMode
 from dodal.devices.electron_analyser.specs import (
     SpecsAnalyserDriverIO,
     SpecsRegion,
 )
-from dodal.devices.electron_analyser.types import EnergyMode
 from tests.devices.unit_tests.electron_analyser.util import (
     TEST_SEQUENCE_REGION_NAMES,
     assert_read_configuration_has_expected_value,

--- a/tests/devices/unit_tests/electron_analyser/test_util.py
+++ b/tests/devices/unit_tests/electron_analyser/test_util.py
@@ -1,7 +1,10 @@
 import pytest
 
-from dodal.devices.electron_analyser import to_binding_energy, to_kinetic_energy
-from dodal.devices.electron_analyser.types import EnergyMode
+from dodal.devices.electron_analyser import (
+    EnergyMode,
+    to_binding_energy,
+    to_kinetic_energy,
+)
 
 ENERGY_MODE_PARAMS = [EnergyMode.KINETIC, EnergyMode.BINDING]
 

--- a/tests/devices/unit_tests/electron_analyser/util.py
+++ b/tests/devices/unit_tests/electron_analyser/util.py
@@ -5,6 +5,7 @@ from bluesky import plan_stubs as bps
 from ophyd_async.core import StandardReadable
 from ophyd_async.epics.motor import Motor
 
+from dodal.devices.electron_analyser import EnergyMode
 from dodal.devices.electron_analyser.abstract import (
     AbstractAnalyserDriverIO,
     AbstractBaseRegion,
@@ -15,14 +16,11 @@ from dodal.devices.electron_analyser.specs import (
     SpecsDetector,
     SpecsSequence,
 )
-from dodal.devices.electron_analyser.types import EnergyMode
 from dodal.devices.electron_analyser.vgscienta import (
     VGScientaAnalyserDriverIO,
     VGScientaDetector,
     VGScientaSequence,
 )
-
-ElectronAnalyserDetectorImpl = SpecsDetector | VGScientaDetector
 
 TEST_DATA_PATH = "tests/test_data/electron_analyser/"
 

--- a/tests/devices/unit_tests/electron_analyser/vgscienta/test_region.py
+++ b/tests/devices/unit_tests/electron_analyser/vgscienta/test_region.py
@@ -3,8 +3,8 @@ from typing import Any
 import pytest
 
 from dodal.common.data_util import load_json_file_to_class
+from dodal.devices.electron_analyser import EnergyMode
 from dodal.devices.electron_analyser.abstract import TAbstractBaseRegion
-from dodal.devices.electron_analyser.types import EnergyMode
 from dodal.devices.electron_analyser.vgscienta import VGScientaRegion, VGScientaSequence
 from dodal.devices.electron_analyser.vgscienta.region import (
     AcquisitionMode,


### PR DESCRIPTION
Reorganised imports for electron_analyser. This has separated out logic of `electron_analyser/abstract/abstract_base_detector.py` to only contain abstract detector classes. Moved generic classes to `electron_analyser/detector.py`

Also created `electron_analyser/enums.py` and `electron_analyser/types.py` for better organisation. The `types.py` specifically helps to define generic electron analyser detectors and the various implementations. Can be used in tests and other repositories such as [sm-blusky.  ](https://github.com/DiamondLightSource/sm-bluesky)

### Checks for reviewer
- Makes sure tests still pass.
- Check structure and file names makes sense.
