### PR TITLE
Moved ConstantDeadTimeController to devices/controllers.py and updated devices to use

### DIFF
--- a/src/dodal/devices/b16/detector.py
+++ b/src/dodal/devices/b16/detector.py
@@ -1,5 +1,4 @@
 from ophyd_async.epics.adcore import (
-    ADBaseController,
     ADBaseIO,
     ADTIFFWriter,
     AreaDetector,
@@ -7,15 +6,7 @@ from ophyd_async.epics.adcore import (
 
 from dodal.common.beamlines.beamline_utils import get_path_provider
 from dodal.common.beamlines.device_helpers import CAM_SUFFIX, TIFF_SUFFIX
-
-
-class ConstantDeadTimeController(ADBaseController):
-    def __init__(self, driver: ADBaseIO, deadtime: float):
-        super().__init__(driver)
-        self.deadtime = deadtime
-
-    def get_deadtime(self, exposure: float | None) -> float:
-        return self.deadtime
+from dodal.devices.controllers import ConstantDeadTimeController
 
 
 def software_triggered_tiff_area_detector(prefix: str, deadtime: float = 0.0):

--- a/src/dodal/devices/controllers.py
+++ b/src/dodal/devices/controllers.py
@@ -1,0 +1,21 @@
+from typing import TypeVar
+
+from ophyd_async.epics.adcore import (
+    ADBaseController,
+    ADBaseIO,
+)
+
+ADBaseIOT = TypeVar("ADBaseIOT", bound=ADBaseIO)
+
+
+class ConstantDeadTimeController(ADBaseController[ADBaseIOT]):
+    """
+    Controller for a driver with a configured constant deadtime.
+    """
+
+    def __init__(self, driver: ADBaseIOT, deadtime: float):
+        super().__init__(driver)
+        self.deadtime = deadtime
+
+    def get_deadtime(self, exposure: float | None) -> float:
+        return self.deadtime

--- a/src/dodal/devices/electron_analyser/abstract/__init__.py
+++ b/src/dodal/devices/electron_analyser/abstract/__init__.py
@@ -1,5 +1,4 @@
 from .base_detector import (
-    AbstractAnalyserDriverIO,
     AbstractElectronAnalyserDetector,
 )
 from .base_driver_io import AbstractAnalyserDriverIO, TAbstractAnalyserDriverIO

--- a/src/dodal/devices/electron_analyser/abstract/base_detector.py
+++ b/src/dodal/devices/electron_analyser/abstract/base_detector.py
@@ -9,19 +9,11 @@ from ophyd_async.core import (
     AsyncStatus,
     Device,
 )
-from ophyd_async.epics.adcore import (
-    ADBaseController,
-)
 
+from dodal.devices.controllers import ConstantDeadTimeController
 from dodal.devices.electron_analyser.abstract.base_driver_io import (
-    AbstractAnalyserDriverIO,
     TAbstractAnalyserDriverIO,
 )
-
-
-class ElectronAnalyserController(ADBaseController[AbstractAnalyserDriverIO]):
-    def get_deadtime(self, exposure: float | None) -> float:
-        return 0
 
 
 class AbstractElectronAnalyserDetector(
@@ -45,9 +37,7 @@ class AbstractElectronAnalyserDetector(
         driver: TAbstractAnalyserDriverIO,
         name: str = "",
     ):
-        self.controller: ElectronAnalyserController = ElectronAnalyserController(
-            driver=driver
-        )
+        self.controller = ConstantDeadTimeController(driver, 0)
         super().__init__(name)
 
     @AsyncStatus.wrap

--- a/tests/beamlines/unit_tests/test_b16.py
+++ b/tests/beamlines/unit_tests/test_b16.py
@@ -1,16 +1,7 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 from dodal.common.beamlines.device_helpers import CAM_SUFFIX, TIFF_SUFFIX
-from dodal.devices.b16.detector import (
-    ConstantDeadTimeController,
-    software_triggered_tiff_area_detector,
-)
-
-
-def test_constant_dead_time_controller_returns_constant():
-    constant_deadtime = 2.4
-    controller = ConstantDeadTimeController(driver=Mock(), deadtime=constant_deadtime)
-    assert controller.get_deadtime(exposure=Mock()) == constant_deadtime
+from dodal.devices.b16.detector import software_triggered_tiff_area_detector
 
 
 def test_software_triggered_tiff_area_detector_calls_with_io_correctly():
@@ -21,7 +12,7 @@ def test_software_triggered_tiff_area_detector_calls_with_io_correctly():
         patch("dodal.devices.b16.detector.ADTIFFWriter.with_io") as mock_writer_with_io,
         patch("dodal.devices.b16.detector.AreaDetector") as mock_area_detector,
         patch(
-            "dodal.devices.b16.detector.ConstantDeadTimeController"
+            "dodal.devices.controllers.ConstantDeadTimeController"
         ) as mock_controller,
         patch("dodal.devices.b16.detector.get_path_provider") as mock_get_path_provider,
         patch("dodal.devices.b16.detector.ADBaseIO") as mock_adbase_io,

--- a/tests/devices/unit_tests/test_controllers.py
+++ b/tests/devices/unit_tests/test_controllers.py
@@ -1,0 +1,11 @@
+from unittest.mock import Mock
+
+from dodal.devices.controllers import (
+    ConstantDeadTimeController,
+)
+
+
+def test_constant_dead_time_controller_returns_constant():
+    constant_deadtime = 2.4
+    controller = ConstantDeadTimeController(driver=Mock(), deadtime=constant_deadtime)
+    assert controller.get_deadtime(exposure=Mock()) == constant_deadtime


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/dodal/issues/1461

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
