### PR TITLE
fix: Temporarily pin event-model to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "redis",
     "deepdiff",
     "scanspec>=0.7.3",
+    "event-model>=1.23",  # Until bluesky pins it https://github.com/DiamondLightSource/dodal/issues/1278
 ]
 
 dynamic = ["version"]

--- a/src/dodal/devices/i22/nxsas.py
+++ b/src/dodal/devices/i22/nxsas.py
@@ -38,7 +38,7 @@ class MetadataHolder:
             if isinstance(value, tuple):
                 return {"units": value[1], **datakey(value[0])}
             dtype = "string"
-            shape = []
+            shape: list[int | None] = []
             match value:
                 case bool():
                     dtype = "boolean"


### PR DESCRIPTION
Linting in CI is currently failing as it fetches the latest version of event model (as bluesky only pins to >=1.19.8). 1.23 which released earlier in the week changes shape in a DataKey from list[int] to list[int | None]. This temporarily pins the version of event-model until a release of bluesky has been made which picks up this new change.

### Instructions to reviewer on how to test:
1. Confirm that CI passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
