### PR TITLE
Remove path provider from b01-1 so it can use numtracker

### DIFF
--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -1,16 +1,12 @@
-from pathlib import Path
-
 from ophyd_async.epics.adaravis import AravisDetector
 from ophyd_async.fastcs.panda import HDFPanda
 
 from dodal.common.beamlines.beamline_utils import (
     device_factory,
     get_path_provider,
-    set_path_provider,
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import CAM_SUFFIX, HDF5_SUFFIX
-from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.motors import XYZStage
 from dodal.devices.synchrotron import Synchrotron
 from dodal.log import set_beamline as set_log_beamline
@@ -20,14 +16,6 @@ BL = "c01"
 PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
-
-set_path_provider(
-    StaticVisitPathProvider(
-        BL,
-        Path("/dls/b01-1/data/2025/cm40661-1/"),
-        client=LocalDirectoryServiceClient(),
-    )
-)
 
 """
 NOTE: Due to ArgoCD and the k8s cluster configuration those PVs are not available remotely.


### PR DESCRIPTION
Fixes internal ticket

### Instructions to reviewer on how to test:
1. Import with blueapi
2. Check it connects to numtracker

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
