### PR TITLE
create i05-1 beamline module

### DIFF
--- a/src/dodal/beamlines/__init__.py
+++ b/src/dodal/beamlines/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 # module name. Add any new beamlines whose name differs from their module name to this
 # dictionary, which maps ${BEAMLINE} to dodal.beamlines.<MODULE NAME>
 _BEAMLINE_NAME_OVERRIDES = {
+    "i05-1": "i05_1",
     "b07-1": "b07_1",
     "i09-1": "i09_1",
     "i13-1": "i13_1",

--- a/src/dodal/beamlines/i05_1.py
+++ b/src/dodal/beamlines/i05_1.py
@@ -1,0 +1,17 @@
+from dodal.common.beamlines.beamline_utils import (
+    device_factory,
+)
+from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.devices.synchrotron import Synchrotron
+from dodal.log import set_beamline as set_log_beamline
+from dodal.utils import BeamlinePrefix, get_beamline_name
+
+BL = get_beamline_name("i05-1")
+PREFIX = BeamlinePrefix(BL, suffix="J")
+set_log_beamline(BL)
+set_utils_beamline(BL)
+
+
+@device_factory()
+def synchrotron() -> Synchrotron:
+    return Synchrotron()


### PR DESCRIPTION
Fixes #1379 

### Instructions to reviewer on how to test:
1.   dodal connect i05-1
2.   Confirm no errors


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
