### PR TITLE
Temporary worksound for instrument session

### DIFF
--- a/src/dodal/beamlines/i19_1.py
+++ b/src/dodal/beamlines/i19_1.py
@@ -77,6 +77,7 @@ def shutter() -> AccessControlledShutter:
     return AccessControlledShutter(
         prefix=f"{PREFIX.beamline_prefix}-PS-SHTR-01:",
         hutch=HutchState.EH1,
+        instrument_session="cm40638-4",
     )
 
 

--- a/src/dodal/beamlines/i19_2.py
+++ b/src/dodal/beamlines/i19_2.py
@@ -65,6 +65,7 @@ def shutter() -> AccessControlledShutter:
     return AccessControlledShutter(
         prefix=f"{PREFIX.beamline_prefix}-PS-SHTR-01:",
         hutch=HutchState.EH2,
+        instrument_session="cm40639-4",
     )
 
 

--- a/src/dodal/devices/i19/shutter.py
+++ b/src/dodal/devices/i19/shutter.py
@@ -22,10 +22,17 @@ class AccessControlledShutter(OpticsBlueAPIDevice):
     https://github.com/DiamondLightSource/i19-bluesky/issues/30.
     """
 
-    def __init__(self, prefix: str, hutch: HutchState, name: str = "") -> None:
+    def __init__(
+        self,
+        prefix: str,
+        hutch: HutchState,
+        instrument_session: str = "",
+        name: str = "",
+    ) -> None:
         with self.add_children_as_readables(StandardReadableFormat.HINTED_SIGNAL):
             self.shutter_status = epics_signal_r(ShutterState, f"{prefix}STA")
         self.hutch_request = hutch
+        self.instrument_session = instrument_session
         super().__init__(name)
 
     @AsyncStatus.wrap
@@ -37,5 +44,6 @@ class AccessControlledShutter(OpticsBlueAPIDevice):
                 "access_device": ACCESS_DEVICE_NAME,
                 "shutter_demand": value.value,
             },
+            "instrument_session": self.instrument_session,
         }
         await super().set(REQUEST_PARAMS)

--- a/tests/devices/i19/test_shutter.py
+++ b/tests/devices/i19/test_shutter.py
@@ -17,7 +17,7 @@ from dodal.devices.i19.shutter import (
 
 
 async def make_test_shutter(hutch: HutchState) -> AccessControlledShutter:
-    shutter = AccessControlledShutter("", hutch, name="mock_shutter")
+    shutter = AccessControlledShutter("", hutch, "cm12345-1", name="mock_shutter")
     await shutter.connect(mock=True)
 
     shutter.url = "http://test-blueapi.url"
@@ -37,7 +37,7 @@ async def eh2_shutter(RE: RunEngine) -> AccessControlledShutter:
 
 @pytest.mark.parametrize("hutch_name", [HutchState.EH1, HutchState.EH2])
 def shutter_can_be_created_without_raising_errors(hutch_name: HutchState):
-    test_shutter = AccessControlledShutter("", hutch_name, "test_shutter")
+    test_shutter = AccessControlledShutter("", hutch_name, "cm12345-1", "test_shutter")
     assert isinstance(test_shutter, AccessControlledShutter)
 
 
@@ -107,6 +107,7 @@ async def test_set_corrently_makes_rest_calls(
             "access_device": "access_control",
             "shutter_demand": shutter_demand.value,
         },
+        "instrument_session": "cm12345-1",
     }
     test_request_json = json.dumps(test_request)
     with (


### PR DESCRIPTION
See [blueapi#1187](https://github.com/DiamondLightSource/blueapi/issues/1187#issuecomment-3237452769)

### Instructions to reviewer on how to test:
1. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
