### PR TITLE
Added assert_plan_has_valid_inject_devices_for_beamline test function

### DIFF
--- a/src/dodal/testing/__init__.py
+++ b/src/dodal/testing/__init__.py
@@ -1,3 +1,12 @@
+from .assert_funcs import (
+    assert_plan_has_valid_inject_devices_for_beamline,
+    find_inject_args,
+)
 from .setup import patch_all_motors, patch_motor
 
-__all__ = ["patch_motor", "patch_all_motors"]
+__all__ = [
+    "patch_motor",
+    "patch_all_motors",
+    "find_inject_args",
+    "assert_plan_has_valid_inject_devices_for_beamline",
+]

--- a/src/dodal/testing/assert_funcs.py
+++ b/src/dodal/testing/assert_funcs.py
@@ -1,0 +1,64 @@
+import inspect
+import re
+from collections.abc import Callable
+from typing import Any
+
+from dodal.utils import make_all_devices
+
+_INJECT_RE = re.compile(r"inject\(['\"]([^'\"]+)['\"]\)")
+
+
+def find_inject_args(
+    func: Callable[..., Any], *, allow_any_str_default: bool = True
+) -> list[str]:
+    """
+    Return a list of injection names found as defaults on `func`'s parameters.
+
+    - If default is a marker object with .name / .inject_name / __inject_name__, use that.
+    - If default is a str and the parameter annotation is not `str`, treat that string
+      as an injection name (controlled by allow_any_str_default).
+    - Fallback: try to parse repr(default) for inject('name').
+    """
+    sig = inspect.signature(func)
+    found: list[str] = []
+
+    for param in sig.parameters.values():
+        default = param.default
+        if default is inspect._empty:
+            continue
+
+        ann = param.annotation
+        ann_is_str = ann is str or getattr(ann, "__origin__", None) is str
+
+        # 1) duck-typed marker objects
+        for attr in ("name", "inject_name", "__inject_name__"):
+            if hasattr(default, attr):
+                val = getattr(default, attr)
+                if isinstance(val, str):
+                    found.append(val)
+                    break
+        else:
+            # 2) plain string default -> treat as injection if annotation != str
+            if isinstance(default, str) and not ann_is_str and allow_any_str_default:
+                found.append(default)
+                continue
+
+            # 3) fallback: parse repr for inject('name')
+            m = _INJECT_RE.search(repr(default))
+            if m:
+                found.append(m.group(1))
+
+    return found
+
+
+def assert_plan_has_valid_inject_devices_for_beamline(beamline: str, plan) -> None:
+    beamline_devices, _ = make_all_devices("dodal.beamlines." + beamline, mock=True)
+    beamline_device_names = list(beamline_devices.keys())
+    plan_inject_device_names = find_inject_args(plan)
+    try:
+        assert set(plan_inject_device_names).issubset(beamline_device_names)
+    except AssertionError as e:
+        raise AssertionError(
+            f"plan had default devices {plan_inject_device_names} but beamline only",
+            "had these device configured {beamline_device_names}.",
+        ) from e

--- a/tests/testing/test_assert_funcs.py
+++ b/tests/testing/test_assert_funcs.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import pytest
+from bluesky import RunEngine
+from bluesky.utils import MsgGenerator
+from ophyd_async.core import Device, init_devices
+from ophyd_async.epics.motor import Motor
+
+from dodal.common import inject
+from dodal.testing import (
+    assert_plan_has_valid_inject_devices_for_beamline,
+    find_inject_args,
+)
+
+
+def plan_with_device_on_beamline(test: Device = inject("device_on_bl")) -> MsgGenerator:  # noqa: B008
+    yield from {}
+
+
+def plan_with_device_not_on_beamline(
+    test: Device = inject("invalid_device"),  # noqa: B008
+) -> MsgGenerator:
+    yield from {}
+
+
+def test_find_inject_args_with_one_():
+    assert ["device_on_bl"] == find_inject_args(plan_with_device_on_beamline)
+
+
+@pytest.fixture
+def device_on_bl(RE: RunEngine) -> Motor:
+    with init_devices(mock=True, connect=False):
+        device_on_bl = Motor("TEST:")
+    return device_on_bl
+
+
+def test_assert_plan_has_valid_inject_devices_for_beamline(device_on_bl: Motor):
+    with patch(
+        "dodal.testing.assert_funcs.make_all_devices",
+        return_value=({device_on_bl.name: device_on_bl}, {}),
+    ):
+        assert_plan_has_valid_inject_devices_for_beamline(
+            "iXX", plan_with_device_on_beamline
+        )
+
+
+def test_assert_plan_has_invalid_inject_devices_for_beamline(device_on_bl: Motor):
+    with patch(
+        "dodal.testing.assert_funcs.make_all_devices",
+        return_value=({device_on_bl.name: device_on_bl}, {}),
+    ):
+        with pytest.raises(AssertionError):
+            assert_plan_has_valid_inject_devices_for_beamline(
+                "iXX", plan_with_device_not_on_beamline
+            )


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/dodal/issues/1543

### Instructions to reviewer on how to test:
1. Check tests pass
2. Check logic makes sense
3. Check tests are adequate 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
