### PR TITLE
add panda to p99

### DIFF
--- a/src/dodal/beamlines/p99.py
+++ b/src/dodal/beamlines/p99.py
@@ -82,8 +82,9 @@ def andor2_point() -> Andor2Point:
 @device_factory()
 def panda() -> HDFPanda:
     """
-    The Panda device is connected to two PMAC motors for position compare under pcomp[1] and pcomp[2] blocks,
-    which handle positive and negative directions, respectively. This setup is used for triggering detectors.
+    The Panda device is connected to two PMAC motors for position comparison under
+     the pcomp[1] and pcomp[2] blocks, which handle positive and negative directions.
+    This setup is used for triggering detectors during a flyscan.
     """
     return HDFPanda(
         f"{PREFIX.beamline_prefix}-MO-PANDA-01:",


### PR DESCRIPTION
Fixes #1342 

### Instructions to reviewer on how to test:
1. run dodal connect p99 on p99 network.
2. Confirm all panda connect. 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
