### PR TITLE
Remove external_io from VGScienta

### DIFF
--- a/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
@@ -32,10 +32,6 @@ class VGScientaAnalyserDriverIO(AbstractAnalyserDriverIO[VGScientaRegion]):
             self.y_channel_size = epics_signal_rw(int, prefix + "SizeY")
             self.detector_mode = epics_signal_rw(DetectorMode, prefix + "DETECTOR_MODE")
 
-        with self.add_children_as_readables():
-            # Used to read detector data after acqusition.
-            self.external_io = epics_signal_r(Array1D[np.float64], prefix + "EXTIO")
-
         super().__init__(prefix, AcquisitionMode, name)
 
     @AsyncStatus.wrap

--- a/tests/devices/unit_tests/electron_analyser/abstract/test_base_driver_io.py
+++ b/tests/devices/unit_tests/electron_analyser/abstract/test_base_driver_io.py
@@ -120,7 +120,6 @@ async def test_given_region_that_analyser_sets_energy_values_correctly(
         sim_driver,
         {
             "sim_driver-excitation_energy": {"value": excitation_energy},
-            "sim_driver-external_io": {"value": []},
             "sim_driver-image": {"value": []},
             "sim_driver-spectrum": {"value": []},
             "sim_driver-total_intensity": {"value": 0.0},


### PR DESCRIPTION
Remove `external_io` as this will no longer be supported with PEAK. Mirrors work done in GDA https://gerrit.diamond.ac.uk/c/gda/gda-core/+/43956

### Instructions to reviewer on how to test:
1. Check tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
