### PR TITLE
Ophyd async motor limit check in smargon

### DIFF
--- a/src/dodal/devices/smargon.py
+++ b/src/dodal/devices/smargon.py
@@ -177,6 +177,7 @@ class Smargon(XYZStage, Movable):
             for motor_name, new_setpoint in value.items():
                 if new_setpoint is not None and isinstance(new_setpoint, int | float):
                     axis: Motor = getattr(self, motor_name)
+                    await axis.check_motor_limit(axis.user_setpoint, new_setpoint)
                     put_completion = await set_and_wait_for_value(
                         axis.user_setpoint,
                         new_setpoint,

--- a/src/dodal/devices/util/test_utils.py
+++ b/src/dodal/devices/util/test_utils.py
@@ -15,6 +15,8 @@ def patch_motor(motor: Motor, initial_position=0):
     set_mock_value(motor.motor_done_move, 1)
     set_mock_value(motor.velocity, 3)
     set_mock_value(motor.max_velocity, 5)
+    set_mock_value(motor.low_limit_travel, -99.99)
+    set_mock_value(motor.high_limit_travel, 99.99)
     return callback_on_mock_put(
         motor.user_setpoint,
         lambda pos, *args, **kwargs: set_mock_value(motor.user_readback, pos),

--- a/tests/devices/unit_tests/test_smargon.py
+++ b/tests/devices/unit_tests/test_smargon.py
@@ -6,6 +6,7 @@ from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices, observe_value
 from ophyd_async.testing import get_mock_put, set_mock_value
+from ophyd_async.epics.motor import MotorLimitsException
 
 from dodal.devices.smargon import CombinedMove, DeferMoves, Smargon, StubPosition
 from dodal.devices.util.test_utils import patch_all_motors
@@ -85,6 +86,30 @@ async def test_given_center_disp_low_when_stub_offsets_set_to_center_and_moved_t
     set_smargon_pos(smargon, (0, 0, 0))
 
     assert await smargon.stub_offsets.to_robot_load.proc.get_value() == 0
+
+@pytest.mark.parametrize(
+    "test_x, test_y, test_z, test_omega, test_chi, test_phi",
+    [
+        (100, 20, 30, 5, 15, 25),   # x goes beyond upper limit
+        (-100, 20, 30, 5, 15, 25),  # x goes beyond lower limit
+        (10, 100, 30, 5, 15, 25),   # y goes beyond upper limit
+        (10, -100, 30, 5, 15, 25),  # y goes beyond lower limit
+        (10, 20, 100, 5, 15, 25),   # z goes beyond upper limit
+        (10, 20, -100, 5, 15, 25),  # z goes beyond lower limit
+        (10, 20, 30, 100, 15, 25),  # omega goes beyond upper limit
+        (10, 20, 30, -100, 15, 25), # omega goes beyond lower limit
+        (10, 20, 30, 5, 100, 25),   # chi goes beyond upper limit
+        (10, 20, 30, 5, -100, 25),  # chi goes beyond lower limit
+        (10, 20, 30, 5, 15, 100),   # phi goes beyond upper limit
+        (10, 20, 30, 5, 15, -100),  # phi goes beyond lower limit
+    ],
+)
+async def test_given_set_with_value_outside_motor_limit(
+        smargon: Smargon,
+        test_x, test_y, test_z, test_omega, test_chi, test_phi
+):
+    with pytest.raises(MotorLimitsException):
+        await smargon.set(CombinedMove(x=test_x, y=test_y, z=test_z, omega=test_omega, chi=test_chi, phi=test_phi))
 
 
 async def test_given_set_with_single_value_then_that_motor_moves(smargon: Smargon):


### PR DESCRIPTION
Fixes #1505 

### Instructions to reviewer on how to test:
1. Check if the motor are initialized with the limits
2. Check if the motor limit check works
3. Check the testing make sense

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
