### PR TITLE
Change adsim stage motors

### DIFF
--- a/src/dodal/devices/adsim.py
+++ b/src/dodal/devices/adsim.py
@@ -9,5 +9,5 @@ class SimStage(StandardReadable):
     def __init__(self, prefix: str, name: str = "sim"):
         with self.add_children_as_readables():
             self.x = Motor(prefix + "M1")
-            self.y = Motor(prefix + "M2")
+            self.theta = Motor(prefix + "M2")
         super().__init__(name=name)


### PR DESCRIPTION
Change admin stage motor names to x and theta rather than x and y, so planned tested on adsim can then be used on the training rigs.


### Instructions to reviewer on how to test:
1. Run `dodal connect adsim` with the sim detector running

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
