### PR TITLE
Update tests to use partial_reading from ophyd-async

### DIFF
--- a/tests/devices/i18/test_kb_mirror.py
+++ b/tests/devices/i18/test_kb_mirror.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.i18.KBMirror import KBMirror
 
@@ -28,23 +28,11 @@ async def test_setting_xy_position_kbmirror(kbmirror: KBMirror):
     await assert_reading(
         kbmirror,
         {
-            "kbmirror-y": {
-                "value": 4.56,
-            },
-            "kbmirror-bend1": {
-                "value": 0.0,
-            },
-            "kbmirror-ellip": {
-                "value": 0.0,
-            },
-            "kbmirror-x": {
-                "value": 1.23,
-            },
-            "kbmirror-bend2": {
-                "value": 0.0,
-            },
-            "kbmirror-curve": {
-                "value": 0.0,
-            },
+            "kbmirror-y": partial_reading(4.56),
+            "kbmirror-bend1": partial_reading(0.0),
+            "kbmirror-ellip": partial_reading(0.0),
+            "kbmirror-x": partial_reading(1.23),
+            "kbmirror-bend2": partial_reading(0.0),
+            "kbmirror-curve": partial_reading(0.0),
         },
     )

--- a/tests/devices/i18/test_table.py
+++ b/tests/devices/i18/test_table.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.i18.table import Table
 
@@ -21,18 +21,10 @@ async def test_setting_xy_position_table(table: Table):
     await assert_reading(
         table,
         {
-            "table-y": {
-                "value": 0.0,
-            },
-            "table-x": {
-                "value": 0.0,
-            },
-            "table-theta": {
-                "value": 0.0,
-            },
-            "table-z": {
-                "value": 0.0,
-            },
+            "table-y": partial_reading(0.0),
+            "table-x": partial_reading(0.0),
+            "table-theta": partial_reading(0.0),
+            "table-z": partial_reading(0.0),
         },
     )
 
@@ -43,18 +35,10 @@ async def test_setting_xy_position_table(table: Table):
     await assert_reading(
         table,
         {
-            "table-y": {
-                "value": 4.56,
-            },
-            "table-x": {
-                "value": 1.23,
-            },
-            "table-theta": {
-                "value": 0.0,
-            },
-            "table-z": {
-                "value": 0,
-            },
+            "table-y": partial_reading(4.56),
+            "table-x": partial_reading(1.23),
+            "table-theta": partial_reading(0.0),
+            "table-z": partial_reading(0),
         },
     )
 
@@ -66,18 +50,10 @@ async def test_setting_xyztheta_position_table(table: Table):
     await assert_reading(
         table,
         {
-            "table-y": {
-                "value": 0.0,
-            },
-            "table-x": {
-                "value": 0.0,
-            },
-            "table-theta": {
-                "value": 0.0,
-            },
-            "table-z": {
-                "value": 0.0,
-            },
+            "table-y": partial_reading(0.0),
+            "table-x": partial_reading(0.0),
+            "table-theta": partial_reading(0.0),
+            "table-z": partial_reading(0.0),
         },
     )
 
@@ -90,17 +66,9 @@ async def test_setting_xyztheta_position_table(table: Table):
     await assert_reading(
         table,
         {
-            "table-y": {
-                "value": 4.56,
-            },
-            "table-x": {
-                "value": 1.23,
-            },
-            "table-theta": {
-                "value": 10.11,
-            },
-            "table-z": {
-                "value": 7.89,
-            },
+            "table-y": partial_reading(4.56),
+            "table-x": partial_reading(1.23),
+            "table-theta": partial_reading(10.11),
+            "table-z": partial_reading(7.89),
         },
     )

--- a/tests/devices/i18/test_thor_labs_stage.py
+++ b/tests/devices/i18/test_thor_labs_stage.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.i18.thor_labs_stage import ThorLabsStage
 
@@ -21,12 +21,8 @@ async def test_setting(thor_labs_stage: ThorLabsStage):
     await assert_reading(
         thor_labs_stage,
         {
-            "thor_labs_stage-x": {
-                "value": 0.0,
-            },
-            "thor_labs_stage-y": {
-                "value": 0.0,
-            },
+            "thor_labs_stage-x": partial_reading(0.0),
+            "thor_labs_stage-y": partial_reading(0.0),
         },
     )
 
