### PR TITLE
Add acquisition_mode enum, adjust classes and tests

### DIFF
--- a/src/dodal/devices/electron_analyser/abstract/base_driver_io.py
+++ b/src/dodal/devices/electron_analyser/abstract/base_driver_io.py
@@ -37,7 +37,9 @@ class AbstractAnalyserDriverIO(
     Electron analysers should inherit from this class for further specialisation.
     """
 
-    def __init__(self, prefix: str, name: str = "") -> None:
+    def __init__(
+        self, prefix: str, acquisition_mode_type: type, name: str = ""
+    ) -> None:
         with self.add_children_as_readables():
             self.image = epics_signal_r(Array1D[np.float64], prefix + "IMAGE")
             self.spectrum = epics_signal_r(Array1D[np.float64], prefix + "INT_SPECTRUM")
@@ -61,7 +63,9 @@ class AbstractAnalyserDriverIO(
             )
             self.energy_step = epics_signal_rw(float, prefix + "STEP_SIZE")
             self.iterations = epics_signal_rw(int, prefix + "NumExposures")
-            self.acquisition_mode = epics_signal_rw(str, prefix + "ACQ_MODE")
+            self.acquisition_mode = epics_signal_rw(
+                acquisition_mode_type, prefix + "ACQ_MODE"
+            )
             self.excitation_energy_source = soft_signal_rw(str, initial_value="")
 
         with self.add_children_as_readables(StandardReadableFormat.CONFIG_SIGNAL):

--- a/src/dodal/devices/electron_analyser/abstract/base_region.py
+++ b/src/dodal/devices/electron_analyser/abstract/base_region.py
@@ -3,9 +3,12 @@ from abc import ABC
 from collections.abc import Callable
 from typing import Generic, TypeVar
 
+from ophyd_async.core import StrictEnum
 from pydantic import BaseModel, Field, model_validator
 
 from dodal.devices.electron_analyser.enums import EnergyMode
+
+TStrictEnum = TypeVar("TStrictEnum", bound=StrictEnum)
 
 
 def java_to_python_case(java_str: str) -> str:
@@ -43,7 +46,7 @@ def energy_mode_validation(data: dict) -> dict:
     return data
 
 
-class AbstractBaseRegion(ABC, JavaToPythonModel):
+class AbstractBaseRegion(ABC, JavaToPythonModel, Generic[TStrictEnum]):
     """
     Generic region model that holds the data. Specialised region models should inherit
     this to extend functionality. All energy units are assumed to be in eV.
@@ -57,7 +60,7 @@ class AbstractBaseRegion(ABC, JavaToPythonModel):
     # These ones we need subclasses to provide default values
     lens_mode: str
     pass_energy: int
-    acquisition_mode: str
+    acquisition_mode: TStrictEnum
     low_energy: float
     high_energy: float
     step_time: float

--- a/src/dodal/devices/electron_analyser/specs/__init__.py
+++ b/src/dodal/devices/electron_analyser/specs/__init__.py
@@ -1,10 +1,12 @@
 from .detector import SpecsDetector
 from .driver_io import SpecsAnalyserDriverIO
+from .enums import AcquisitionMode
 from .region import SpecsRegion, SpecsSequence
 
 __all__ = [
     "SpecsDetector",
     "SpecsAnalyserDriverIO",
+    "AcquisitionMode",
     "SpecsRegion",
     "SpecsSequence",
 ]

--- a/src/dodal/devices/electron_analyser/specs/driver_io.py
+++ b/src/dodal/devices/electron_analyser/specs/driver_io.py
@@ -13,6 +13,7 @@ from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 from dodal.devices.electron_analyser.abstract.base_driver_io import (
     AbstractAnalyserDriverIO,
 )
+from dodal.devices.electron_analyser.specs.enums import AcquisitionMode
 from dodal.devices.electron_analyser.specs.region import SpecsRegion
 
 
@@ -28,7 +29,7 @@ class SpecsAnalyserDriverIO(AbstractAnalyserDriverIO[SpecsRegion]):
             self.min_angle_axis = epics_signal_r(float, prefix + "Y_MIN_RBV")
             self.max_angle_axis = epics_signal_r(float, prefix + "Y_MAX_RBV")
 
-        super().__init__(prefix, name)
+        super().__init__(prefix, AcquisitionMode, name)
 
     @AsyncStatus.wrap
     async def set(self, region: SpecsRegion):
@@ -38,12 +39,10 @@ class SpecsAnalyserDriverIO(AbstractAnalyserDriverIO[SpecsRegion]):
             self.snapshot_values.set(region.values),
             self.psu_mode.set(region.psu_mode),
         )
