### PR TITLE
Remove references to 3.10 and to asyncio.TimeoutError

### DIFF
--- a/docs/how-to/dev-install.md
+++ b/docs/how-to/dev-install.md
@@ -19,7 +19,7 @@ in a container under [VSCode](https://code.visualstudio.com/)
 If on a DLS machine make sure you have python >3.11 running by doing `module load python/3.11`
 
 ```
-python -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 pip install --upgrade pip
 pip install -e '.[dev]'

--- a/docs/how-to/dev-install.md
+++ b/docs/how-to/dev-install.md
@@ -8,16 +8,20 @@ First clone the repository locally using [Git](https://git-scm.com/downloads). T
 
 ## Install dependencies
 
-You can choose to either develop on the host machine using a `venv` (which requires python 3.10 or later) or to run 
+You can choose to either develop on the host machine using a `venv` (which requires python 3.11 or later) or to run 
 in a container under [VSCode](https://code.visualstudio.com/)
 
 <!-- https://sphinx-design.readthedocs.io/en/latest/tabs.html# -->
 ::::{tab-set}
 
 :::{tab-item} Local virtualenv
+
+If on a DLS machine make sure you have python >3.11 running by doing `module load python/3.11`
+
 ```
-python3 -m venv venv
+python -m venv venv
 source venv/bin/activate
+pip install --upgrade pip
 pip install -e '.[dev]'
 ```
 

--- a/docs/reference/standards.rst
+++ b/docs/reference/standards.rst
@@ -29,7 +29,7 @@ Supported Python Versions
 As a standard for the python versions to support, we should be matching the deprecation policy at 
 https://numpy.org/neps/nep-0029-deprecation_policy.html.
 
-Currently supported versions are: 3.10, 3.11, 3.12. (As of the last edit of this document.)
+Currently supported versions are: 3.11, 3.12. (As of the last edit of this document.)
 
 .. _documentation_standards:
 

--- a/src/dodal/devices/oav/pin_image_recognition/__init__.py
+++ b/src/dodal/devices/oav/pin_image_recognition/__init__.py
@@ -1,4 +1,3 @@
-import asyncio
 import time
 
 import numpy as np
@@ -160,7 +159,7 @@ class PinTipDetection(StandardReadable):
                     )
                 else:
                     break
-        except asyncio.exceptions.TimeoutError:
+        except TimeoutError:
             LOGGER.error(
                 f"No tip found in {await self.validity_timeout.get_value()} seconds."
             )

--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -178,7 +178,6 @@ class BartRobot(StandardReadable, Movable[SampleLocation]):
                 timeout=self.LOAD_TIMEOUT + self.NOT_BUSY_TIMEOUT,
             )
         except TimeoutError as e:
-            # Will only need to catch asyncio.TimeoutError after https://github.com/bluesky/ophyd-async/issues/572
             await self.prog_error.raise_if_error(e)
             await self.controller_error.raise_if_error(e)
             raise RobotLoadFailed(0, "Robot timed out") from e

--- a/src/dodal/utils.py
+++ b/src/dodal/utils.py
@@ -426,16 +426,9 @@ def is_v2_device_type(obj: type[Any]) -> bool:
             # This is all very badly documented and possibly prone to change in future versions of Python
             non_parameterized_class = obj.__origin__
         if non_parameterized_class:
-            try:
-                return non_parameterized_class and issubclass(
-                    non_parameterized_class, OphydV2Device
-                )
-            except TypeError:
-                # Python 3.10 will return inspect.isclass(t) == True but then
-                # raise TypeError: issubclass() arg 1 must be a class
-                # when inspecting device_factory decorator function itself
-                # Later versions of Python seem not to be affected
-                pass
+            return non_parameterized_class and issubclass(
+                non_parameterized_class, OphydV2Device
+            )
 
     return False
 

--- a/tests/devices/i04/test_transfocator.py
+++ b/tests/devices/i04/test_transfocator.py
@@ -70,7 +70,7 @@ async def test_if_timeout_exceeded_and_start_rbv_not_equal_to_set_value_then_tim
     with patch.object(fake_transfocator, "TIMEOUT", 0):
         given_predicted_lenses_is_half_of_beamsize(fake_transfocator)
         fake_transfocator.start_rbv.get_value = AsyncMock(side_effect=[0, 1])
-        with pytest.raises((TimeoutError, asyncio.exceptions.TimeoutError)):
+        with pytest.raises(TimeoutError):
             await fake_transfocator.set(315)
 
 

--- a/tests/devices/unit_tests/i24/test_pmac.py
+++ b/tests/devices/unit_tests/i24/test_pmac.py
@@ -119,7 +119,7 @@ async def test_counter_refresh_timeout(fake_pmac: PMAC, RE):
     )
 
     set_mock_value(fake_pmac.counter_time, 0.1)
-    with pytest.raises(asyncio.exceptions.TimeoutError):
+    with pytest.raises(TimeoutError):
         await fake_pmac.run_program.kickoff()
         await fake_pmac.run_program.complete()
 

--- a/tests/devices/unit_tests/test_apple2_undulator.py
+++ b/tests/devices/unit_tests/test_apple2_undulator.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections import defaultdict
 from unittest.mock import AsyncMock
 
@@ -128,7 +127,7 @@ async def test_given_gate_never_closes_then_setting_gaps_times_out(
     )
     mock_id_gap.get_timeout = AsyncMock(return_value=0.002)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         await mock_id_gap.set(2)
 
 
@@ -176,7 +175,7 @@ async def test_given_gate_never_closes_then_setting_phases_times_out(
         lambda *_, **__: set_mock_value(mock_phaseAxes.gate, UndulatorGateStatus.OPEN),
     )
     mock_phaseAxes.get_timeout = AsyncMock(return_value=0.002)
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         await mock_phaseAxes.set(setValue)
 
 
@@ -314,7 +313,7 @@ async def test_given_gate_never_closes_then_setting_jaw_phases_times_out(
         lambda *_, **__: set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.OPEN),
     )
     mock_jaw_phase.get_timeout = AsyncMock(return_value=0.002)
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         await mock_jaw_phase.set(2)
 
 

--- a/tests/devices/unit_tests/test_attenuator.py
+++ b/tests/devices/unit_tests/test_attenuator.py
@@ -57,5 +57,5 @@ async def test_given_attenuator_fails_to_set_filters_then_set_timeout(
 
     callback_on_mock_put(fake_attenuator._change, mock_apply_values)
 
-    with pytest.raises(asyncio.exceptions.TimeoutError):
+    with pytest.raises(TimeoutError):
         await asyncio.wait_for(fake_attenuator.set(0.65), timeout=0.01)

--- a/tests/devices/unit_tests/test_focusing_mirror.py
+++ b/tests/devices/unit_tests/test_focusing_mirror.py
@@ -1,9 +1,4 @@
 import asyncio
-
-# prevent python 3.10 exception doppelganger stupidity
-# see https://docs.python.org/3.10/library/asyncio-exceptions.html
-# https://github.com/python/cpython/issues?q=is%3Aissue+timeouterror++alias+
-from asyncio import TimeoutError
 from unittest.mock import ANY, DEFAULT, patch
 
 import pytest

--- a/tests/devices/unit_tests/test_gridscan.py
+++ b/tests/devices/unit_tests/test_gridscan.py
@@ -1,5 +1,4 @@
-import asyncio
-from asyncio import TimeoutError, wait_for
+from asyncio import wait_for
 from contextlib import nullcontext
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -401,7 +400,7 @@ async def test_timeout_on_complete_triggers_stop_and_logs_error(
     zebra_fast_grid_scan.COMPLETE_STATUS = 0.01
     zebra_fast_grid_scan.stop_cmd = AsyncMock()
     set_mock_value(zebra_fast_grid_scan.status, 1)
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         await zebra_fast_grid_scan.complete()
     mock_log_error.assert_called_once()
     zebra_fast_grid_scan.stop_cmd.trigger.assert_awaited_once()

--- a/tests/devices/unit_tests/test_xspress3.py
+++ b/tests/devices/unit_tests/test_xspress3.py
@@ -68,7 +68,7 @@ async def test_stage_fail_on_detector_not_busy_state(
     set_mock_value(mock_xspress3mini.acquire_rbv, AcquireRBVState.DONE)
     set_mock_value(mock_xspress3mini.detector_state, DetectorState.IDLE)
     mock_xspress3mini.timeout = 0.1
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         await mock_xspress3mini.stage()
     with pytest.raises(FailedStatus):
         RE(bps.stage(mock_xspress3mini, wait=True))
@@ -84,7 +84,7 @@ async def test_stage_fail_to_acquire_timeout(
     set_mock_value(mock_xspress3mini.detector_state, DetectorState.ACQUIRE)
     set_mock_value(mock_xspress3mini.acquire_rbv, AcquireRBVState.DONE)
     mock_xspress3mini.timeout = 0.1
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         await mock_xspress3mini.stage()
     with pytest.raises(FailedStatus):
         RE(bps.stage(mock_xspress3mini, wait=True))


### PR DESCRIPTION
Fixes #1237

### Instructions to reviewer on how to test:
1. Search 3.10 and confirm there is no reference to it
2. Confirm there are no more references to `asyncio.TimeoutError`

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
