### PR TITLE
chore: Refactor XBPM device to match docs expectations

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -347,7 +347,6 @@ def xbpm_feedback() -> XBPMFeedback:
     """
     return XBPMFeedback(
         f"{PREFIX.beamline_prefix}-EA-FDBK-01:",
-        stage_prefix=f"{PREFIX.beamline_prefix}-EA-XBPM-02:",
     )
 
 

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -346,7 +346,8 @@ def xbpm_feedback() -> XBPMFeedback:
     If this is called when already instantiated in i03, it will return the existing object.
     """
     return XBPMFeedback(
-        PREFIX.beamline_prefix,
+        f"{PREFIX.beamline_prefix}-EA-FDBK-01:",
+        stage_prefix=f"{PREFIX.beamline_prefix}-EA-XBPM-02:",
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -155,7 +155,6 @@ def xbpm_feedback() -> XBPMFeedback:
     """
     return XBPMFeedback(
         f"{PREFIX.beamline_prefix}-EA-FDBK-01:",
-        stage_prefix=f"{PREFIX.beamline_prefix}-EA-XBPM-02:",
     )
 
 

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -154,7 +154,8 @@ def xbpm_feedback() -> XBPMFeedback:
     If this is called when already instantiated in i04, it will return the existing object.
     """
     return XBPMFeedback(
-        PREFIX.beamline_prefix,
+        f"{PREFIX.beamline_prefix}-EA-FDBK-01:",
+        stage_prefix=f"{PREFIX.beamline_prefix}-EA-XBPM-02:",
     )
 
 

--- a/src/dodal/devices/xbpm_feedback.py
+++ b/src/dodal/devices/xbpm_feedback.py
@@ -1,8 +1,9 @@
 from bluesky.protocols import Triggerable
-from ophyd_async.core import AsyncStatus, Device, StrictEnum, observe_value
+from ophyd_async.core import AsyncStatus, StrictEnum, observe_value
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 from dodal.common.device_utils import periodic_reminder
+from dodal.devices.motors import XYStage
 
 
 class Pause(StrictEnum):
@@ -10,17 +11,17 @@ class Pause(StrictEnum):
     RUN = "Ok to Run"  # 1
 
 
-class XBPMFeedback(Device, Triggerable):
+class XBPMFeedback(XYStage, Triggerable):
     """The XBPM feedback device is an IOC that moves the DCM, HFM and VFM to automatically
     hold the beam into place, as measured by the XBPM sensor."""
 
-    def __init__(self, prefix: str, name: str = "xbpm_feedback") -> None:
-        self.pos_ok = epics_signal_r(float, prefix + "-EA-FDBK-01:XBPM2POSITION_OK")
-        self.pos_stable = epics_signal_r(float, prefix + "-EA-FDBK-01:XBPM2_STABLE")
-        self.pause_feedback = epics_signal_rw(Pause, prefix + "-EA-FDBK-01:FB_PAUSE")
-        self.x = epics_signal_r(float, prefix + "-EA-XBPM-02:PosX:MeanValue_RBV")
-        self.y = epics_signal_r(float, prefix + "-EA-XBPM-02:PosY:MeanValue_RBV")
-        super().__init__(name=name)
+    def __init__(
+        self, prefix: str, stage_prefix: str, name: str = "xbpm_feedback"
+    ) -> None:
+        self.pos_ok = epics_signal_r(float, prefix + "XBPM2POSITION_OK")
+        self.pos_stable = epics_signal_r(float, prefix + "XBPM2_STABLE")
+        self.pause_feedback = epics_signal_rw(Pause, prefix + "FB_PAUSE")
+        super().__init__(stage_prefix, x_infix="PosX", y_infix="PosY", name=name)
 
     @AsyncStatus.wrap
     async def trigger(self):

--- a/src/dodal/devices/xbpm_feedback.py
+++ b/src/dodal/devices/xbpm_feedback.py
@@ -15,9 +15,7 @@ class XBPMFeedback(XYStage, Triggerable):
     """The XBPM feedback device is an IOC that moves the DCM, HFM and VFM to automatically
     hold the beam into place, as measured by the XBPM sensor."""
 
-    def __init__(
-        self, prefix: str, stage_prefix: str, name: str = "xbpm_feedback"
-    ) -> None:
+    def __init__(self, prefix: str, stage_prefix: str, name: str = "") -> None:
         self.pos_ok = epics_signal_r(float, prefix + "XBPM2POSITION_OK")
         self.pos_stable = epics_signal_r(float, prefix + "XBPM2_STABLE")
         self.pause_feedback = epics_signal_rw(Pause, prefix + "FB_PAUSE")

--- a/src/dodal/devices/xbpm_feedback.py
+++ b/src/dodal/devices/xbpm_feedback.py
@@ -1,9 +1,8 @@
 from bluesky.protocols import Triggerable
-from ophyd_async.core import AsyncStatus, StrictEnum, observe_value
+from ophyd_async.core import AsyncStatus, Device, StrictEnum, observe_value
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 from dodal.common.device_utils import periodic_reminder
-from dodal.devices.motors import XYStage
 
 
 class Pause(StrictEnum):
@@ -11,15 +10,15 @@ class Pause(StrictEnum):
     RUN = "Ok to Run"  # 1
 
 
-class XBPMFeedback(XYStage, Triggerable):
+class XBPMFeedback(Device, Triggerable):
     """The XBPM feedback device is an IOC that moves the DCM, HFM and VFM to automatically
     hold the beam into place, as measured by the XBPM sensor."""
 
-    def __init__(self, prefix: str, stage_prefix: str, name: str = "") -> None:
+    def __init__(self, prefix: str, name: str = "") -> None:
         self.pos_ok = epics_signal_r(float, prefix + "XBPM2POSITION_OK")
         self.pos_stable = epics_signal_r(float, prefix + "XBPM2_STABLE")
         self.pause_feedback = epics_signal_rw(Pause, prefix + "FB_PAUSE")
-        super().__init__(stage_prefix, x_infix="PosX", y_infix="PosY", name=name)
+        super().__init__(name=name)
 
     @AsyncStatus.wrap
     async def trigger(self):

--- a/tests/devices/unit_tests/test_xbpm_feedback.py
+++ b/tests/devices/unit_tests/test_xbpm_feedback.py
@@ -13,8 +13,8 @@ from dodal.devices.xbpm_feedback import XBPMFeedback
 @pytest.fixture
 async def fake_xbpm_feedback() -> XBPMFeedback:
     async with init_devices(mock=True):
-        xbpm = XBPMFeedback("", stage_prefix="")
-    return xbpm
+        xbpm_feedback = XBPMFeedback("", stage_prefix="")
+    return xbpm_feedback
 
 
 def test_given_pos_stable_when_xbpm_feedback_kickoff_then_return_immediately(

--- a/tests/devices/unit_tests/test_xbpm_feedback.py
+++ b/tests/devices/unit_tests/test_xbpm_feedback.py
@@ -13,7 +13,7 @@ from dodal.devices.xbpm_feedback import XBPMFeedback
 @pytest.fixture
 async def fake_xbpm_feedback() -> XBPMFeedback:
     async with init_devices(mock=True):
-        xbpm_feedback = XBPMFeedback("", stage_prefix="")
+        xbpm_feedback = XBPMFeedback("")
     return xbpm_feedback
 
 

--- a/tests/devices/unit_tests/test_xbpm_feedback.py
+++ b/tests/devices/unit_tests/test_xbpm_feedback.py
@@ -13,7 +13,7 @@ from dodal.devices.xbpm_feedback import XBPMFeedback
 @pytest.fixture
 async def fake_xbpm_feedback() -> XBPMFeedback:
     async with init_devices(mock=True):
-        xbpm = XBPMFeedback("")
+        xbpm = XBPMFeedback("", stage_prefix="")
     return xbpm
 
 


### PR DESCRIPTION
Adjusts the XPBMFeedback device to match expectations of devices from the docs. Unlike other changes in #1388 this mildly changes the device so has been isolated into this patchset. This assumes that the PosX/PosY readback values came from a Motor record- which I have not verified so should make sure the dodal connect for the beamlines that use it still works.

### Instructions to reviewer on how to test:
1. Test that device still connects

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
