### PR TITLE
Pin epicscorelibs to 7.0.7.99.1.2a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "click",
     "ophyd",
     "ophyd-async>=0.10.0a4",
+    "epicscorelibs<=7.0.7.99.1.2a1",  # Pending https://github.com/epics-base/epicscorelibs/issues/41
     "bluesky",
     "pyepics",
     "dataclasses-json",


### PR DESCRIPTION
Pin epicscorelibs to 7.0.7.99.1.2a1 due to
logging configuration in more recent versions
breaking tests.

See https://github.com/epics-base/epicscorelibs/issues/41

### Instructions to reviewer on how to test:
1. Check CI passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
