### PR TITLE
add max timeout for polarisation

### DIFF
--- a/src/dodal/devices/i10/i10_apple2.py
+++ b/src/dodal/devices/i10/i10_apple2.py
@@ -34,6 +34,7 @@ MAXIMUM_ROW_PHASE_MOTOR_POSITION = 24.0
 MAXIMUM_GAP_MOTOR_POSITION = 100
 DEFAULT_JAW_PHASE_POLY_PARAMS = [1.0 / 7.5, -120.0 / 7.5]
 ALPHA_OFFSET = 180
+MAXIMUM_MOVE_TIME = 200  # slowest possible move(closing ID from open to min)
 
 
 # data class to store the lookup table configuration that is use in convert_csv_to_lookup
@@ -250,7 +251,8 @@ class I10Apple2Pol(StandardReadable, Movable[Pol]):
     @AsyncStatus.wrap
     async def set(self, value: Pol) -> None:
         LOGGER.info(f"Changing f{self.name} polarisation to {value}.")
-        await self.id_ref().polarisation.set(value)
+        # Timeout is determined internally by the set method later, so we set it to max here.
+        await self.id_ref().polarisation.set(value, timeout=MAXIMUM_MOVE_TIME)
 
 
 class LinearArbitraryAngle(StandardReadable, Movable[SupportsFloat]):

--- a/src/dodal/devices/i10/i10_apple2.py
+++ b/src/dodal/devices/i10/i10_apple2.py
@@ -34,7 +34,7 @@ MAXIMUM_ROW_PHASE_MOTOR_POSITION = 24.0
 MAXIMUM_GAP_MOTOR_POSITION = 100
 DEFAULT_JAW_PHASE_POLY_PARAMS = [1.0 / 7.5, -120.0 / 7.5]
 ALPHA_OFFSET = 180
-MAXIMUM_MOVE_TIME = 200  # slowest possible move(closing ID from open to min)
+MAXIMUM_MOVE_TIME = 550  # There is no useful movements take longer than this.
 
 
 # data class to store the lookup table configuration that is use in convert_csv_to_lookup


### PR DESCRIPTION
Fixes #1519 
A maximum timeout has been added for polarisation.set because the actual timeout is always shorter and is calculated internally when the real motors are set.

### Instructions to reviewer on how to test:
1. Check added timeout make sense.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
