### PR TITLE
When thawer is triggered again, reset the timer instead of raising an exception

### DIFF
--- a/tests/devices/test_thawer.py
+++ b/tests/devices/test_thawer.py
@@ -96,6 +96,7 @@ async def test_given_thawing_already_triggered_run_engine_stop_stops_thawer(
         RE.abort()
 
     loop = new_event_loop()
+    test_thread = None
     try:
 
         def test_loop():
@@ -113,7 +114,8 @@ async def test_given_thawing_already_triggered_run_engine_stop_stops_thawer(
         loop.call_soon_threadsafe(loop.stop)
         result_fut.result()
     finally:
-        test_thread.join()
+        if test_thread:
+            test_thread.join()
 
 
 @patch("dodal.devices.thawer.sleep")


### PR DESCRIPTION
Fixes 

* DiamondLightSource/mx-bluesky#1190

If another sample is loaded before the thawer timer for the previous sample expires, instead of raising an exception, the thawer timer is reset.

### Instructions to reviewer on how to test:
1. Tests pass
2. When Hyperion is run in UDC, on loading a bad pin, the next sample load does not raise an exception from the thawer.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
