### PR TITLE
Prevent unit tests creating > 2GB of temp files

### DIFF
--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -1,11 +1,11 @@
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import PathProvider, StandardDetector, init_devices
-from ophyd_async.sim import SimBlobDetector, SimMotor
-from ophyd_async.sim._pattern_generator import NullPatternGenerator
+from ophyd_async.sim import PatternGenerator, SimBlobDetector, SimMotor
 from tests.constants import UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
 
 from dodal.devices.common_dcm import BaseDCM
@@ -36,7 +36,32 @@ def det(
     tmp_path: Path,
     path_provider,
 ) -> StandardDetector:
-    pattern_generator = NullPatternGenerator()
+    class DevNullPatternGenerator(PatternGenerator):
+        def __init__(self, sleep=asyncio.sleep):
+            super().__init__(sleep)
+            self.n_images = 0
+
+        def open_file(self, path: Path, width: int, height: int):
+            pass
+
+        async def write_images_to_file(
+            self, exposure: float, period: float, number_of_frames: int
+        ):
+            self.n_images += number_of_frames
+
+        def generate_point(self, channel: int = 1, high_energy: bool = False) -> float:
+            return 0.0
+
+        async def wait_for_next_index(self, timeout: float):
+            pass
+
+        def get_last_index(self) -> int:
+            return self.n_images
+
+        def close_file(self):
+            pass
+
+    pattern_generator = DevNullPatternGenerator()
     with init_devices(mock=True):
         det = SimBlobDetector(path_provider, pattern_generator)
     return det

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -35,7 +36,32 @@ def det(
     tmp_path: Path,
     path_provider,
 ) -> StandardDetector:
-    pattern_generator = PatternGenerator()
+    class DevNullPatternGenerator(PatternGenerator):
+        def __init__(self, sleep=asyncio.sleep):
+            super().__init__(sleep)
+            self.n_images = 0
+
+        def open_file(self, path: Path, width: int, height: int):
+            pass
+
+        async def write_images_to_file(
+            self, exposure: float, period: float, number_of_frames: int
+        ):
+            self.n_images += number_of_frames
+
+        def generate_point(self, channel: int = 1, high_energy: bool = False) -> float:
+            return 0.0
+
+        def wait_for_next_index(self, timeout: float):
+            pass
+
+        def get_last_index(self) -> int:
+            return self.n_images
+
+        def close_file(self):
+            pass
+
+    pattern_generator = DevNullPatternGenerator()
     with init_devices(mock=True):
         det = SimBlobDetector(path_provider, pattern_generator)
     return det

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -1,11 +1,11 @@
-import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import PathProvider, StandardDetector, init_devices
-from ophyd_async.sim import PatternGenerator, SimBlobDetector, SimMotor
+from ophyd_async.sim import SimBlobDetector, SimMotor
+from ophyd_async.sim._pattern_generator import NullPatternGenerator
 from tests.constants import UNDULATOR_ID_GAP_LOOKUP_TABLE_PATH
 
 from dodal.devices.common_dcm import BaseDCM
@@ -36,32 +36,7 @@ def det(
     tmp_path: Path,
     path_provider,
 ) -> StandardDetector:
-    class DevNullPatternGenerator(PatternGenerator):
-        def __init__(self, sleep=asyncio.sleep):
-            super().__init__(sleep)
-            self.n_images = 0
-
-        def open_file(self, path: Path, width: int, height: int):
-            pass
-
-        async def write_images_to_file(
-            self, exposure: float, period: float, number_of_frames: int
-        ):
-            self.n_images += number_of_frames
-
-        def generate_point(self, channel: int = 1, high_energy: bool = False) -> float:
-            return 0.0
-
-        async def wait_for_next_index(self, timeout: float):
-            pass
-
-        def get_last_index(self) -> int:
-            return self.n_images
-
-        def close_file(self):
-            pass
-
-    pattern_generator = DevNullPatternGenerator()
+    pattern_generator = NullPatternGenerator()
     with init_devices(mock=True):
         det = SimBlobDetector(path_provider, pattern_generator)
     return det

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -52,7 +52,7 @@ def det(
         def generate_point(self, channel: int = 1, high_energy: bool = False) -> float:
             return 0.0
 
-        def wait_for_next_index(self, timeout: float):
+        async def wait_for_next_index(self, timeout: float):
             pass
 
         def get_last_index(self) -> int:


### PR DESCRIPTION
Implement a PatternGenerator that doesn't create any nexus file

Fixes #1268

`test_scanspec` was creating large numbers of ~76MB nexus files due to the high level of parameterisation.
These nexus files are not needed by the test, they are created by the `SimBlobDetector` which writes out the nexus file.

This fix impements a do-nothing `PatternGenerator` which doesn't attempt to create any file.

### Instructions to reviewer on how to test:
1. Unit tests pass
2. /tmp/pytest-<fedid> doesn't contain masses of files any more


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
