### PR TITLE
Add default image mode setting for analysers and clean up imports

### DIFF
--- a/src/dodal/devices/electron_analyser/abstract/base_driver_io.py
+++ b/src/dodal/devices/electron_analyser/abstract/base_driver_io.py
@@ -13,7 +13,7 @@ from ophyd_async.core import (
     derived_signal_r,
     soft_signal_rw,
 )
-from ophyd_async.epics.adcore import ADBaseIO
+from ophyd_async.epics.adcore import ADBaseIO, ADImageMode
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 from dodal.devices.electron_analyser.abstract.base_region import (
@@ -138,6 +138,8 @@ class AbstractAnalyserDriverIO(
         Args:
             region: Contains the parameters to setup the driver for a scan.
         """
+        # Set image_mode to SINGLE by default for all analysers
+        await self.image_mode.set(ADImageMode.SINGLE)
 
     def _get_energy_source(self, alias_name: str) -> SignalR[float]:
         energy_source = self.energy_sources.get(alias_name)

--- a/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
@@ -9,7 +9,6 @@ from ophyd_async.core import (
     SignalR,
     StandardReadableFormat,
 )
-from ophyd_async.epics.adcore import ADImageMode
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 from dodal.devices.electron_analyser.abstract.base_driver_io import (
@@ -73,6 +72,7 @@ class VGScientaAnalyserDriverIO(
 
     @AsyncStatus.wrap
     async def set(self, region: VGScientaRegion[TLensMode, TPassEnergyEnum]):
+        await super().set(region)
         source = self._get_energy_source(region.excitation_energy_source)
         excitation_energy = await source.get_value()  # eV
         # Copy region so doesn't alter the actual region and switch to kinetic energy
@@ -92,7 +92,6 @@ class VGScientaAnalyserDriverIO(
             self.excitation_energy.set(excitation_energy),
             self.excitation_energy_source.set(source.name),
             self.energy_step.set(ke_region.energy_step),
-            self.image_mode.set(ADImageMode.SINGLE),
             self.detector_mode.set(ke_region.detector_mode),
             self.region_min_x.set(ke_region.min_x),
             self.region_size_x.set(ke_region.size_x),


### PR DESCRIPTION
Fixes #ISSUE

### Instructions to reviewer on how to test:
1. Refector image mode setting to apply to all electron analysers
2. Confirm imports are all correctly done

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
