### PR TITLE
Fix beamstop, enum and unskip

### DIFF
--- a/src/dodal/beamlines/i19_1.py
+++ b/src/dodal/beamlines/i19_1.py
@@ -42,7 +42,7 @@ DISPLAY_CONFIG = "/dls_sw/i19-1/software/daq_configuration/domain/display.config
 
 # Needs to wait until enum is fixed on the beamline
 # See https://github.com/DiamondLightSource/dodal/issues/1150
-@device_factory(skip=True)
+@device_factory()
 def beamstop() -> BeamStop:
     """Get the i19-1 beamstop device, instantiate it if it hasn't already been.
     If this is called when already instantiated in i19-1, it will return the existing object.

--- a/src/dodal/devices/i19/beamstop.py
+++ b/src/dodal/devices/i19/beamstop.py
@@ -6,7 +6,7 @@ from dodal.devices.motors import XYZStage
 
 class HomeGroup(StrictEnum):
     NONE = "none"
-    ALL = "All"
+    ALL = "ALL"
     X = "X"
     Y = "Y"
     Z = "Z"
@@ -23,4 +23,4 @@ class BeamStop(XYZStage):
     def __init__(self, prefix: str, name: str = "") -> None:
         self.homing = HomingControl(f"{prefix}HM", name)
 
-        super().__init__(name)
+        super().__init__(prefix, name)


### PR DESCRIPTION
Fixes #1150 

- Fixes enum to new unified value for the beamstop
- Fixes missing prefix in beamstop 
- Removes skip from device instantiation

### Instructions to reviewer on how to test:
1. Run `dodal connect` for both I19-1 and i19-2 and verify it works

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
