### PR TITLE
Add mako camera for ViSR

### DIFF
--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -64,6 +64,20 @@ def manta() -> AravisDetector:
 
 
 @device_factory()
+def mako() -> AravisDetector:
+    """
+    The camera for the imaging experiment,
+    looking at the on-axis viewing screen
+    """
+    return AravisDetector(
+        f"{PREFIX.beamline_prefix}-DI-DCAM-01:",
+        path_provider=get_path_provider(),
+        drv_suffix=CAM_SUFFIX,
+        fileio_suffix=HDF5_SUFFIX,
+    )
+
+
+@device_factory()
 def sample_stage() -> XYZStage:
     return XYZStage(
         f"{PREFIX.beamline_prefix}-MO-PPMAC-01:",


### PR DESCRIPTION
Dodal configuration for the mako camera, which is part of the imaging experimental setup.
