### PR TITLE
Initial docs for plans standards - add baseline set of devices

### DIFF
--- a/docs/reference/plan-standards.md
+++ b/docs/reference/plan-standards.md
@@ -1,3 +1,78 @@
 # Plan Standards
 
+> [!NOTE]
+> These are some notes on how to write plans . Plans should not be implemented in dodal (unless very general).
+
 ## Use a list of standard baseline devices
+
+
+Bluesky has a standard preprocesser/plan decorator baseline_decorator that reads from a collection of Readable devices at the start and end of every plan.
+
+These devices are usually not included in the scan logic (e.g. upstream optical components). They are likely to be consistent across multiple plans, although they may be overridden by explicitly passed arguments.
+
+
+### Example: besaline devices implementation and use for I22
+
+```python
+from bluesky.protocols import Readable
+from dodal.common import inject
+
+DEFAULT_BASELINE_MEASUREMENTS: set[Readable] = {
+    inject("fswitch"),
+    inject("slits_1"),
+    inject("slits_2"),
+    inject("slits_3"),
+    inject("slits_4"),
+    inject("slits_5"),
+    inject("slits_6"),
+    inject("hfm"),
+    inject("vfm"),
+    inject("undulator"),
+    inject("dcm"),
+    inject("synchrotron"),
+}
+```
+
+```python
+from typing import Any
+
+import bluesky.preprocessors as bpp
+import bluesky.plans as bp
+from bluesky.protocols import Readable
+from bluesky.utils import MsgGenerator
+
+from sas_bluesky.baseline import (
+    DEFAULT_BASELINE_MEASUREMENTS,
+)
+
+_PLAN_NAME = "stopflow"
+
+def experiment(
+    experiment_detector: Readable,
+    experiment_param: int,
+    baseline: set[Readable] = DEFAULT_BASELINE_MEASUREMENTS,
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+
+    # Collect metadata
+    plan_args = {
+        "experiment_device": experiment_detector.name,
+        "experiment_param": experiment_param,
+        "baseline": {device.name + ":" + repr(device) for device in baseline},
+    }
+
+    _md = {
+        "detectors": {experiment_detector.name},
+        "plan_args": plan_args,
+        "hints": {},
+    }
+    _md.update(metadata or {})
+
+    @bpp.baseline_decorator(baseline)
+    @bpp.stage_decorator([experiment_detector])
+    @bpp.run_decorator(md=_md)
+    def inner_plan():
+        yield from bp.count([experiment_detector], experiment_param)
+
+    yield from inner_plan()
+```

--- a/docs/reference/plan-standards.md
+++ b/docs/reference/plan-standards.md
@@ -1,0 +1,3 @@
+# Plan Standards
+
+## Use a list of standard baseline devices

--- a/docs/reference/plan-standards.md
+++ b/docs/reference/plan-standards.md
@@ -1,7 +1,7 @@
 # Plan Standards
 
 > [!NOTE]
-> These are some notes on how to write plans . Plans should not be implemented in dodal (unless very general).
+> Plans should not be implemented in dodal (unless very general), but in the specific technique-bluesky repository.
 
 ## Use a list of standard baseline devices
 
@@ -12,6 +12,8 @@ These devices are usually not included in the scan logic (e.g. upstream optical 
 
 
 ### Example: besaline devices implementation and use for I22
+
+
 
 ```python
 from bluesky.protocols import Readable

--- a/docs/reference/plan-standards.md
+++ b/docs/reference/plan-standards.md
@@ -1,21 +1,24 @@
 # Plan Standards
 
 > [!NOTE]
-> Plans should not be implemented in dodal (unless very general), but in the specific technique-bluesky repository.
+> This is meant as a collection of guidelines on plan standards using dodal devices.
+> As a general rule, beamline/technique specific plans should not be in dodal.
+
 
 ## Use a list of standard baseline devices
 
 
-Bluesky has a standard preprocesser/plan decorator baseline_decorator that reads from a collection of Readable devices at the start and end of every plan.
+Bluesky has a standard preprocessor/plan decorator [baseline_decorator](https://blueskyproject.io/bluesky/main/generated/bluesky.preprocessors.baseline_decorator.html#bluesky.preprocessors.baseline_decorator) that reads from a collection of Readable devices at the start and end of every plan.
 
 These devices are usually not included in the scan logic (e.g. upstream optical components). They are likely to be consistent across multiple plans, although they may be overridden by explicitly passed arguments.
 
 
 ### Example: besaline devices implementation and use for I22
 
-
+In this example, a set of Readable devices from the optics hutch is defined by injecting all the devices that we want to read at the start of the plan, while not being used directly in the plan logic.
 
 ```python
+# In sas_bluesky/baseline.py
 from bluesky.protocols import Readable
 from dodal.common import inject
 
@@ -34,6 +37,8 @@ DEFAULT_BASELINE_MEASUREMENTS: set[Readable] = {
     inject("synchrotron"),
 }
 ```
+
+This set of devices is passed to the `baseline_decorator` which decorates the `inner_plan`. This decorator will record a reading from all devices once the `open_run` document is emitted.
 
 ```python
 from typing import Any

--- a/docs/reference/plan-standards.md
+++ b/docs/reference/plan-standards.md
@@ -8,14 +8,13 @@
 ## Use a list of standard baseline devices
 
 
-Bluesky has a standard preprocessor/plan decorator [baseline_decorator](https://blueskyproject.io/bluesky/main/generated/bluesky.preprocessors.baseline_decorator.html#bluesky.preprocessors.baseline_decorator) that reads from a collection of Readable devices at the start and end of every plan.
+Bluesky has a standard preprocessor/plan decorator [baseline_decorator](https://blueskyproject.io/bluesky/main/generated/bluesky.preprocessors.baseline_decorator.html#bluesky.preprocessors.baseline_decorator) that reads from a collection of Readable devices which are not usually included in the plan logic at the start and end of every plan.
 
-These devices are usually not included in the scan logic (e.g. upstream optical components). They are likely to be consistent across multiple plans, although they may be overridden by explicitly passed arguments.
 
 
 ### Example: besaline devices implementation and use for I22
 
-In this example, a set of Readable devices from the optics hutch is defined by injecting all the devices that we want to read at the start of the plan, while not being used directly in the plan logic.
+In this example, a set of Readable devices from the optics hutch is defined by injecting all the devices that we want to read at the start and end of the plan, while not being used directly in the plan logic.
 
 ```python
 # In sas_bluesky/baseline.py
@@ -38,7 +37,7 @@ DEFAULT_BASELINE_MEASUREMENTS: set[Readable] = {
 }
 ```
 
-This set of devices is passed to the `baseline_decorator` which decorates the `inner_plan`. This decorator will record a reading from all devices once the `open_run` document is emitted.
+This set of devices is passed to the `baseline_decorator` which decorates the `inner_plan`. This decorator will record a reading from all devices after `open_run` and emit an event document with metadata from all those devices.
 
 ```python
 from typing import Any


### PR DESCRIPTION
Fixes #761 

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
