### PR TITLE
chore: Make better use of assert_reading from ophyd_async testing

### DIFF
--- a/tests/devices/i18/test_kb_mirror.py
+++ b/tests/devices/i18/test_kb_mirror.py
@@ -1,8 +1,6 @@
-from unittest.mock import ANY
-
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import set_mock_value
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.i18.KBMirror import KBMirror
 
@@ -27,38 +25,26 @@ async def test_setting_xy_position_kbmirror(kbmirror: KBMirror):
     await kbmirror.x.set(1.23)
     await kbmirror.y.set(4.56)
 
-    reading = await kbmirror.read()
-    expected_reading = {
-        "kbmirror-y": {
-            "value": 4.56,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        kbmirror,
+        {
+            "kbmirror-y": {
+                "value": 4.56,
+            },
+            "kbmirror-bend1": {
+                "value": 0.0,
+            },
+            "kbmirror-ellip": {
+                "value": 0.0,
+            },
+            "kbmirror-x": {
+                "value": 1.23,
+            },
+            "kbmirror-bend2": {
+                "value": 0.0,
+            },
+            "kbmirror-curve": {
+                "value": 0.0,
+            },
         },
-        "kbmirror-bend1": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "kbmirror-ellip": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "kbmirror-x": {
-            "value": 1.23,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "kbmirror-bend2": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "kbmirror-curve": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-    }
-
-    assert reading == expected_reading
+    )

--- a/tests/devices/i18/test_table.py
+++ b/tests/devices/i18/test_table.py
@@ -1,8 +1,6 @@
-from unittest.mock import ANY
-
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import set_mock_value
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.i18.table import Table
 
@@ -20,80 +18,68 @@ async def test_setting_xy_position_table(table: Table):
     Test setting x and y positions on the Table using the ophyd_async mock tools.
     """
 
-    reading = await table.read()
-    expected_reading = {
-        "table-y": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        table,
+        {
+            "table-y": {
+                "value": 0.0,
+            },
+            "table-x": {
+                "value": 0.0,
+            },
+            "table-theta": {
+                "value": 0.0,
+            },
+            "table-z": {
+                "value": 0.0,
+            },
         },
-        "table-x": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "table-theta": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": 0.0,
-        },
-        "table-z": {"alarm_severity": 0, "timestamp": ANY, "value": 0.0},
-    }
-
-    assert reading == expected_reading
+    )
 
     # Call set to update the position
     set_mock_value(table.x.user_readback, 1.23)
     set_mock_value(table.y.user_readback, 4.56)
 
-    reading = await table.read()
-    expected_reading = {
-        "table-y": {
-            "value": 4.56,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        table,
+        {
+            "table-y": {
+                "value": 4.56,
+            },
+            "table-x": {
+                "value": 1.23,
+            },
+            "table-theta": {
+                "value": 0.0,
+            },
+            "table-z": {
+                "value": 0,
+            },
         },
-        "table-x": {
-            "value": 1.23,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "table-theta": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": 0.0,
-        },
-        "table-z": {"alarm_severity": 0, "timestamp": ANY, "value": 0.0},
-    }
-
-    assert reading == expected_reading
+    )
 
 
 async def test_setting_xyztheta_position_table(table: Table):
     """
     Test setting x and y positions on the Table using the ophyd_async mock tools.
     """
-    reading = await table.read()
-    expected_reading = {
-        "table-y": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        table,
+        {
+            "table-y": {
+                "value": 0.0,
+            },
+            "table-x": {
+                "value": 0.0,
+            },
+            "table-theta": {
+                "value": 0.0,
+            },
+            "table-z": {
+                "value": 0.0,
+            },
         },
-        "table-x": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "table-theta": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": 0.0,
-        },
-        "table-z": {"alarm_severity": 0, "timestamp": ANY, "value": 0.0},
-    }
-
-    assert reading == expected_reading
+    )
 
     # Call set to update the position
     set_mock_value(table.x.user_readback, 1.23)
@@ -101,24 +87,20 @@ async def test_setting_xyztheta_position_table(table: Table):
     set_mock_value(table.z.user_readback, 7.89)
     set_mock_value(table.theta.user_readback, 10.11)
 
-    reading = await table.read()
-    expected_reading = {
-        "table-y": {
-            "value": 4.56,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        table,
+        {
+            "table-y": {
+                "value": 4.56,
+            },
+            "table-x": {
+                "value": 1.23,
+            },
+            "table-theta": {
+                "value": 10.11,
+            },
+            "table-z": {
+                "value": 7.89,
+            },
         },
-        "table-x": {
-            "value": 1.23,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "table-theta": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": 10.11,
-        },
-        "table-z": {"alarm_severity": 0, "timestamp": ANY, "value": 7.89},
-    }
-
-    assert reading == expected_reading
+    )

--- a/tests/devices/i18/test_thor_labs_stage.py
+++ b/tests/devices/i18/test_thor_labs_stage.py
@@ -1,8 +1,6 @@
-from unittest.mock import ANY
-
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import set_mock_value
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.i18.thor_labs_stage import ThorLabsStage
 
@@ -20,43 +18,31 @@ async def test_setting(thor_labs_stage: ThorLabsStage):
     Test setting x and y positions on the ThorLabsStage using ophyd_async mock tools.
     """
 
-    reading = await thor_labs_stage.read()
-
-    expected_reading = {
-        "thor_labs_stage-x": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        thor_labs_stage,
+        {
+            "thor_labs_stage-x": {
+                "value": 0.0,
+            },
+            "thor_labs_stage-y": {
+                "value": 0.0,
+            },
         },
-        "thor_labs_stage-y": {
-            "value": 0.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-    }
-
-    assert reading == expected_reading
+    )
 
     # Call set to update the position
     set_mock_value(thor_labs_stage.x.user_readback, 5)
     set_mock_value(thor_labs_stage.y.user_readback, 5)
 
-    # Read the stage's current position
-    reading = await thor_labs_stage.read()
-
     # Define the expected position values after the set operation
-    expected_reading = {
-        "thor_labs_stage-x": {
-            "value": 5.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        thor_labs_stage,
+        {
+            "thor_labs_stage-x": {
+                "value": 5.0,
+            },
+            "thor_labs_stage-y": {
+                "value": 5.0,
+            },
         },
-        "thor_labs_stage-y": {
-            "value": 5.0,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-    }
-
-    # Assert the actual reading matches the expected reading
-    assert reading == expected_reading
+    )

--- a/tests/devices/i19/test_shutter.py
+++ b/tests/devices/i19/test_shutter.py
@@ -1,10 +1,10 @@
 import json
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp.client import ClientConnectionError
 from bluesky.run_engine import RunEngine
-from ophyd_async.testing import set_mock_value
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.hutch_shutter import (
     ShutterDemand,
@@ -44,27 +44,27 @@ def shutter_can_be_created_without_raising_errors(hutch_name: HutchState):
 async def test_read_on_eh1_shutter_device_returns_correct_status(
     eh1_shutter: AccessControlledShutter,
 ):
-    reading = await eh1_shutter.read()
-    assert reading == {
-        "mock_shutter-shutter_status": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": ShutterState.CLOSED,
-        }
-    }
+    await assert_reading(
+        eh1_shutter,
+        {
+            "mock_shutter-shutter_status": {
+                "value": ShutterState.CLOSED,
+            }
+        },
+    )
 
 
 async def test_read_on_eh2_shutter_device_returns_correct_status(
     eh2_shutter: AccessControlledShutter,
 ):
-    reading = await eh2_shutter.read()
-    assert reading == {
-        "mock_shutter-shutter_status": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": ShutterState.CLOSED,
-        }
-    }
+    await assert_reading(
+        eh2_shutter,
+        {
+            "mock_shutter-shutter_status": {
+                "value": ShutterState.CLOSED,
+            }
+        },
+    )
 
 
 async def test_set_raises_error_if_post_not_successful(

--- a/tests/devices/i22/test_fswitch.py
+++ b/tests/devices/i22/test_fswitch.py
@@ -1,11 +1,9 @@
-from unittest import mock
-
 import pytest
 from bluesky.plans import count
 from bluesky.run_engine import RunEngine
 from event_model import DataKey
 from ophyd_async.core import init_devices
-from ophyd_async.testing import set_mock_value
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.i22.fswitch import FilterState, FSwitch
 
@@ -28,13 +26,14 @@ async def test_reading_fswitch(fswitch: FSwitch):
     set_mock_value(fswitch.filters[1], FilterState.OUT_BEAM)
     set_mock_value(fswitch.filters[2], FilterState.OUT_BEAM)
 
-    reading = await fswitch.read()
-    assert reading == {
-        "number_of_lenses": {
-            "timestamp": mock.ANY,
-            "value": 125,  # three filters out
-        }
-    }
+    await assert_reading(
+        fswitch,
+        {
+            "number_of_lenses": {
+                "value": 125,  # three filters out
+            }
+        },
+    )
 
 
 def test_fswitch_count_plan(RE: RunEngine, fswitch: FSwitch):

--- a/tests/devices/test_diamond_filter.py
+++ b/tests/devices/test_diamond_filter.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY
-
 import pytest
 from ophyd_async.core import init_devices
 from ophyd_async.testing import assert_reading
@@ -29,8 +27,6 @@ async def test_reading_includes_read_fields(
         {
             "diamond_filter-stage_position": {
                 "value": I03Filters.EMPTY,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )

--- a/tests/devices/training_rig/test_sample_stage.py
+++ b/tests/devices/training_rig/test_sample_stage.py
@@ -1,7 +1,6 @@
-from unittest import mock
-
 import pytest
 from ophyd_async.core import init_devices
+from ophyd_async.testing import assert_reading
 
 from dodal.devices.training_rig.sample_stage import TrainingRigSampleStage
 
@@ -15,16 +14,14 @@ async def stage() -> TrainingRigSampleStage:
 
 
 async def test_reading_training_rig(stage: TrainingRigSampleStage):
-    reading = await stage.read()
-    assert reading == {
-        "stage-theta": {
-            "alarm_severity": mock.ANY,
-            "timestamp": mock.ANY,
-            "value": 0.0,
+    await assert_reading(
+        stage,
+        {
+            "stage-theta": {
+                "value": 0.0,
+            },
+            "stage-x": {
+                "value": 0.0,
+            },
         },
-        "stage-x": {
-            "alarm_severity": mock.ANY,
-            "timestamp": mock.ANY,
-            "value": 0.0,
-        },
-    }
+    )

--- a/tests/devices/unit_tests/electron_analyser/abstract/test_base_driver_io.py
+++ b/tests/devices/unit_tests/electron_analyser/abstract/test_base_driver_io.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.epics.motor import Motor
-from ophyd_async.testing import get_mock_put, set_mock_value
+from ophyd_async.testing import assert_reading, get_mock_put, set_mock_value
 
 from dodal.devices.electron_analyser import (
     to_kinetic_energy,
@@ -23,7 +23,6 @@ from dodal.devices.electron_analyser.vgscienta import (
 from tests.devices.unit_tests.electron_analyser.util import (
     TEST_SEQUENCE_REGION_NAMES,
     assert_read_configuration_has_expected_value,
-    assert_read_has_expected_value,
     configure_driver_with_region,
 )
 
@@ -111,14 +110,21 @@ async def test_given_region_that_analyser_sets_energy_values_correctly(
     get_mock_put(sim_driver.excitation_energy).assert_called_once_with(
         excitation_energy, wait=True
     )
-    await assert_read_has_expected_value(
-        sim_driver, "excitation_energy", excitation_energy
-    )
     get_mock_put(sim_driver.excitation_energy_source).assert_called_once_with(
         expected_energy_source, wait=True
     )
     await assert_read_configuration_has_expected_value(
         sim_driver, "excitation_energy_source", expected_energy_source
+    )
+    await assert_reading(
+        sim_driver,
+        {
+            "sim_driver-excitation_energy": {"value": excitation_energy},
+            "sim_driver-external_io": {"value": []},
+            "sim_driver-image": {"value": []},
+            "sim_driver-spectrum": {"value": []},
+            "sim_driver-total_intensity": {"value": 0.0},
+        },
     )
 
 

--- a/tests/devices/unit_tests/electron_analyser/util.py
+++ b/tests/devices/unit_tests/electron_analyser/util.py
@@ -80,22 +80,6 @@ def assert_region_has_expected_values(
         assert r.__dict__.get(key) is not None
 
 
-async def assert_read_has_expected_value(
-    device: StandardReadable, key: str, expected_value
-) -> None:
-    reading = await device.read()
-    try:
-        assert (
-            reading[device.name + device._child_name_separator + key]["value"]
-            == expected_value
-        )
-    except KeyError as e:
-        raise KeyError(
-            f'Cannot find key "{key}" in read method. Following keys '
-            + f"are {reading.keys()}"
-        ) from e
-
-
 async def assert_read_configuration_has_expected_value(
     device: StandardReadable, key: str, expected_value
 ) -> None:

--- a/tests/devices/unit_tests/test_apple2_undulator.py
+++ b/tests/devices/unit_tests/test_apple2_undulator.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections import defaultdict
-from unittest.mock import ANY, AsyncMock
+from unittest.mock import AsyncMock
 
 import bluesky.plan_stubs as bps
 import pytest
@@ -9,6 +9,7 @@ from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
 from ophyd_async.testing import (
     assert_emitted,
+    assert_reading,
     callback_on_mock_put,
     get_mock_put,
     set_mock_value,
@@ -286,30 +287,23 @@ async def test_phase_success_set(mock_phaseAxes: UndulatorPhaseAxes, RE: RunEngi
         set_value.btm_outer, wait=True
     )
 
-    expected_in_reading = {
-        "mock_phaseAxes-top_inner-user_readback": {
-            "value": 3,
-            "timestamp": ANY,
-            "alarm_severity": 0,
+    await assert_reading(
+        mock_phaseAxes,
+        {
+            "mock_phaseAxes-top_inner-user_readback": {
+                "value": 3,
+            },
+            "mock_phaseAxes-top_outer-user_readback": {
+                "value": 2,
+            },
+            "mock_phaseAxes-btm_inner-user_readback": {
+                "value": 5,
+            },
+            "mock_phaseAxes-btm_outer-user_readback": {
+                "value": 7,
+            },
         },
-        "mock_phaseAxes-top_outer-user_readback": {
-            "value": 2,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "mock_phaseAxes-btm_inner-user_readback": {
-            "value": 5,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-        "mock_phaseAxes-btm_outer-user_readback": {
-            "value": 7,
-            "timestamp": ANY,
-            "alarm_severity": 0,
-        },
-    }
-    actual_reading = await mock_phaseAxes.read()
-    assert expected_in_reading.items() <= actual_reading.items()
+    )
 
 
 async def test_given_gate_never_closes_then_setting_jaw_phases_times_out(

--- a/tests/devices/unit_tests/test_backlight.py
+++ b/tests/devices/unit_tests/test_backlight.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, AsyncMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from bluesky import plan_stubs as bps
@@ -24,13 +24,9 @@ async def test_backlight_can_be_written_and_read_from(fake_backlight: Backlight)
         {
             "backlight-power": {
                 "value": BacklightPower.ON,
-                "alarm_severity": 0,
-                "timestamp": ANY,
             },
             "backlight-position": {
                 "value": BacklightPosition.IN,
-                "alarm_severity": 0,
-                "timestamp": ANY,
             },
         },
     )

--- a/tests/devices/unit_tests/test_baton.py
+++ b/tests/devices/unit_tests/test_baton.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY
-
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
 from ophyd_async.testing import assert_reading
@@ -14,13 +12,9 @@ async def test_mock_baton_can_be_initialised_and_read(RE: RunEngine):
         baton,
         {
             "baton-current_user": {
-                "alarm_severity": 0,
-                "timestamp": ANY,
                 "value": "",
             },
             "baton-requested_user": {
-                "alarm_severity": 0,
-                "timestamp": ANY,
                 "value": "",
             },
         },

--- a/tests/devices/unit_tests/test_motors.py
+++ b/tests/devices/unit_tests/test_motors.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY
-
 import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
@@ -22,33 +20,21 @@ async def test_reading_six_axis_gonio(six_axis_gonio: SixAxisGonio):
         {
             "gonio-omega": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "gonio-kappa": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "gonio-phi": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "gonio-z": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "gonio-y": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "gonio-x": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -1,5 +1,4 @@
 import asyncio
-from unittest.mock import ANY
 
 import pytest
 from ophyd_async.core import init_devices
@@ -42,23 +41,15 @@ async def test_reading_pjumpcell_includes_read_fields_valves(
         {
             "pjump-all_valves_control-valve_states-1": {
                 "value": ValveState.CLOSED,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-all_valves_control-valve_states-3": {
                 "value": ValveState.OPEN,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-all_valves_control-fast_valve_states-5": {
                 "value": FastValveState.CLOSED_ARMED,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-all_valves_control-fast_valve_states-6": {
                 "value": FastValveState.OPEN_ARMED,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -103,13 +94,9 @@ async def test_reading_pjumpcell_includes_config_fields_valves(
         {
             "pjump-all_valves_control-valve_control-1-open": {
                 "value": int(ValveOpenSeqRequest.INACTIVE.value),
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-all_valves_control-valve_control-1-close": {
                 "value": ValveControlRequest.CLOSE,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -152,13 +139,9 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
             {
                 "pjump-all_valves_control-valve_control-1-open": {
                     "value": int(ValveOpenSeqRequest.OPEN_SEQ.value),
-                    "timestamp": ANY,
-                    "alarm_severity": 0,
                 },
                 "pjump-all_valves_control-valve_control-1-close": {
-                    "value": ANY,
-                    "timestamp": ANY,
-                    "alarm_severity": 0,
+                    "value": ValveControlRequest.CLOSE,
                 },
             },
         ),
@@ -167,13 +150,9 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
             {
                 "pjump-all_valves_control-fast_valve_control-6-open": {
                     "value": int(ValveOpenSeqRequest.OPEN_SEQ.value),
-                    "timestamp": ANY,
-                    "alarm_severity": 0,
                 },
                 "pjump-all_valves_control-fast_valve_control-6-close": {
-                    "value": ANY,
-                    "timestamp": ANY,
-                    "alarm_severity": 0,
+                    "value": FastValveControlRequest.ARM,
                 },
             },
         ),
@@ -186,13 +165,9 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
         {
             "pjump-all_valves_control-valve_control-1-open": {
                 "value": int(ValveOpenSeqRequest.INACTIVE.value),
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-all_valves_control-valve_control-1-close": {
                 "value": ValveControlRequest.CLOSE,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -204,13 +179,9 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
         {
             "pjump-all_valves_control-fast_valve_control-6-close": {
                 "value": FastValveControlRequest.ARM,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-all_valves_control-fast_valve_control-6-open": {
                 "value": int(ValveOpenSeqRequest.INACTIVE.value),
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -231,18 +202,12 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
         {
             "pjump-pump-pump_position": {
                 "value": 100,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pump-pump_motor_direction": {
                 "value": PumpMotorDirectionState.FORWARD,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pump-pump_speed": {
                 "value": 100,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -271,23 +236,15 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
         {
             "pjump-pressure_transducers-1-omron_pressure": {
                 "value": 1001,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-1-omron_voltage": {
                 "value": 2.51,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-1-beckhoff_pressure": {
                 "value": 1001.1,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-1-slow_beckhoff_voltage_readout": {
                 "value": 2.51,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -296,23 +253,15 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
         {
             "pjump-pressure_transducers-2-omron_pressure": {
                 "value": 1002,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-2-omron_voltage": {
                 "value": 2.52,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-2-beckhoff_pressure": {
                 "value": 1002.2,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-2-slow_beckhoff_voltage_readout": {
                 "value": 2.52,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -321,23 +270,15 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
         {
             "pjump-pressure_transducers-3-omron_pressure": {
                 "value": 1003,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-3-omron_voltage": {
                 "value": 2.53,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-3-beckhoff_pressure": {
                 "value": 1003.3,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "pjump-pressure_transducers-3-slow_beckhoff_voltage_readout": {
                 "value": 2.53,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -353,8 +294,6 @@ async def test_reading_pjumpcell_includes_read_fields(
         {
             "pjump-cell_temperature": {
                 "value": 12.3,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )

--- a/tests/devices/unit_tests/test_qbpm.py
+++ b/tests/devices/unit_tests/test_qbpm.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY
-
 import pytest
 from ophyd_async.core import init_devices
 from ophyd_async.testing import assert_reading
@@ -20,8 +18,6 @@ async def test_reading_includes_read_fields(qbpm: QBPM):
         {
             "qbpm-intensity_uA": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )

--- a/tests/devices/unit_tests/test_slits.py
+++ b/tests/devices/unit_tests/test_slits.py
@@ -1,10 +1,6 @@
-from collections.abc import Mapping
-from typing import Any
-from unittest.mock import ANY
-
 import pytest
-from ophyd_async.core import StandardReadable, init_devices
-from ophyd_async.testing import set_mock_value
+from ophyd_async.core import init_devices
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.slits import Slits
 
@@ -26,33 +22,16 @@ async def test_reading_slits_reads_gaps_and_centres(slits: Slits):
         slits,
         {
             "slits-x_centre": {
-                "alarm_severity": 0,
-                "timestamp": ANY,
                 "value": 0.0,
             },
             "slits-x_gap": {
-                "alarm_severity": 0,
-                "timestamp": ANY,
                 "value": 0.5,
             },
             "slits-y_centre": {
-                "alarm_severity": 0,
-                "timestamp": ANY,
                 "value": 1.0,
             },
             "slits-y_gap": {
-                "alarm_severity": 0,
-                "timestamp": ANY,
                 "value": 1.5,
             },
         },
     )
-
-
-async def assert_reading(
-    device: StandardReadable,
-    expected_reading: Mapping[str, Any],
-) -> None:
-    reading = await device.read()
-
-    assert reading == expected_reading

--- a/tests/devices/unit_tests/test_turbo_slit.py
+++ b/tests/devices/unit_tests/test_turbo_slit.py
@@ -1,9 +1,9 @@
-from unittest.mock import ANY, AsyncMock
+from unittest.mock import AsyncMock
 
 import pytest
 from bluesky import RunEngine
 from ophyd_async.core import init_devices
-from ophyd_async.testing import set_mock_value
+from ophyd_async.testing import assert_reading, set_mock_value
 
 from dodal.devices.turbo_slit import TurboSlit
 
@@ -33,22 +33,17 @@ async def test_turbo_slit_read(slit: TurboSlit, RE: RunEngine):
     set_mock_value(slit.arc.user_readback, 1.0)
     set_mock_value(slit.xfine.user_readback, 1.5)
 
-    reading = await slit.read()
-
-    assert reading == {
-        "turbo_slit-gap": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": 0.5,
+    await assert_reading(
+        slit,
+        {
+            "turbo_slit-gap": {
+                "value": 0.5,
+            },
+            "turbo_slit-arc": {
+                "value": 1.0,
+            },
+            "turbo_slit-xfine": {
+                "value": 1.5,
+            },
         },
-        "turbo_slit-arc": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": 1.0,
-        },
-        "turbo_slit-xfine": {
-            "alarm_severity": 0,
-            "timestamp": ANY,
-            "value": 1.5,
-        },
-    }
+    )

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY
-
 import numpy as np
 import pytest
 from ophyd_async.core import init_devices
@@ -37,18 +35,12 @@ async def test_reading_includes_read_fields(undulator: Undulator):
         {
             "undulator-gap_access": {
                 "value": UndulatorGapAccess.ENABLED,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "undulator-gap_motor": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "undulator-current_gap": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )
@@ -60,32 +52,20 @@ async def test_configuration_includes_configuration_fields(undulator: Undulator)
         {
             "undulator-gap_motor-motor_egu": {
                 "value": "",
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "undulator-gap_motor-velocity": {
                 "value": 0.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "undulator-length": {
                 "value": 2.0,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "undulator-poles": {
                 "value": 80,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "undulator-gap_discrepancy_tolerance_mm": {
                 "value": 0.002,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "undulator-gap_motor-offset": {
-                "alarm_severity": 0,
-                "timestamp": ANY,
                 "value": 0.0,
             },
         },

--- a/tests/devices/unit_tests/test_watsonmarlow323_pump.py
+++ b/tests/devices/unit_tests/test_watsonmarlow323_pump.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY
-
 import pytest
 from ophyd_async.core import init_devices
 from ophyd_async.testing import assert_reading, set_mock_value
@@ -31,18 +29,12 @@ async def test_reading_pump_reads_state_speed_and_direction(
         {
             "wm_pump-state": {
                 "value": WatsonMarlow323PumpState.STOPPED,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "wm_pump-speed": {
                 "value": 25,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
             "wm_pump-direction": {
                 "value": WatsonMarlow323PumpDirection.CLOCKWISE,
-                "timestamp": ANY,
-                "alarm_severity": 0,
             },
         },
     )


### PR DESCRIPTION
Simplifies tests by making use of assert_reading and assert_configuration from ophyd-async, which did not exist at the time some of the initial tests were written. Patterns from those early tests propagated, such as providing a timestamp of ANY and passing in an alarm severity that will almost never differ with SimBackends. 

This hopefully gives better examples for future test writers and ensuring that fields that should be tested are the only ones being tested, making it clearer what is actually being tested.

### Instructions to reviewer on how to test:
1. Check that code coverage has not decreased
2. Marvel

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
