### PR TITLE
Murko: Set uuid after sending to redis

### DIFF
--- a/src/dodal/devices/oav/oav_to_redis_forwarder.py
+++ b/src/dodal/devices/oav/oav_to_redis_forwarder.py
@@ -110,11 +110,11 @@ class OAVToRedisForwarder(StandardReadable, Flyable, Stoppable):
         pickled numpy array of pixel values but raw byes are more space efficient. There
         may be better ways of doing this, see https://github.com/DiamondLightSource/mx-bluesky/issues/592"""
         jpeg_bytes = await get_next_jpeg(response)
-        self.uuid_setter(redis_uuid)
         sample_id = await self.sample_id.get_value()
         redis_key = f"murko:{sample_id}:raw"
         await self.redis_client.hset(redis_key, redis_uuid, jpeg_bytes)  # type: ignore
         await self.redis_client.expire(redis_key, timedelta(days=self.DATA_EXPIRY_DAYS))
+        self.uuid_setter(redis_uuid)
 
     async def _open_connection_and_do_function(
         self, function_to_do: Callable[[ClientResponse, OAVSource], Awaitable]


### PR DESCRIPTION
Part of https://github.com/DiamondLightSource/mx-bluesky/issues/1163

### Instructions to reviewer on how to test:
1. Confirm new test passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
