### PR TITLE
Remove combined cryostream/cryojet device

### DIFF
--- a/src/dodal/devices/cryostream.py
+++ b/src/dodal/devices/cryostream.py
@@ -1,6 +1,5 @@
 from ophyd_async.core import (
     EnabledDisabled,
-    InOut,
     StandardReadable,
     StandardReadableFormat,
     StrictEnum,
@@ -10,20 +9,6 @@ from ophyd_async.epics.core import (
     epics_signal_rw,
     epics_signal_x,
 )
-
-
-class CryoStream(StandardReadable):
-    MAX_TEMP_K = 110
-    MAX_PRESSURE_BAR = 0.1
-
-    def __init__(self, prefix: str, name: str = ""):
-        self.course = epics_signal_rw(InOut, f"{prefix}-EA-CJET-01:COARSE:CTRL")
-        self.fine = epics_signal_rw(InOut, f"{prefix}-EA-CJET-01:FINE:CTRL")
-        self.temperature_k = epics_signal_r(float, f"{prefix}-EA-CSTRM-01:TEMP")
-        self.back_pressure_bar = epics_signal_r(
-            float, f"{prefix}-EA-CSTRM-01:BACKPRESS"
-        )
-        super().__init__(name)
 
 
 class TurboEnum(StrictEnum):


### PR DESCRIPTION
When I was writing the oxford cryostream device for i11, I noticed there was already a device for the crypstream. This cryostream however is a composite device consisting a total of 4 PV's. 2 PV's from a crypstream and 2 PV's from a Cryojet and only implementing a very limited functionality.

I believe this was committed for the purpose of MX and as far as I'm aware this device is not being used anywhere.  @olliesilvester @DominicOram Please correct me if wrong.

I think this should be removed an re-implemented again later (if needed) using the new Oxford Cryostream device