-        # ToDo - This needs to be changed to an Enum
-        # https://github.com/DiamondLightSource/dodal/issues/1258
-        if region.acquisition_mode == "Fixed Transmission":
+        if region.acquisition_mode == AcquisitionMode.FIXED_TRANSMISSION:
             await self.centre_energy.set(region.centre_energy)
 
-        if self.acquisition_mode == "Fixed Energy":
+        if self.acquisition_mode == AcquisitionMode.FIXED_ENERGY:
             await self.energy_step.set(region.energy_step)
 
     def _create_angle_axis_signal(self, prefix: str) -> SignalR[Array1D[np.float64]]:

--- a/src/dodal/devices/electron_analyser/specs/enums.py
+++ b/src/dodal/devices/electron_analyser/specs/enums.py
@@ -1,0 +1,8 @@
+from ophyd_async.core import StrictEnum
+
+
+class AcquisitionMode(StrictEnum):
+    FIXED_TRANSMISSION = "Fixed Transmission"
+    SNAPSHOT = "Snapshot"
+    FIXED_RETARDING_RATIO = "Fixed Retarding Ratio"
+    FIXED_ENERGY = "Fixed Energy"

--- a/src/dodal/devices/electron_analyser/specs/region.py
+++ b/src/dodal/devices/electron_analyser/specs/region.py
@@ -4,13 +4,14 @@ from dodal.devices.electron_analyser.abstract.base_region import (
     AbstractBaseRegion,
     AbstractBaseSequence,
 )
+from dodal.devices.electron_analyser.specs.enums import AcquisitionMode
 
 
-class SpecsRegion(AbstractBaseRegion):
+class SpecsRegion(AbstractBaseRegion[AcquisitionMode]):
     # Override base class with defaults
     lens_mode: str = "SmallArea"
     pass_energy: int = 5
-    acquisition_mode: str = "Fixed Transmission"
+    acquisition_mode: AcquisitionMode = AcquisitionMode.FIXED_TRANSMISSION
     low_energy: float = Field(default=800, alias="start_energy")
     high_energy: float = Field(default=850, alias="end_energy")
     step_time: float = Field(default=1.0, alias="exposure_time")

--- a/src/dodal/devices/electron_analyser/vgscienta/__init__.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/__init__.py
@@ -1,10 +1,12 @@
 from .detector import VGScientaDetector
 from .driver_io import VGScientaAnalyserDriverIO
