### PR TITLE
Change i22 bimorph_vfm number_of_channels to 32

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -136,7 +136,7 @@ def bimorph_hfm() -> BimorphMirror:
 @device_factory()
 def bimorph_vfm() -> BimorphMirror:
     return BimorphMirror(
-        prefix=f"{PREFIX.beamline_prefix}-OP-KBM-01:G1:", number_of_channels=16
+        prefix=f"{PREFIX.beamline_prefix}-OP-KBM-01:G1:", number_of_channels=32
     )
 
 


### PR DESCRIPTION
The I22 vertical focusing mirror has 32 channels, not the 16 currently listed in dodal.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
