### PR TITLE
chore(deps): Update ophyd-async to 0.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async>=0.12.3",
-    "epicscorelibs<=7.0.7.99.1.2a1", # Pending https://github.com/epics-base/epicscorelibs/issues/41
+    "ophyd-async[ca,pva]>=0.12.3",
     "bluesky",
     "pyepics",
     "dataclasses-json",
@@ -25,8 +24,6 @@ dependencies = [
     "graypy",
     "pydantic>=2.0",
     "opencv-python-headless",        # For pin-tip detection.
-    "aioca",                         # Required for CA support with ophyd-async.
-    "p4p",                           # Required for PVA support with ophyd-async.
     "numpy",
     "aiofiles",
     "aiohttp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async==0.11.0",           # Pending https://github.com/bluesky/ophyd-async/issues/976
+    "ophyd-async>=0.12.3",
     "epicscorelibs<=7.0.7.99.1.2a1", # Pending https://github.com/epics-base/epicscorelibs/issues/41
     "bluesky",
     "pyepics",

--- a/src/dodal/devices/i13_1/merlin_controller.py
+++ b/src/dodal/devices/i13_1/merlin_controller.py
@@ -12,8 +12,8 @@ from ophyd_async.epics.adcore import (
     ADBaseIO,
     ADImageMode,
     ADState,
-    stop_busy_record,
 )
+from ophyd_async.epics.core import stop_busy_record
 
 
 class MerlinController(ADBaseController):

--- a/src/dodal/devices/tetramm.py
+++ b/src/dodal/devices/tetramm.py
@@ -22,9 +22,8 @@ from ophyd_async.epics.adcore import (
     NDArrayBaseIO,
     NDFileHDFIO,
     NDPluginBaseIO,
-    stop_busy_record,
 )
-from ophyd_async.epics.core import PvSuffix
+from ophyd_async.epics.core import PvSuffix, stop_busy_record
 
 
 class TetrammRange(StrictEnum):

--- a/system_tests/test_adsim.py
+++ b/system_tests/test_adsim.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Generator
+from pathlib import PurePath
 from typing import cast
 from unittest.mock import patch
 
@@ -62,7 +63,7 @@ def with_env():
 @pytest.fixture
 def path_provider() -> Generator[PathProvider]:
     # path must be available to the `det` container, so cannot use tmp_path
-    path_provider = StaticPathProvider(UUIDFilenameProvider(), "/tmp")
+    path_provider = StaticPathProvider(UUIDFilenameProvider(), PurePath("/tmp"))
     set_path_provider(path_provider)
     yield path_provider
     clear_path_provider()

--- a/tests/devices/i13_1/test_merlin.py
+++ b/tests/devices/i13_1/test_merlin.py
@@ -62,7 +62,6 @@ async def test_can_collect(
     set_mock_value(merlin.drv.array_size_x, 10)
     set_mock_value(merlin.drv.array_size_y, 20)
     set_mock_value(merlin.hdf.num_frames_chunks, 1)
-    set_mock_value(merlin.hdf.full_file_name, "/foo/bar.hdf")
 
     await merlin.stage()
     await merlin.prepare(one_shot_trigger_info)
@@ -70,10 +69,13 @@ async def test_can_collect(
     assert len(docs) == 2
     assert docs[0][0] == "stream_resource"
     stream_resource = cast(StreamResource, docs[0][1])
-
     sr_uid = stream_resource["uid"]
     assert stream_resource["data_key"] == "merlin"
-    assert stream_resource["uri"] == "file://localhost/foo/bar.hdf"
+    expected_path = static_path_provider(merlin.name)
+    assert (
+        stream_resource["uri"]
+        == f"file://localhost{expected_path.directory_path}/{expected_path.filename}.h5"
+    )
     assert stream_resource["parameters"] == {
         "dataset": "/entry/data/data",
         "chunk_shape": (1, 20, 10),

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -1,5 +1,5 @@
 import asyncio
-from pathlib import Path
+from pathlib import Path, PurePath
 from unittest.mock import patch
 
 import pytest
@@ -41,7 +41,7 @@ def det(
             super().__init__(sleep)
             self.n_images = 0
 
-        def open_file(self, path: Path, width: int, height: int):
+        def open_file(self, path: PurePath, width: int, height: int):
             pass
 
         async def write_images_to_file(

--- a/tests/plans/test_configure_arm_trigger_and_disarm_detector.py
+++ b/tests/plans/test_configure_arm_trigger_and_disarm_detector.py
@@ -35,8 +35,12 @@ async def test_configure_arm_trigger_and_disarm_detector(
         trigger=DetectorTrigger.INTERNAL,
         deadtime=0.0001,
     )
+    filename: str = "filename.h5"
+    fake_eiger._writer._path_provider.return_value.filename = filename
 
     def set_meta_active(*args, **kwargs) -> None:
+        set_mock_value(fake_eiger.odin.meta_file_name, filename)
+        set_mock_value(fake_eiger.odin.id, filename)
         set_mock_value(fake_eiger.odin.meta_active, "Active")
 
     def set_capture_rbv_meta_writing_and_detector_state(*args, **kwargs) -> None:


### PR DESCRIPTION
Fixes [dodal main pytest issue](https://github.com/DiamondLightSource/dodal/actions/runs/16417747325/job/46475552855#step:7:1676)

The ophyd-async issue related to this is https://github.com/bluesky/ophyd-async/issues/976

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
