### PR TITLE
Fix region detector trigger by adding missing await

### DIFF
--- a/src/dodal/devices/electron_analyser/detector.py
+++ b/src/dodal/devices/electron_analyser/detector.py
@@ -48,7 +48,7 @@ class ElectronAnalyserRegionDetector(
     async def trigger(self) -> None:
         # Configure region parameters on the driver first before data collection.
         await self.driver.set(self.region)
-        super().trigger()
+        await super().trigger()
 
 
 TElectronAnalyserRegionDetector = TypeVar(

--- a/tests/devices/unit_tests/electron_analyser/abstract/test_base_detector.py
+++ b/tests/devices/unit_tests/electron_analyser/abstract/test_base_detector.py
@@ -2,7 +2,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 from bluesky import plan_stubs as bps
+from bluesky.protocols import Triggerable
 from bluesky.run_engine import RunEngine
+from ophyd_async.epics.adcore import ADBaseController
 
 from dodal.devices.electron_analyser import GenericElectronAnalyserDetector
 from dodal.devices.electron_analyser.specs import SpecsDetector
@@ -63,7 +65,30 @@ def test_analyser_detector_has_driver_as_child_and_region_detector_does_not(
         assert det.driver.parent == sim_detector
 
 
-def test_analyser_region_detector_trigger_sets_driver_with_region(
+def assert_detector_trigger_uses_controller_correctly(
+    detector: Triggerable,
+    controller: ADBaseController,
+    RE: RunEngine,
+) -> None:
+    controller.arm = AsyncMock()
+    controller.wait_for_idle = AsyncMock()
+
+    RE(bps.trigger(detector))
+
+    controller.arm.assert_awaited_once()
+    controller.wait_for_idle.assert_awaited_once()
+
+
+def test_analyser_detector_trigger(
+    sim_detector: GenericElectronAnalyserDetector,
+    RE: RunEngine,
+) -> None:
+    assert_detector_trigger_uses_controller_correctly(
+        sim_detector, sim_detector.controller, RE
+    )
+
+
+async def test_analyser_region_detector_trigger_sets_driver_with_region(
     sim_detector: GenericElectronAnalyserDetector,
     sequence_file_path: str,
     RE: RunEngine,
@@ -71,11 +96,15 @@ def test_analyser_region_detector_trigger_sets_driver_with_region(
     region_detectors = sim_detector.create_region_detector_list(
         sequence_file_path, enabled_only=False
     )
+
     for reg_det in region_detectors:
         reg_det.driver.set = AsyncMock()
 
-        RE(bps.trigger(reg_det, wait=True))
-        reg_det.driver.set.assert_called_once_with(reg_det.region)
+        assert_detector_trigger_uses_controller_correctly(
+            reg_det, reg_det.controller, RE
+        )
+
+        reg_det.driver.set.assert_awaited_once_with(reg_det.region)
 
 
 # ToDo - Add tests for BaseElectronAnalyserDetector class + controller

--- a/tests/devices/unit_tests/electron_analyser/abstract/test_base_detector.py
+++ b/tests/devices/unit_tests/electron_analyser/abstract/test_base_detector.py
@@ -73,7 +73,7 @@ def assert_detector_trigger_uses_controller_correctly(
     controller.arm = AsyncMock()
     controller.wait_for_idle = AsyncMock()
 
-    RE(bps.trigger(detector))
+    RE(bps.trigger(detector), wait=True)
 
     controller.arm.assert_awaited_once()
     controller.wait_for_idle.assert_awaited_once()


### PR DESCRIPTION
Testing electron analyser simulator, we were running into error messages when running through bluesky. Have found that the issue was the detector trigger method was never awaited.

### Instructions to reviewer on how to test:
1. Check tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
