### PR TITLE
fix: Pin ophyd-async to 0.11.0 until StandardDetector trigger/stage timeouts investigated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async>=0.11",
+    "ophyd-async==0.11.0",  # Pending https://github.com/bluesky/ophyd-async/issues/976
     "epicscorelibs<=7.0.7.99.1.2a1",  # Pending https://github.com/epics-base/epicscorelibs/issues/41
     "bluesky",
     "pyepics",


### PR DESCRIPTION
https://github.com/bluesky/ophyd-async/issues/976


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
