### PR TITLE
Use timeout built into observe_value for pin detect

### DIFF
--- a/src/dodal/devices/oav/pin_image_recognition/__init__.py
+++ b/src/dodal/devices/oav/pin_image_recognition/__init__.py
@@ -141,14 +141,16 @@ class PinTipDetection(StandardReadable):
 
     @AsyncStatus.wrap
     async def trigger(self):
-        async def _set_triggered_tip():
-            """Monitors the camera data and updates the triggered_tip signal.
+        """Monitors the camera data and updates the triggered_tip signal.
 
-            If a tip is found it will update the signal and stop monitoring
-            If no tip is found it will retry with the next monitored value
-            This loop will serve as a good example of using 'observe_value' in the ophyd_async documentation
-            """
-            async for value in observe_value(self.array_data):
+        * If a tip is found it will update the signal and stop monitoring
+        * If no tip is found it will retry with the next monitored value, if this
+            continues for {validity_timeout} seconds it will timeout.
+        """
+        try:
+            async for value in observe_value(
+                self.array_data, done_timeout=await self.validity_timeout.get_value()
+            ):
                 try:
                     location = await self._get_tip_and_edge_data(value)
                     self._set_triggered_values(location)
@@ -157,12 +159,7 @@ class PinTipDetection(StandardReadable):
                         f"Failed to detect pin-tip location, will retry with next image: {e}"
                     )
                 else:
-                    return
-
-        try:
-            await asyncio.wait_for(
-                _set_triggered_tip(), timeout=await self.validity_timeout.get_value()
-            )
+                    break
         except asyncio.exceptions.TimeoutError:
             LOGGER.error(
                 f"No tip found in {await self.validity_timeout.get_value()} seconds."

--- a/tests/devices/unit_tests/oav/image_recognition/test_pin_tip_detect.py
+++ b/tests/devices/unit_tests/oav/image_recognition/test_pin_tip_detect.py
@@ -140,14 +140,13 @@ async def test_given_find_tip_fails_when_triggered_then_tip_invalid():
 async def test_given_find_tip_fails_twice_when_triggered_then_tip_invalid_and_tried_twice(
     mock_image_read,
 ):
-    async def get_array_data(_):
+    async def get_array_data(*_, **__):
         yield np.array([1, 2, 3])
         yield np.array([1, 2])
-        await asyncio.sleep(100)
+        raise asyncio.TimeoutError()
 
     mock_image_read.side_effect = get_array_data
     device = await _get_pin_tip_detection_device()
-    await device.validity_timeout.set(0.1)
 
     with (
         patch.object(MxSampleDetect, "__init__", return_value=None),
@@ -167,10 +166,9 @@ async def test_given_tip_invalid_then_loop_keeps_retrying_until_valid(
     mock_image_read: MagicMock,
     mock_logger: MagicMock,
 ):
-    async def get_array_data(_):
+    async def get_array_data(*_, **__):
         yield np.array([1, 2, 3])
         yield np.array([1, 2])
-        await asyncio.sleep(100)
 
     mock_image_read.side_effect = get_array_data
     device = await _get_pin_tip_detection_device()


### PR DESCRIPTION
Fixes #1293 

### Instructions to reviewer on how to test:
1. Confirm logic on linked issues makes sense
2. Confirm tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
