### PR TITLE
Fix pressure cell controller PVs

### DIFF
--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Generic, TypeVar
 
-from bluesky.protocols import HasName, Movable
+from bluesky.protocols import Movable
 from ophyd_async.core import (
     AsyncStatus,
     DeviceVector,
@@ -200,25 +200,26 @@ class PressureTransducer(StandardReadable):
         super().__init__(name)
 
 
-class PressureJumpCellController(HasName):
+class PressureJumpCellController(StandardReadable):
+    """
+    Top-level control for a fixed pressure or pressure jumps.
+    """
     def __init__(self, prefix: str, name: str = "") -> None:
-        self.stop = epics_signal_rw(StopState, f"{prefix}STOP")
+        with self.add_children_as_readables():
+            self.stop = epics_signal_rw(StopState, f"{prefix}STOP")
 
-        self.target_pressure = epics_signal_rw(float, f"{prefix}TARGET")
-        self.timeout = epics_signal_rw(float, f"{prefix}TIMER.HIGH")
-        self.go = epics_signal_rw(bool, f"{prefix}GO")
+            self.target_pressure = epics_signal_rw(float, f"{prefix}TARGET")
+            self.timeout = epics_signal_rw(float, f"{prefix}TIMER.HIGH")
+            self.go = epics_signal_rw(bool, f"{prefix}GO")
 
-        ## Jump logic ##
-        self.start_pressure = epics_signal_rw(float, f"{prefix}JUMPF")
-        self.target_pressure = epics_signal_rw(float, f"{prefix}JUMPT")
-        self.jump_ready = epics_signal_rw(bool, f"{prefix}SETJUMP")
+            self.from_pressure = epics_signal_rw(float, f"{prefix}JUMPF")
+            self.to_pressure = epics_signal_rw(float, f"{prefix}JUMPT")
+            self.jump_ready = epics_signal_rw(bool, f"{prefix}SETJUMP")
 
-        self._name = name
-        super().__init__()
+            self.result = epics_signal_r(str, f"{prefix}RESULT")
 
-    @property
-    def name(self):
-        return self._name
+            self._name = name
+        super().__init__(name)
 
 
 class PressureJumpCell(StandardReadable):


### PR DESCRIPTION
Fixes errors when setting the pressure cell `control` PVs. Uses the wrapped style declaration style used elsewhere by pressure the cell code.  

### Instructions to reviewer on how to test:
1. Confirm the unit tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