+from .enums import AcquisitionMode
 from .region import VGScientaExcitationEnergySource, VGScientaRegion, VGScientaSequence
 
 __all__ = [
     "VGScientaDetector",
     "VGScientaAnalyserDriverIO",
+    "AcquisitionMode",
     "VGScientaExcitationEnergySource",
     "VGScientaRegion",
     "VGScientaSequence",

--- a/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
@@ -14,6 +14,7 @@ from dodal.devices.electron_analyser.abstract.base_driver_io import (
     AbstractAnalyserDriverIO,
 )
 from dodal.devices.electron_analyser.util import to_kinetic_energy
+from dodal.devices.electron_analyser.vgscienta.enums import AcquisitionMode
 from dodal.devices.electron_analyser.vgscienta.region import (
     DetectorMode,
     VGScientaRegion,
@@ -35,7 +36,7 @@ class VGScientaAnalyserDriverIO(AbstractAnalyserDriverIO[VGScientaRegion]):
             # Used to read detector data after acqusition.
             self.external_io = epics_signal_r(Array1D[np.float64], prefix + "EXTIO")
 
-        super().__init__(prefix, name)
+        super().__init__(prefix, AcquisitionMode, name)
 
     @AsyncStatus.wrap
     async def set(self, region: VGScientaRegion):

--- a/src/dodal/devices/electron_analyser/vgscienta/enums.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/enums.py
@@ -1,0 +1,19 @@
+from ophyd_async.core import StrictEnum
+
+
+class Status(StrictEnum):
+    READY = "Ready"
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    INVALID = "Invalid"
+    ABORTED = "Aborted"
+
+
+class DetectorMode(StrictEnum):
+    ADC = "ADC"
+    PULSE_COUNTING = "Pulse Counting"
+
+
+class AcquisitionMode(StrictEnum):
+    SWEPT = "Swept"
+    FIXED = "Fixed"

--- a/src/dodal/devices/electron_analyser/vgscienta/region.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/region.py
@@ -1,7 +1,5 @@
 import uuid
-from enum import Enum
 
-from ophyd_async.core import StrictEnum
 from pydantic import Field
 
 from dodal.devices.electron_analyser.abstract.base_region import (
@@ -9,31 +7,18 @@ from dodal.devices.electron_analyser.abstract.base_region import (
     AbstractBaseSequence,
     JavaToPythonModel,
 )
+from dodal.devices.electron_analyser.vgscienta.enums import (
+    AcquisitionMode,
+    DetectorMode,
+    Status,
+)
 
 
-class Status(str, Enum):
-    READY = "Ready"
-    RUNNING = "Running"
-    COMPLETED = "Completed"
-    INVALID = "Invalid"
-    ABORTED = "Aborted"
-
-
-class DetectorMode(StrictEnum):
-    ADC = "ADC"
-    PULSE_COUNTING = "Pulse Counting"
-
-
-class AcquisitionMode(str, Enum):
-    SWEPT = "Swept"
-    FIXED = "Fixed"
-
-
-class VGScientaRegion(AbstractBaseRegion):
+class VGScientaRegion(AbstractBaseRegion[AcquisitionMode]):
     # Override defaults of base region class
     lens_mode: str = "Angular45"
     pass_energy: int = 5
-    acquisition_mode: str = AcquisitionMode.SWEPT
+    acquisition_mode: AcquisitionMode = AcquisitionMode.SWEPT
     low_energy: float = 8.0
     high_energy: float = 10.0
     step_time: float = 1.0

--- a/tests/devices/unit_tests/electron_analyser/specs/test_driver_io.py
+++ b/tests/devices/unit_tests/electron_analyser/specs/test_driver_io.py
@@ -10,6 +10,7 @@ from ophyd_async.testing import (
 
 from dodal.devices.electron_analyser import EnergyMode
 from dodal.devices.electron_analyser.specs import (
+    AcquisitionMode,
     SpecsAnalyserDriverIO,
     SpecsRegion,
 )
@@ -34,7 +35,7 @@ async def test_given_region_that_analyser_sets_energy_values_correctly(
 ) -> None:
     RE(configure_driver_with_region(sim_driver, region, sim_energy_source))
 
-    if region.acquisition_mode == "Fixed Transmission":
+    if region.acquisition_mode == AcquisitionMode.FIXED_TRANSMISSION:
         get_mock_put(sim_driver.centre_energy).assert_called_once_with(
             region.centre_energy, wait=True
         )
@@ -44,7 +45,7 @@ async def test_given_region_that_analyser_sets_energy_values_correctly(
     else:
         get_mock_put(sim_driver.centre_energy).assert_not_called()
 
-    if region.acquisition_mode == "Fixed Energy":
+    if region.acquisition_mode == AcquisitionMode.FIXED_ENERGY:
         get_mock_put(sim_driver.energy_step).assert_called_once_with(
             region.energy_step, wait=True
         )


### PR DESCRIPTION
Addresses issue https://github.com/DiamondLightSource/dodal/issues/1258. Add Acquisition mode enum support, adjust classes and tests to use.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
