### PR TITLE
Add roistat plugin to ViSR spectroscopy detector

### DIFF
--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -1,4 +1,5 @@
 from ophyd_async.epics.adaravis import AravisDetector
+from ophyd_async.epics.adcore import NDROIStatIO
 from ophyd_async.fastcs.panda import HDFPanda
 
 from dodal.common.beamlines.beamline_utils import (
@@ -57,11 +58,15 @@ def spectroscopy_detector() -> AravisDetector:
     Returns:
         AravisDetector: The spectroscopy camera device.
     """
+    pv_prefix = f"{PREFIX.beamline_prefix}-DI-DCAM-02:"
     return AravisDetector(
-        f"{PREFIX.beamline_prefix}-DI-DCAM-02:",
+        pv_prefix,
         path_provider=get_path_provider(),
         drv_suffix=CAM_SUFFIX,
         fileio_suffix=HDF5_SUFFIX,
+        plugins={
+            "roistat": NDROIStatIO(f"{pv_prefix}ROISTAT:", num_channels=3),
+        },
     )
 
 


### PR DESCRIPTION
- [x] Needs https://github.com/bluesky/ophyd-async/pull/975
- [x] Needs new ophyd-async release to point at

### Instructions to reviewer on how to test:
1. On b01-1-ws001 do
```
In [1]: from bluesky import RunEngine

In [2]: RE = RunEngine()

In [3]: from dodal.beamlines.b01_1 import spectroscopy_detector

In [4]: s = spectroscopy_detector(connect_immediately=True)
```

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
