### PR TITLE
chore(deps): Unpin epicscorelibs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "click",
     "ophyd",
     "ophyd-async==0.11.0",  # Pending https://github.com/bluesky/ophyd-async/issues/976
-    "epicscorelibs<=7.0.7.99.1.2a1",  # Pending https://github.com/epics-base/epicscorelibs/issues/41
+    "epicscorelibs>=7.0.7.99.1.2a3",
     "bluesky",
     "pyepics",
     "dataclasses-json",


### PR DESCRIPTION
epicscorelibs 7.0.7.99.1.2a3 was released that includes https://github.com/epics-base/epicscorelibs/issues/41 which should allow us to unpin this dependency

e: @AlexanderWells-diamond is apparently still working on a non-alpha release, and [ophyd-async support for 3.13 is awaiting Tango updates](https://github.com/bluesky/ophyd-async/pull/935). So will leave this parked momentarily.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