@@ -38,11 +34,7 @@ async def test_setting(thor_labs_stage: ThorLabsStage):
     await assert_reading(
         thor_labs_stage,
         {
-            "thor_labs_stage-x": {
-                "value": 5.0,
-            },
-            "thor_labs_stage-y": {
-                "value": 5.0,
-            },
+            "thor_labs_stage-x": partial_reading(5.0),
+            "thor_labs_stage-y": partial_reading(5.0),
         },
     )

--- a/tests/devices/i19/test_shutter.py
+++ b/tests/devices/i19/test_shutter.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp.client import ClientConnectionError
 from bluesky.run_engine import RunEngine
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.hutch_shutter import (
     ShutterDemand,
@@ -47,9 +47,7 @@ async def test_read_on_eh1_shutter_device_returns_correct_status(
     await assert_reading(
         eh1_shutter,
         {
-            "mock_shutter-shutter_status": {
-                "value": ShutterState.CLOSED,
-            }
+            "mock_shutter-shutter_status": partial_reading(ShutterState.CLOSED),
         },
     )
 
@@ -60,9 +58,7 @@ async def test_read_on_eh2_shutter_device_returns_correct_status(
     await assert_reading(
         eh2_shutter,
         {
-            "mock_shutter-shutter_status": {
-                "value": ShutterState.CLOSED,
-            }
+            "mock_shutter-shutter_status": partial_reading(ShutterState.CLOSED),
         },
     )
 

--- a/tests/devices/i22/test_dcm.py
+++ b/tests/devices/i22/test_dcm.py
@@ -6,6 +6,7 @@ from ophyd_async.testing import (
     assert_configuration,
     assert_emitted,
     assert_reading,
+    partial_reading,
     set_mock_value,
 )
 
@@ -68,51 +69,21 @@ async def test_reading(dcm: DCM):
     await assert_reading(
         dcm,
         {
-            "dcm-backplate_temp": {
-                "value": 0.0,
-            },
-            "dcm-bragg_in_degrees": {
-                "value": 0.0,
-            },
-            "dcm-crystal_1_heater_temp": {
-                "value": 0.0,
-            },
-            "dcm-crystal_1_temp": {
-                "value": 0.0,
-            },
-            "dcm-crystal_2_heater_temp": {
-                "value": 0.0,
-            },
-            "dcm-crystal_2_temp": {
-                "value": 0.0,
-            },
-            "dcm-crystal_metadata_d_spacing_a": {
-                "value": 0.0,
-            },
-            "dcm-energy_in_kev": {
-                "value": 0.0,
-            },
-            "dcm-offset_in_mm": {
-                "value": 0.0,
-            },
-            "dcm-perp": {
-                "value": 0.0,
-            },
-            "dcm-perp_temp": {
-                "value": 0.0,
-            },
-            "dcm-wavelength_in_a": {
-                "value": 0.0,
-            },
-            "dcm-xtal_1-roll_in_mrad": {
-                "value": 0.0,
-            },
-            "dcm-xtal_2-pitch_in_mrad": {
-                "value": 0.0,
-            },
-            "dcm-xtal_2-roll_in_mrad": {
-                "value": 0.0,
-            },
+            "dcm-backplate_temp": partial_reading(0.0),
+            "dcm-bragg_in_degrees": partial_reading(0.0),
+            "dcm-crystal_1_heater_temp": partial_reading(0.0),
+            "dcm-crystal_1_temp": partial_reading(0.0),
+            "dcm-crystal_2_heater_temp": partial_reading(0.0),
+            "dcm-crystal_2_temp": partial_reading(0.0),
+            "dcm-crystal_metadata_d_spacing_a": partial_reading(0.0),
+            "dcm-energy_in_kev": partial_reading(0.0),
+            "dcm-offset_in_mm": partial_reading(0.0),
+            "dcm-perp": partial_reading(0.0),
+            "dcm-perp_temp": partial_reading(0.0),
+            "dcm-wavelength_in_a": partial_reading(0.0),
+            "dcm-xtal_1-roll_in_mrad": partial_reading(0.0),
+            "dcm-xtal_2-pitch_in_mrad": partial_reading(0.0),
+            "dcm-xtal_2-roll_in_mrad": partial_reading(0.0),
         },
     )
 
@@ -121,97 +92,37 @@ async def test_configuration(dcm: DCM):
     await assert_configuration(
         dcm,
         {
-            "dcm-bragg_in_degrees-motor_egu": {
-                "value": "",
-            },
-            "dcm-bragg_in_degrees-offset": {
-                "value": 0.0,
-            },
-            "dcm-bragg_in_degrees-velocity": {
-                "value": 0.0,
-            },
-            "dcm-crystal_1_d_spacing": {
-                "value": 0.31356,
-            },
-            "dcm-crystal_1_reflection": {"value": [1, 1, 1]},
-            "dcm-crystal_1_type": {
-                "value": "silicon",
-            },
-            "dcm-crystal_1_usage": {
-                "value": "Bragg",
-            },
-            "dcm-crystal_2_d_spacing": {
-                "value": 0.31356,
-            },
-            "dcm-crystal_2_reflection": {"value": [1, 1, 1]},
-            "dcm-crystal_2_type": {
-                "value": "silicon",
-            },
-            "dcm-crystal_2_usage": {
-                "value": "Bragg",
-            },
-            "dcm-energy_in_kev-motor_egu": {
-                "value": "",
-            },
-            "dcm-energy_in_kev-offset": {
-                "value": 0.0,
-            },
-            "dcm-energy_in_kev-velocity": {
-                "value": 0.0,
-            },
-            "dcm-offset_in_mm-motor_egu": {
-                "value": "",
-            },
-            "dcm-offset_in_mm-offset": {
-                "value": 0.0,
-            },
-            "dcm-offset_in_mm-velocity": {
-                "value": 0.0,
-            },
-            "dcm-perp-motor_egu": {
-                "value": "",
-            },
-            "dcm-perp-offset": {
-                "value": 0.0,
-            },
-            "dcm-perp-velocity": {
-                "value": 0.0,
-            },
-            "dcm-wavelength_in_a-motor_egu": {
-                "value": "",
-            },
-            "dcm-wavelength_in_a-offset": {
-                "value": 0.0,
-            },
-            "dcm-wavelength_in_a-velocity": {
-                "value": 0.0,
-            },
-            "dcm-xtal_1-roll_in_mrad-motor_egu": {
-                "value": "",
-            },
-            "dcm-xtal_1-roll_in_mrad-offset": {
-                "value": 0.0,
-            },
-            "dcm-xtal_1-roll_in_mrad-velocity": {
-                "value": 0.0,
-            },
-            "dcm-xtal_2-pitch_in_mrad-motor_egu": {
-                "value": "",
-            },
-            "dcm-xtal_2-pitch_in_mrad-offset": {
-                "value": 0.0,
-            },
-            "dcm-xtal_2-pitch_in_mrad-velocity": {
-                "value": 0.0,
-            },
-            "dcm-xtal_2-roll_in_mrad-motor_egu": {
-                "value": "",
-            },
-            "dcm-xtal_2-roll_in_mrad-offset": {
-                "value": 0.0,
-            },
-            "dcm-xtal_2-roll_in_mrad-velocity": {
-                "value": 0.0,
-            },
+            "dcm-bragg_in_degrees-motor_egu": partial_reading(""),
+            "dcm-bragg_in_degrees-offset": partial_reading(0.0),
+            "dcm-bragg_in_degrees-velocity": partial_reading(0.0),
+            "dcm-crystal_1_d_spacing": partial_reading(0.31356),
+            "dcm-crystal_1_reflection": partial_reading([1, 1, 1]),
+            "dcm-crystal_1_type": partial_reading("silicon"),
+            "dcm-crystal_1_usage": partial_reading("Bragg"),
+            "dcm-crystal_2_d_spacing": partial_reading(0.31356),
+            "dcm-crystal_2_reflection": partial_reading([1, 1, 1]),
+            "dcm-crystal_2_type": partial_reading("silicon"),
+            "dcm-crystal_2_usage": partial_reading("Bragg"),
+            "dcm-energy_in_kev-motor_egu": partial_reading(""),
+            "dcm-energy_in_kev-offset": partial_reading(0.0),
+            "dcm-energy_in_kev-velocity": partial_reading(0.0),
+            "dcm-offset_in_mm-motor_egu": partial_reading(""),
+            "dcm-offset_in_mm-offset": partial_reading(0.0),
+            "dcm-offset_in_mm-velocity": partial_reading(0.0),
+            "dcm-perp-motor_egu": partial_reading(""),
+            "dcm-perp-offset": partial_reading(0.0),
+            "dcm-perp-velocity": partial_reading(0.0),
+            "dcm-wavelength_in_a-motor_egu": partial_reading(""),
+            "dcm-wavelength_in_a-offset": partial_reading(0.0),
+            "dcm-wavelength_in_a-velocity": partial_reading(0.0),
+            "dcm-xtal_1-roll_in_mrad-motor_egu": partial_reading(""),
+            "dcm-xtal_1-roll_in_mrad-offset": partial_reading(0.0),
+            "dcm-xtal_1-roll_in_mrad-velocity": partial_reading(0.0),
+            "dcm-xtal_2-pitch_in_mrad-motor_egu": partial_reading(""),
+            "dcm-xtal_2-pitch_in_mrad-offset": partial_reading(0.0),
+            "dcm-xtal_2-pitch_in_mrad-velocity": partial_reading(0.0),
+            "dcm-xtal_2-roll_in_mrad-motor_egu": partial_reading(""),
+            "dcm-xtal_2-roll_in_mrad-offset": partial_reading(0.0),
+            "dcm-xtal_2-roll_in_mrad-velocity": partial_reading(0.0),
         },
     )

--- a/tests/devices/i22/test_fswitch.py
+++ b/tests/devices/i22/test_fswitch.py
@@ -3,7 +3,7 @@ from bluesky.plans import count
 from bluesky.run_engine import RunEngine
 from event_model import DataKey
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.i22.fswitch import FilterState, FSwitch
 
@@ -29,9 +29,7 @@ async def test_reading_fswitch(fswitch: FSwitch):
     await assert_reading(
         fswitch,
         {
-            "number_of_lenses": {
-                "value": 125,  # three filters out
-            }
+            "number_of_lenses": partial_reading(125),  # three filters out
         },
     )
 

--- a/tests/devices/test_diamond_filter.py
+++ b/tests/devices/test_diamond_filter.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading
+from ophyd_async.testing import assert_reading, partial_reading
 
 from dodal.devices.diamond_filter import DiamondFilter, I03Filters, I04Filters
 
@@ -25,9 +25,7 @@ async def test_reading_includes_read_fields(
     await assert_reading(
         i03_diamond_filter,
         {
-            "diamond_filter-stage_position": {
-                "value": I03Filters.EMPTY,
-            },
+            "diamond_filter-stage_position": partial_reading(I03Filters.EMPTY),
         },
     )
 

--- a/tests/devices/training_rig/test_sample_stage.py
+++ b/tests/devices/training_rig/test_sample_stage.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading
+from ophyd_async.testing import assert_reading, partial_reading
 
 from dodal.devices.training_rig.sample_stage import TrainingRigSampleStage
 
@@ -17,11 +17,7 @@ async def test_reading_training_rig(stage: TrainingRigSampleStage):
     await assert_reading(
         stage,
         {
-            "stage-theta": {
-                "value": 0.0,
-            },
-            "stage-x": {
-                "value": 0.0,
-            },
+            "stage-theta": partial_reading(0.0),
+            "stage-x": partial_reading(0.0),
         },
     )

--- a/tests/devices/unit_tests/test_apple2_undulator.py
+++ b/tests/devices/unit_tests/test_apple2_undulator.py
@@ -12,6 +12,7 @@ from ophyd_async.testing import (
     assert_reading,
     callback_on_mock_put,
     get_mock_put,
+    partial_reading,
     set_mock_value,
 )
 
@@ -290,18 +291,10 @@ async def test_phase_success_set(mock_phaseAxes: UndulatorPhaseAxes, RE: RunEngi
     await assert_reading(
         mock_phaseAxes,
         {
-            "mock_phaseAxes-top_inner-user_readback": {
-                "value": 3,
-            },
-            "mock_phaseAxes-top_outer-user_readback": {
-                "value": 2,
-            },
-            "mock_phaseAxes-btm_inner-user_readback": {
-                "value": 5,
-            },
-            "mock_phaseAxes-btm_outer-user_readback": {
-                "value": 7,
-            },
+            "mock_phaseAxes-top_inner-user_readback": partial_reading(3),
+            "mock_phaseAxes-top_outer-user_readback": partial_reading(2),
+            "mock_phaseAxes-btm_inner-user_readback": partial_reading(5),
+            "mock_phaseAxes-btm_outer-user_readback": partial_reading(7),
         },
     )
 

--- a/tests/devices/unit_tests/test_backlight.py
+++ b/tests/devices/unit_tests/test_backlight.py
@@ -4,7 +4,7 @@ import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.backlight import Backlight, BacklightPosition, BacklightPower
 
@@ -22,12 +22,8 @@ async def test_backlight_can_be_written_and_read_from(fake_backlight: Backlight)
     await assert_reading(
         fake_backlight,
         {
-            "backlight-power": {
-                "value": BacklightPower.ON,
-            },
-            "backlight-position": {
-                "value": BacklightPosition.IN,
-            },
+            "backlight-power": partial_reading(BacklightPower.ON),
+            "backlight-position": partial_reading(BacklightPosition.IN),
         },
     )
 

--- a/tests/devices/unit_tests/test_baton.py
+++ b/tests/devices/unit_tests/test_baton.py
@@ -1,6 +1,6 @@
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading
+from ophyd_async.testing import assert_reading, partial_reading
 
 from dodal.devices.baton import Baton
 
@@ -11,11 +11,7 @@ async def test_mock_baton_can_be_initialised_and_read(RE: RunEngine):
     await assert_reading(
         baton,
         {
-            "baton-current_user": {
-                "value": "",
-            },
-            "baton-requested_user": {
-                "value": "",
-            },
+            "baton-current_user": partial_reading(""),
+            "baton-requested_user": partial_reading(""),
         },
     )

--- a/tests/devices/unit_tests/test_motors.py
+++ b/tests/devices/unit_tests/test_motors.py
@@ -1,7 +1,7 @@
 import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading
+from ophyd_async.testing import assert_reading, partial_reading
 
 from dodal.devices.motors import SixAxisGonio
 
@@ -18,23 +18,11 @@ async def test_reading_six_axis_gonio(six_axis_gonio: SixAxisGonio):
     await assert_reading(
         six_axis_gonio,
         {
-            "gonio-omega": {
-                "value": 0.0,
-            },
-            "gonio-kappa": {
-                "value": 0.0,
-            },
-            "gonio-phi": {
-                "value": 0.0,
-            },
-            "gonio-z": {
-                "value": 0.0,
-            },
-            "gonio-y": {
-                "value": 0.0,
-            },
-            "gonio-x": {
-                "value": 0.0,
-            },
+            "gonio-omega": partial_reading(0.0),
+            "gonio-kappa": partial_reading(0.0),
+            "gonio-phi": partial_reading(0.0),
+            "gonio-z": partial_reading(0.0),
+            "gonio-y": partial_reading(0.0),
+            "gonio-x": partial_reading(0.0),
         },
     )

--- a/tests/devices/unit_tests/test_pressure_jump_cell.py
+++ b/tests/devices/unit_tests/test_pressure_jump_cell.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.pressure_jump_cell import (
     FastValveControlRequest,
@@ -39,18 +39,16 @@ async def test_reading_pjumpcell_includes_read_fields_valves(
     await assert_reading(
         cell.all_valves_control,
         {
-            "pjump-all_valves_control-valve_states-1": {
-                "value": ValveState.CLOSED,
-            },
-            "pjump-all_valves_control-valve_states-3": {
-                "value": ValveState.OPEN,
-            },
-            "pjump-all_valves_control-fast_valve_states-5": {
-                "value": FastValveState.CLOSED_ARMED,
-            },
-            "pjump-all_valves_control-fast_valve_states-6": {
-                "value": FastValveState.OPEN_ARMED,
-            },
+            "pjump-all_valves_control-valve_states-1": partial_reading(
+                ValveState.CLOSED
+            ),
+            "pjump-all_valves_control-valve_states-3": partial_reading(ValveState.OPEN),
+            "pjump-all_valves_control-fast_valve_states-5": partial_reading(
+                FastValveState.CLOSED_ARMED
+            ),
+            "pjump-all_valves_control-fast_valve_states-6": partial_reading(
+                FastValveState.OPEN_ARMED
+            ),
         },
     )
 
@@ -92,12 +90,12 @@ async def test_reading_pjumpcell_includes_config_fields_valves(
     await assert_reading(
         cell.all_valves_control.valve_control[1],
         {
-            "pjump-all_valves_control-valve_control-1-open": {
-                "value": int(ValveOpenSeqRequest.INACTIVE.value),
-            },
-            "pjump-all_valves_control-valve_control-1-close": {
-                "value": ValveControlRequest.CLOSE,
-            },
+            "pjump-all_valves_control-valve_control-1-open": partial_reading(
+                int(ValveOpenSeqRequest.INACTIVE.value)
+            ),
+            "pjump-all_valves_control-valve_control-1-close": partial_reading(
+                ValveControlRequest.CLOSE
+            ),
         },
     )
 
@@ -137,23 +135,23 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
         assert_reading(
             cell.all_valves_control.valve_control[1],
             {
-                "pjump-all_valves_control-valve_control-1-open": {
-                    "value": int(ValveOpenSeqRequest.OPEN_SEQ.value),
-                },
-                "pjump-all_valves_control-valve_control-1-close": {
-                    "value": ValveControlRequest.CLOSE,
-                },
+                "pjump-all_valves_control-valve_control-1-open": partial_reading(
+                    int(ValveOpenSeqRequest.OPEN_SEQ.value)
+                ),
+                "pjump-all_valves_control-valve_control-1-close": partial_reading(
+                    ValveControlRequest.CLOSE
+                ),
             },
         ),
         assert_reading(
             cell.all_valves_control.fast_valve_control[6],
             {
-                "pjump-all_valves_control-fast_valve_control-6-open": {
-                    "value": int(ValveOpenSeqRequest.OPEN_SEQ.value),
-                },
-                "pjump-all_valves_control-fast_valve_control-6-close": {
-                    "value": FastValveControlRequest.ARM,
-                },
+                "pjump-all_valves_control-fast_valve_control-6-open": partial_reading(
+                    int(ValveOpenSeqRequest.OPEN_SEQ.value)
+                ),
+                "pjump-all_valves_control-fast_valve_control-6-close": partial_reading(
+                    FastValveControlRequest.ARM
+                ),
             },
         ),
     )
@@ -163,12 +161,12 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
     await assert_reading(
         cell.all_valves_control.valve_control[1],
         {
-            "pjump-all_valves_control-valve_control-1-open": {
-                "value": int(ValveOpenSeqRequest.INACTIVE.value),
-            },
-            "pjump-all_valves_control-valve_control-1-close": {
-                "value": ValveControlRequest.CLOSE,
-            },
+            "pjump-all_valves_control-valve_control-1-open": partial_reading(
+                int(ValveOpenSeqRequest.INACTIVE.value)
+            ),
+            "pjump-all_valves_control-valve_control-1-close": partial_reading(
+                ValveControlRequest.CLOSE
+            ),
         },
     )
 
@@ -177,12 +175,12 @@ async def test_pjumpcell_set_valve_sets_valve_fields(
     await assert_reading(
         cell.all_valves_control.fast_valve_control[6],
         {
-            "pjump-all_valves_control-fast_valve_control-6-close": {
-                "value": FastValveControlRequest.ARM,
-            },
-            "pjump-all_valves_control-fast_valve_control-6-open": {
-                "value": int(ValveOpenSeqRequest.INACTIVE.value),
-            },
+            "pjump-all_valves_control-fast_valve_control-6-close": partial_reading(
+                FastValveControlRequest.ARM
+            ),
+            "pjump-all_valves_control-fast_valve_control-6-open": partial_reading(
+                int(ValveOpenSeqRequest.INACTIVE.value)
+            ),
         },
     )
 
@@ -200,15 +198,11 @@ async def test_reading_pjumpcell_includes_read_fields_pump(
     await assert_reading(
         cell.pump,
         {
-            "pjump-pump-pump_position": {
-                "value": 100,
-            },
-            "pjump-pump-pump_motor_direction": {
-                "value": PumpMotorDirectionState.FORWARD,
-            },
-            "pjump-pump-pump_speed": {
-                "value": 100,
-            },
+            "pjump-pump-pump_position": partial_reading(100),
+            "pjump-pump-pump_motor_direction": partial_reading(
+                PumpMotorDirectionState.FORWARD
+            ),
+            "pjump-pump-pump_speed": partial_reading(100),
         },
     )
 
@@ -234,52 +228,34 @@ async def test_reading_pjumpcell_includes_read_fields_transducers(
     await assert_reading(
         cell.pressure_transducers[1],
         {
-            "pjump-pressure_transducers-1-omron_pressure": {
-                "value": 1001,
-            },
-            "pjump-pressure_transducers-1-omron_voltage": {
-                "value": 2.51,
-            },
-            "pjump-pressure_transducers-1-beckhoff_pressure": {
-                "value": 1001.1,
-            },
-            "pjump-pressure_transducers-1-slow_beckhoff_voltage_readout": {
-                "value": 2.51,
-            },
+            "pjump-pressure_transducers-1-omron_pressure": partial_reading(1001),
+            "pjump-pressure_transducers-1-omron_voltage": partial_reading(2.51),
+            "pjump-pressure_transducers-1-beckhoff_pressure": partial_reading(1001.1),
+            "pjump-pressure_transducers-1-slow_beckhoff_voltage_readout": partial_reading(
+                2.51
+            ),
         },
     )
     await assert_reading(
         cell.pressure_transducers[2],
         {
-            "pjump-pressure_transducers-2-omron_pressure": {
-                "value": 1002,
-            },
-            "pjump-pressure_transducers-2-omron_voltage": {
-                "value": 2.52,
-            },
-            "pjump-pressure_transducers-2-beckhoff_pressure": {
-                "value": 1002.2,
-            },
-            "pjump-pressure_transducers-2-slow_beckhoff_voltage_readout": {
-                "value": 2.52,
-            },
+            "pjump-pressure_transducers-2-omron_pressure": partial_reading(1002),
+            "pjump-pressure_transducers-2-omron_voltage": partial_reading(2.52),
+            "pjump-pressure_transducers-2-beckhoff_pressure": partial_reading(1002.2),
+            "pjump-pressure_transducers-2-slow_beckhoff_voltage_readout": partial_reading(
+                2.52
+            ),
         },
     )
     await assert_reading(
         cell.pressure_transducers[3],
         {
-            "pjump-pressure_transducers-3-omron_pressure": {
-                "value": 1003,
-            },
-            "pjump-pressure_transducers-3-omron_voltage": {
-                "value": 2.53,
-            },
-            "pjump-pressure_transducers-3-beckhoff_pressure": {
-                "value": 1003.3,
-            },
-            "pjump-pressure_transducers-3-slow_beckhoff_voltage_readout": {
-                "value": 2.53,
-            },
+            "pjump-pressure_transducers-3-omron_pressure": partial_reading(1003),
+            "pjump-pressure_transducers-3-omron_voltage": partial_reading(2.53),
+            "pjump-pressure_transducers-3-beckhoff_pressure": partial_reading(1003.3),
+            "pjump-pressure_transducers-3-slow_beckhoff_voltage_readout": partial_reading(
+                2.53
+            ),
         },
     )
 
@@ -292,8 +268,6 @@ async def test_reading_pjumpcell_includes_read_fields(
     await assert_reading(
         cell.cell_temperature,
         {
-            "pjump-cell_temperature": {
-                "value": 12.3,
-            },
+            "pjump-cell_temperature": partial_reading(12.3),
         },
     )

--- a/tests/devices/unit_tests/test_qbpm.py
+++ b/tests/devices/unit_tests/test_qbpm.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading
+from ophyd_async.testing import assert_reading, partial_reading
 
 from dodal.devices.qbpm import QBPM
 
@@ -16,8 +16,6 @@ async def test_reading_includes_read_fields(qbpm: QBPM):
     await assert_reading(
         qbpm,
         {
-            "qbpm-intensity_uA": {
-                "value": 0.0,
-            },
+            "qbpm-intensity_uA": partial_reading(0.0),
         },
     )

--- a/tests/devices/unit_tests/test_slits.py
+++ b/tests/devices/unit_tests/test_slits.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.slits import Slits
 
@@ -21,17 +21,9 @@ async def test_reading_slits_reads_gaps_and_centres(slits: Slits):
     await assert_reading(
         slits,
         {
-            "slits-x_centre": {
-                "value": 0.0,
-            },
-            "slits-x_gap": {
-                "value": 0.5,
-            },
-            "slits-y_centre": {
-                "value": 1.0,
-            },
-            "slits-y_gap": {
-                "value": 1.5,
-            },
+            "slits-x_centre": partial_reading(0.0),
+            "slits-x_gap": partial_reading(0.5),
+            "slits-y_centre": partial_reading(1.0),
+            "slits-y_gap": partial_reading(1.5),
         },
     )

--- a/tests/devices/unit_tests/test_turbo_slit.py
+++ b/tests/devices/unit_tests/test_turbo_slit.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 from bluesky import RunEngine
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.turbo_slit import TurboSlit
 
@@ -36,14 +36,8 @@ async def test_turbo_slit_read(slit: TurboSlit, RE: RunEngine):
     await assert_reading(
         slit,
         {
-            "turbo_slit-gap": {
-                "value": 0.5,
-            },
-            "turbo_slit-arc": {
-                "value": 1.0,
-            },
-            "turbo_slit-xfine": {
-                "value": 1.5,
-            },
+            "turbo_slit-gap": partial_reading(0.5),
+            "turbo_slit-arc": partial_reading(1.0),
+            "turbo_slit-xfine": partial_reading(1.5),
         },
     )

--- a/tests/devices/unit_tests/test_undulator.py
+++ b/tests/devices/unit_tests/test_undulator.py
@@ -4,6 +4,7 @@ from ophyd_async.core import init_devices
 from ophyd_async.testing import (
     assert_configuration,
     assert_reading,
+    partial_reading,
     set_mock_value,
 )
 
@@ -33,15 +34,9 @@ async def test_reading_includes_read_fields(undulator: Undulator):
     await assert_reading(
         undulator,
         {
-            "undulator-gap_access": {
-                "value": UndulatorGapAccess.ENABLED,
-            },
-            "undulator-gap_motor": {
-                "value": 0.0,
-            },
-            "undulator-current_gap": {
-                "value": 0.0,
-            },
+            "undulator-gap_access": partial_reading(UndulatorGapAccess.ENABLED),
+            "undulator-gap_motor": partial_reading(0.0),
+            "undulator-current_gap": partial_reading(0.0),
         },
     )
 
@@ -50,24 +45,12 @@ async def test_configuration_includes_configuration_fields(undulator: Undulator)
     await assert_configuration(
         undulator,
         {
-            "undulator-gap_motor-motor_egu": {
-                "value": "",
-            },
-            "undulator-gap_motor-velocity": {
-                "value": 0.0,
-            },
-            "undulator-length": {
-                "value": 2.0,
-            },
-            "undulator-poles": {
-                "value": 80,
-            },
-            "undulator-gap_discrepancy_tolerance_mm": {
-                "value": 0.002,
-            },
-            "undulator-gap_motor-offset": {
-                "value": 0.0,
-            },
+            "undulator-gap_motor-motor_egu": partial_reading(""),
+            "undulator-gap_motor-velocity": partial_reading(0.0),
+            "undulator-length": partial_reading(2.0),
+            "undulator-poles": partial_reading(80),
+            "undulator-gap_discrepancy_tolerance_mm": partial_reading(0.002),
+            "undulator-gap_motor-offset": partial_reading(0.0),
         },
     )
 

--- a/tests/devices/unit_tests/test_watsonmarlow323_pump.py
+++ b/tests/devices/unit_tests/test_watsonmarlow323_pump.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd_async.core import init_devices
-from ophyd_async.testing import assert_reading, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading, set_mock_value
 
 from dodal.devices.watsonmarlow323_pump import (
     WatsonMarlow323Pump,
@@ -27,14 +27,10 @@ async def test_reading_pump_reads_state_speed_and_direction(
     await assert_reading(
         watsonmarlow323,
         {
-            "wm_pump-state": {
-                "value": WatsonMarlow323PumpState.STOPPED,
-            },
-            "wm_pump-speed": {
-                "value": 25,
-            },
-            "wm_pump-direction": {
-                "value": WatsonMarlow323PumpDirection.CLOCKWISE,
-            },
+            "wm_pump-state": partial_reading(WatsonMarlow323PumpState.STOPPED),
+            "wm_pump-speed": partial_reading(25),
+            "wm_pump-direction": partial_reading(
+                WatsonMarlow323PumpDirection.CLOCKWISE
+            ),
         },
     )


### PR DESCRIPTION
Updates existing tests to use the `partial_reading`from ophyd-async so it is standardised. 

### Instructions to reviewer on how to test:
1. Check tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
