### PR TITLE
Added base table class

### DIFF
--- a/src/dodal/devices/base_table.py
+++ b/src/dodal/devices/base_table.py
@@ -1,0 +1,35 @@
+from ophyd_async.core import StandardReadable
+from ophyd_async.epics.motor import Motor
+
+
+class BaseTable(StandardReadable):
+    """Base class for a sample table with two motors representing X and Y directions."""
+
+    def __init__(
+        self,
+        prefix: str,
+        x: str = "X",
+        y: str = "Y",
+        name: str = "",
+    ) -> None:
+        with self.add_children_as_readables():
+            self.x = Motor(prefix + x)
+            self.y = Motor(prefix + y)
+        super().__init__(name=name)
+
+
+class PitchedBaseTable(BaseTable):
+    """Base class for a sample table with two motors representing gaps
+    in X and Y directions, with additional motor for pitch."""
+
+    def __init__(
+        self,
+        prefix: str,
+        x: str = "X",
+        y: str = "Y",
+        pitch: str = "PITCH",
+        name: str = "",
+    ) -> None:
+        with self.add_children_as_readables():
+            self.pitch = Motor(prefix + pitch)
+        super().__init__(prefix=prefix, x=x, y=y, name=name)


### PR DESCRIPTION
Fixes #1299

Added base_tables.py and two classes for sample base tables, these are intended for i22 and b21 but should be generic enough to be used on any beamline

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
