### PR TITLE
Remove sleeps from bart robot tests

### DIFF
--- a/src/dodal/devices/robot.py
+++ b/src/dodal/devices/robot.py
@@ -21,6 +21,9 @@ from ophyd_async.epics.core import (
 
 from dodal.log import LOGGER
 
+WAIT_FOR_OLD_PIN_MSG = "Waiting on old pin unloaded"
+WAIT_FOR_NEW_PIN_MSG = "Waiting on new pin loaded"
+
 
 class RobotLoadFailed(Exception):
     error_code: int
@@ -144,6 +147,7 @@ class BartRobot(StandardReadable, Movable[SampleLocation]):
             # in the current task, when it propagates to here we should cancel all pending tasks before bubbling up
             for task in tasks:
                 task.cancel()
+
             raise
 
     async def _load_pin_and_puck(self, sample_location: SampleLocation):
@@ -164,9 +168,9 @@ class BartRobot(StandardReadable, Movable[SampleLocation]):
         )
         await self.load.trigger()
         if await self.gonio_pin_sensor.get_value() == PinMounted.PIN_MOUNTED:
-            LOGGER.info("Waiting on old pin unloaded")
+            LOGGER.info(WAIT_FOR_OLD_PIN_MSG)
             await wait_for_value(self.gonio_pin_sensor, PinMounted.NO_PIN_MOUNTED, None)
-        LOGGER.info("Waiting on new pin loaded")
+        LOGGER.info(WAIT_FOR_NEW_PIN_MSG)
 
         await self.pin_mounted_or_no_pin_found()
 

--- a/tests/devices/unit_tests/test_bart_robot.py
+++ b/tests/devices/unit_tests/test_bart_robot.py
@@ -66,6 +66,8 @@ async def test_given_program_not_running_but_pin_not_unmounting_when_load_pin_th
     patch_logger: MagicMock,
 ):
     device = await _get_bart_robot()
+    device.LOAD_TIMEOUT = 0.01  # type: ignore
+    device.NOT_BUSY_TIMEOUT = 0.01  # type: ignore
     set_mock_value(device.program_running, False)
     set_mock_value(device.gonio_pin_sensor, PinMounted.PIN_MOUNTED)
     device.load = AsyncMock(side_effect=device.load)
@@ -81,6 +83,8 @@ async def test_given_program_not_running_and_pin_unmounting_but_new_pin_not_moun
     patch_logger: MagicMock,
 ):
     device = await _get_bart_robot()
+    device.LOAD_TIMEOUT = 0.01  # type: ignore
+    device.NOT_BUSY_TIMEOUT = 0.01  # type: ignore
     set_mock_value(device.program_running, False)
     set_mock_value(device.gonio_pin_sensor, PinMounted.NO_PIN_MOUNTED)
     device.load = AsyncMock(side_effect=device.load)
@@ -158,6 +162,8 @@ async def test_set_waits_for_both_timeouts(mock_wait_for: AsyncMock):
 
 async def test_moving_the_robot_will_reset_error_if_light_curtain_is_tripped_and_still_throw_if_error_not_cleared():
     device = await _get_bart_robot()
+    device.LOAD_TIMEOUT = 0.01  # type: ignore
+    device.NOT_BUSY_TIMEOUT = 0.01  # type: ignore
     set_mock_value(device.controller_error.code, BartRobot.LIGHT_CURTAIN_TRIPPED)
 
     with pytest.raises(RobotLoadFailed) as e:

--- a/tests/devices/unit_tests/test_bart_robot.py
+++ b/tests/devices/unit_tests/test_bart_robot.py
@@ -100,7 +100,7 @@ async def test_given_program_not_running_and_pin_unmounting_but_new_pin_not_moun
         raise
 
 
-def _set_pin_sensor_on_log_messages(device: BartRobot, msg):
+def _set_pin_sensor_on_log_messages(device: BartRobot, msg: str):
     if msg == "Waiting on old pin unloaded":
         set_mock_value(device.gonio_pin_sensor, PinMounted.NO_PIN_MOUNTED)
     elif msg == "Waiting on new pin loaded":


### PR DESCRIPTION
Fixes #943 (hopefully)

These tests relied on sleeps to order when to set signals. I've changed it so that the signals are set based on specific logging messages. Not sure if it's the _best_ fix but it should work for now

### Instructions to reviewer on how to test:
1. Confirm tests are still sensible
2. Confirm flakiness is resolved

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
