### PR TITLE
Updated vgscienta sensor_max_size PV's to be read only and to use _RBV

### DIFF
--- a/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/driver_io.py
@@ -55,11 +55,11 @@ class VGScientaAnalyserDriverIO(
 
             self.region_min_x = epics_signal_rw(int, prefix + "MinX")
             self.region_size_x = epics_signal_rw(int, prefix + "SizeX")
-            self.sensor_max_size_x = epics_signal_rw(int, prefix + "MaxSizeX")
+            self.sensor_max_size_x = epics_signal_r(int, prefix + "MaxSizeX_RBV")
 
             self.region_min_y = epics_signal_rw(int, prefix + "MinY")
             self.region_size_y = epics_signal_rw(int, prefix + "SizeY")
-            self.sensor_max_size_y = epics_signal_rw(int, prefix + "MaxSizeY")
+            self.sensor_max_size_y = epics_signal_r(int, prefix + "MaxSizeY_RBV")
 
         super().__init__(
             prefix,


### PR DESCRIPTION
Fixes `sensor_max_size` PV's not connecting

### Instructions to reviewer on how to test:
1. Check dodal connect for sensor_max_size work for I09

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
