### PR TITLE
Updated remaining electron_analyser tests to use assert_configuration

### DIFF
--- a/src/dodal/devices/electron_analyser/specs/driver_io.py
+++ b/src/dodal/devices/electron_analyser/specs/driver_io.py
@@ -19,6 +19,7 @@ from dodal.devices.electron_analyser.abstract.base_driver_io import (
 )
 from dodal.devices.electron_analyser.specs.enums import AcquisitionMode
 from dodal.devices.electron_analyser.specs.region import SpecsRegion
+from dodal.devices.electron_analyser.util import to_kinetic_energy
 
 
 class SpecsAnalyserDriverIO(
@@ -53,10 +54,15 @@ class SpecsAnalyserDriverIO(
             self.psu_mode.set(region.psu_mode),
         )
         if region.acquisition_mode == AcquisitionMode.FIXED_TRANSMISSION:
-            await self.centre_energy.set(region.centre_energy)
+            await self.energy_step.set(region.energy_step)
 
         if self.acquisition_mode == AcquisitionMode.FIXED_ENERGY:
-            await self.energy_step.set(region.energy_step)
+            source = self._get_energy_source(region.excitation_energy_source)
+            excitation_energy = await source.get_value()
+            centre_energy = to_kinetic_energy(
+                region.centre_energy, region.energy_mode, excitation_energy
+            )
+            await self.centre_energy.set(centre_energy)
 
     def _create_angle_axis_signal(self, prefix: str) -> SignalR[Array1D[np.float64]]:
         angle_axis = derived_signal_r(

--- a/tests/devices/unit_tests/electron_analyser/abstract/test_base_driver_io.py
+++ b/tests/devices/unit_tests/electron_analyser/abstract/test_base_driver_io.py
@@ -7,7 +7,12 @@ from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
 from ophyd_async.core import StrictEnum
-from ophyd_async.testing import assert_reading, get_mock_put, set_mock_value
+from ophyd_async.testing import (
+    assert_configuration,
+    assert_reading,
+    get_mock_put,
+    set_mock_value,
+)
 
 from dodal.devices import b07, i09
 from dodal.devices.electron_analyser import (
@@ -25,7 +30,6 @@ from dodal.devices.electron_analyser.vgscienta import (
 )
 from tests.devices.unit_tests.electron_analyser.util import (
     TEST_SEQUENCE_REGION_NAMES,
-    assert_read_configuration_has_expected_value,
 )
 
 
@@ -42,7 +46,7 @@ def driver_class(
 
 
 @pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_analyser_sets_modes_correctly(
+async def test_analyser_sets_region_and_configuration_is_correct(
     sim_driver: AbstractAnalyserDriverIO,
     region: AbstractBaseRegion,
     RE: RunEngine,
@@ -50,36 +54,15 @@ async def test_given_region_that_analyser_sets_modes_correctly(
     RE(bps.mv(sim_driver, region))
 
     get_mock_put(sim_driver.region_name).assert_called_once_with(region.name, wait=True)
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "region_name", region.name
-    )
     get_mock_put(sim_driver.energy_mode).assert_called_once_with(
         region.energy_mode, wait=True
-    )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "energy_mode", region.energy_mode
     )
     get_mock_put(sim_driver.acquisition_mode).assert_called_once_with(
         region.acquisition_mode, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "acquisition_mode", region.acquisition_mode
-    )
     get_mock_put(sim_driver.lens_mode).assert_called_once_with(
         region.lens_mode, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "lens_mode", region.lens_mode
-    )
-
-
-@pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_analyser_sets_energy_values_correctly(
-    sim_driver: AbstractAnalyserDriverIO,
-    region: AbstractBaseRegion,
-    RE: RunEngine,
-) -> None:
-    RE(bps.mv(sim_driver, region))
 
     energy_source = sim_driver._get_energy_source(region.excitation_energy_source)
     excitation_energy = await energy_source.get_value()
@@ -93,76 +76,28 @@ async def test_given_region_that_analyser_sets_energy_values_correctly(
     expected_pass_e_type = sim_driver.pass_energy_type
     expected_pass_e = expected_pass_e_type(region.pass_energy)
 
-    expected_energy_source = energy_source.name
-
     get_mock_put(sim_driver.low_energy).assert_called_once_with(
         expected_low_e, wait=True
-    )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "low_energy", expected_low_e
     )
     get_mock_put(sim_driver.high_energy).assert_called_once_with(
         expected_high_e, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "high_energy", expected_high_e
-    )
     get_mock_put(sim_driver.pass_energy).assert_called_once_with(
         expected_pass_e, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "pass_energy", expected_pass_e
-    )
-
     get_mock_put(sim_driver.excitation_energy).assert_called_once_with(
         excitation_energy, wait=True
     )
     get_mock_put(sim_driver.excitation_energy_source).assert_called_once_with(
-        expected_energy_source, wait=True
+        energy_source.name, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "excitation_energy_source", expected_energy_source
-    )
-    await assert_reading(
-        sim_driver,
-        {
-            "sim_driver-excitation_energy": {"value": excitation_energy},
-            "sim_driver-image": {"value": []},
-            "sim_driver-spectrum": {"value": []},
-            "sim_driver-total_intensity": {"value": 0.0},
-        },
-    )
-
-
-@pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_analyser_sets_channel_correctly(
-    sim_driver: AbstractAnalyserDriverIO,
-    region: AbstractBaseRegion,
-    RE: RunEngine,
-) -> None:
-    RE(bps.mv(sim_driver, region))
-
-    expected_slices = region.slices
-    expected_iterations = region.iterations
-    get_mock_put(sim_driver.slices).assert_called_once_with(expected_slices, wait=True)
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "slices", expected_slices
-    )
+    get_mock_put(sim_driver.slices).assert_called_once_with(region.slices, wait=True)
     get_mock_put(sim_driver.iterations).assert_called_once_with(
-        expected_iterations, wait=True
+        region.iterations, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "iterations", expected_iterations
-    )
-
-
-@pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_that_data_to_read_is_correct(
-    sim_driver: AbstractAnalyserDriverIO,
-    region: AbstractBaseRegion,
-    RE: RunEngine,
-) -> None:
-    RE(bps.mv(sim_driver, region))
+    mock_values = 10
+    set_mock_value(sim_driver.total_steps, mock_values)
+    set_mock_value(sim_driver.step_time, mock_values)
 
     expected_total_time = math.prod(
         await asyncio.gather(
@@ -171,12 +106,63 @@ async def test_that_data_to_read_is_correct(
             sim_driver.step_time.get_value(),
         )
     )
-    assert await sim_driver.total_time.get_value() == expected_total_time
+
+    # Depends on implementation, so get directly from device.
+    energy_axis = await sim_driver.energy_axis.get_value()
+    binding_axis = await sim_driver.binding_energy_axis.get_value()
+    angle_axis = await sim_driver.angle_axis.get_value()
+
+    # Check partial match as different analysers will have more fields
+    await assert_configuration(
+        sim_driver,
+        {
+            "sim_driver-region_name": {"value": region.name},
+            "sim_driver-energy_mode": {"value": region.energy_mode},
+            "sim_driver-acquisition_mode": {"value": region.acquisition_mode},
+            "sim_driver-lens_mode": {"value": region.lens_mode},
+            "sim_driver-low_energy": {"value": expected_low_e},
+            "sim_driver-high_energy": {"value": expected_high_e},
+            "sim_driver-pass_energy": {"value": expected_pass_e},
+            "sim_driver-excitation_energy": {"value": excitation_energy},
+            "sim_driver-excitation_energy_source": {"value": energy_source.name},
+            "sim_driver-energy_step": {
+                "value": region.energy_step
+            },  # Wont work with Specs
+            "sim_driver-slices": {"value": region.slices},
+            "sim_driver-iterations": {"value": region.iterations},
+            "sim_driver-total_steps": {"value": mock_values},
+            "sim_driver-step_time": {"value": mock_values},
+            "sim_driver-total_time": {"value": expected_total_time},
+            "sim_driver-energy_axis": {"value": energy_axis},
+            "sim_driver-binding_energy_axis": {"value": binding_axis},
+            "sim_driver-angle_axis": {"value": angle_axis},
+        },
+        # full_match=False
+    )
+
+
+@pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
+async def test_analyser_reading_is_correct(
+    sim_driver: AbstractAnalyserDriverIO,
+    region: AbstractBaseRegion,
+    RE: RunEngine,
+) -> None:
+    energy_source = sim_driver._get_energy_source(region.excitation_energy_source)
+    excitation_energy = await energy_source.get_value()
 
     spectrum = np.array([1, 2, 3, 4, 5], dtype=float)
     expected_total_intensity = np.sum(spectrum)
     set_mock_value(sim_driver.spectrum, spectrum)
-    assert await sim_driver.total_intensity.get_value() == expected_total_intensity
+
+    await assert_reading(
+        sim_driver,
+        {
+            "sim_driver-excitation_energy": {"value": excitation_energy},
+            "sim_driver-image": {"value": []},
+            "sim_driver-spectrum": {"value": spectrum},
+            "sim_driver-total_intensity": {"value": expected_total_intensity},
+        },
+    )
 
 
 @pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)

--- a/tests/devices/unit_tests/electron_analyser/specs/test_driver_io.py
+++ b/tests/devices/unit_tests/electron_analyser/specs/test_driver_io.py
@@ -1,14 +1,13 @@
+from typing import Any
+
 import numpy as np
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
-from ophyd_async.testing import (
-    get_mock_put,
-    set_mock_value,
-)
+from ophyd_async.testing import assert_configuration, get_mock_put, set_mock_value
 
 from dodal.devices.b07 import LensMode
-from dodal.devices.electron_analyser import EnergyMode
+from dodal.devices.electron_analyser import EnergyMode, to_kinetic_energy
 from dodal.devices.electron_analyser.specs import (
     AcquisitionMode,
     SpecsAnalyserDriverIO,
@@ -16,7 +15,6 @@ from dodal.devices.electron_analyser.specs import (
 )
 from tests.devices.unit_tests.electron_analyser.util import (
     TEST_SEQUENCE_REGION_NAMES,
-    assert_read_configuration_has_expected_value,
 )
 
 
@@ -26,59 +24,54 @@ def driver_class() -> type[SpecsAnalyserDriverIO[LensMode]]:
 
 
 @pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_analyser_sets_energy_values_correctly(
+async def test_analyser_sets_region_and_configuration_is_correct(
     sim_driver: SpecsAnalyserDriverIO,
     region: SpecsRegion,
     RE: RunEngine,
 ) -> None:
-    RE(bps.mv(sim_driver, region))
-
+    # ToDo - Put energy step and centre energy into abstract, remove if statements.
     if region.acquisition_mode == AcquisitionMode.FIXED_TRANSMISSION:
-        get_mock_put(sim_driver.centre_energy).assert_called_once_with(
-            region.centre_energy, wait=True
-        )
-        await assert_read_configuration_has_expected_value(
-            sim_driver, "centre_energy", region.centre_energy
-        )
-    else:
-        get_mock_put(sim_driver.centre_energy).assert_not_called()
-
-    if region.acquisition_mode == AcquisitionMode.FIXED_ENERGY:
         get_mock_put(sim_driver.energy_step).assert_called_once_with(
             region.energy_step, wait=True
-        )
-        await assert_read_configuration_has_expected_value(
-            sim_driver, "energy_step", region.energy_step
         )
     else:
         get_mock_put(sim_driver.energy_step).assert_not_called()
 
-
-@pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_analyser_sets_modes_correctly(
-    sim_driver: SpecsAnalyserDriverIO[LensMode],
-    region: SpecsRegion,
-    RE: RunEngine,
-) -> None:
-    RE(bps.mv(sim_driver, region))
+    if region.acquisition_mode == AcquisitionMode.FIXED_ENERGY:
+        source = sim_driver._get_energy_source(region.excitation_energy_source)
+        excitation_energy = await source.get_value()
+        expected_centre_e = to_kinetic_energy(
+            region.centre_energy, region.energy_mode, excitation_energy
+        )
+        get_mock_put(sim_driver.centre_energy).assert_called_once_with(
+            expected_centre_e, wait=True
+        )
+    else:
+        get_mock_put(sim_driver.centre_energy).assert_not_called()
 
     get_mock_put(sim_driver.psu_mode).assert_called_once_with(
         region.psu_mode, wait=True
-    )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "psu_mode", region.psu_mode
     )
 
     get_mock_put(sim_driver.snapshot_values).assert_called_once_with(
         region.values, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "snapshot_values", region.values
+
+    # Check partial match, check only specific fields not covered by abstract class
+    await assert_configuration(
+        sim_driver,
+        {
+            "sim_driver-centre_energy": {"value": Any},
+            "sim_driver-energy_step": {"value": region.energy_step},
+            "sim_driver-psu_mode": {"value": region.psu_mode},
+            "sim_driver-snapshot_values": {"value": region.values},
+        },
+        # full_match=False
     )
 
 
 @pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_that_data_to_read_is_correct(
+async def test_specs_analyser_binding_energy_axis(
     sim_driver: SpecsAnalyserDriverIO,
     region: SpecsRegion,
     RE: RunEngine,

--- a/tests/devices/unit_tests/electron_analyser/util.py
+++ b/tests/devices/unit_tests/electron_analyser/util.py
@@ -1,8 +1,6 @@
 import os
 from typing import Any
 
-from ophyd_async.core import StandardReadable
-
 from dodal.devices.electron_analyser import EnergyMode
 from dodal.devices.electron_analyser.abstract import (
     AbstractBaseRegion,
@@ -66,19 +64,3 @@ def assert_region_has_expected_values(
 
     for key in expected_region_values.keys():
         assert r.__dict__.get(key) is not None
-
-
-async def assert_read_configuration_has_expected_value(
-    device: StandardReadable, key: str, expected_value
-) -> None:
-    read_config = await device.read_configuration()
-    try:
-        assert (
-            read_config[device.name + device._child_name_separator + key]["value"]
-            == expected_value
-        )
-    except KeyError as e:
-        raise KeyError(
-            f'Cannot find key "{key}" in read_configuration method. Following keys '
-            + f"are {read_config.keys()}"
-        ) from e

--- a/tests/devices/unit_tests/electron_analyser/vgscienta/test_driver_io.py
+++ b/tests/devices/unit_tests/electron_analyser/vgscienta/test_driver_io.py
@@ -3,10 +3,7 @@ import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from ophyd_async.epics.adcore import ADImageMode
-from ophyd_async.testing import (
-    get_mock_put,
-    set_mock_value,
-)
+from ophyd_async.testing import assert_configuration, get_mock_put, set_mock_value
 
 from dodal.devices.electron_analyser import (
     EnergyMode,
@@ -19,7 +16,6 @@ from dodal.devices.electron_analyser.vgscienta import (
 from dodal.devices.i09 import LensMode
 from tests.devices.unit_tests.electron_analyser.util import (
     TEST_SEQUENCE_REGION_NAMES,
-    assert_read_configuration_has_expected_value,
 )
 
 
@@ -29,31 +25,19 @@ def driver_class() -> type[VGScientaAnalyserDriverIO[LensMode]]:
 
 
 @pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_analyser_sets_modes_correctly(
+async def test_analyser_sets_region_and_reads_correctly(
     sim_driver: VGScientaAnalyserDriverIO,
     region: VGScientaRegion,
     RE: RunEngine,
 ) -> None:
     RE(bps.mv(sim_driver, region))
 
-    get_mock_put(sim_driver.detector_mode).assert_called_once_with(
-        region.detector_mode, wait=True
-    )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "detector_mode", region.detector_mode
-    )
     get_mock_put(sim_driver.image_mode).assert_called_once_with(
         ADImageMode.SINGLE, wait=True
     )
-
-
-@pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_analyser_sets_energy_values_correctly(
-    sim_driver: VGScientaAnalyserDriverIO,
-    region: VGScientaRegion,
-    RE: RunEngine,
-) -> None:
-    RE(bps.mv(sim_driver, region))
+    get_mock_put(sim_driver.detector_mode).assert_called_once_with(
+        region.detector_mode, wait=True
+    )
 
     excitation_energy = await sim_driver._get_energy_source(
         region.excitation_energy_source
@@ -67,38 +51,17 @@ async def test_given_region_that_analyser_sets_energy_values_correctly(
     get_mock_put(sim_driver.centre_energy).assert_called_once_with(
         expected_centre_e, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "centre_energy", expected_centre_e
-    )
     get_mock_put(sim_driver.energy_step).assert_called_once_with(
         region.energy_step, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "energy_step", region.energy_step
-    )
-
-
-@pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_given_region_that_vgscienta_sets_channel_correctly(
-    sim_driver: VGScientaAnalyserDriverIO,
-    region: VGScientaRegion,
-    RE: RunEngine,
-) -> None:
-    RE(bps.mv(sim_driver, region))
 
     expected_first_x = region.first_x_channel
     expected_size_x = region.x_channel_size()
     get_mock_put(sim_driver.first_x_channel).assert_called_once_with(
         expected_first_x, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "first_x_channel", expected_first_x
-    )
     get_mock_put(sim_driver.x_channel_size).assert_called_once_with(
         expected_size_x, wait=True
-    )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "x_channel_size", expected_size_x
     )
 
     expected_first_y = region.first_y_channel
@@ -106,19 +69,28 @@ async def test_given_region_that_vgscienta_sets_channel_correctly(
     get_mock_put(sim_driver.first_y_channel).assert_called_once_with(
         expected_first_y, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "first_y_channel", expected_first_y
-    )
     get_mock_put(sim_driver.y_channel_size).assert_called_once_with(
         expected_size_y, wait=True
     )
-    await assert_read_configuration_has_expected_value(
-        sim_driver, "y_channel_size", expected_size_y
+
+    # Check partial match, check only specific fields not covered by abstract class
+    await assert_configuration(
+        sim_driver,
+        {
+            "sim_driver-centre_energy": {"value": expected_centre_e},
+            "sim_driver-detector_mode": {"value": region.detector_mode},
+            "sim_driver-energy_step": {"value": region.energy_step},
+            "sim_driver-first_x_channel": {"value": region.first_x_channel},
+            "sim_driver-x_channel_size": {"value": region.x_channel_size()},
+            "sim_driver-first_y_channel": {"value": region.first_y_channel},
+            "sim_driver-y_channel_size": {"value": region.y_channel_size()},
+        },
+        # full_match=False
     )
 
 
 @pytest.mark.parametrize("region", TEST_SEQUENCE_REGION_NAMES, indirect=True)
-async def test_that_data_to_read_is_correct(
+async def test_analayser_binding_energy_is_correct(
     sim_driver: VGScientaAnalyserDriverIO,
     region: VGScientaRegion,
 ) -> None:


### PR DESCRIPTION
Fixes #ISSUE

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
