### PR TITLE
feat: instantiate panda on i19_2.py

### DIFF
--- a/src/dodal/beamlines/i19_2.py
+++ b/src/dodal/beamlines/i19_2.py
@@ -1,5 +1,8 @@
+from ophyd_async.fastcs.panda import HDFPanda
+
 from dodal.common.beamlines.beamline_utils import (
     device_factory,
+    get_path_provider,
 )
 from dodal.common.beamlines.beamline_utils import (
     set_beamline as set_utils_beamline,
@@ -84,3 +87,11 @@ def backlight() -> BacklightPosition:
     If this is called when already instantiated in i19-2, it will return the existing object.
     """
     return BacklightPosition(prefix=f"{PREFIX.beamline_prefix}-EA-IOC-12:")
+
+
+@device_factory()
+def panda() -> HDFPanda:
+    return HDFPanda(
+        prefix=f"{PREFIX.beamline_prefix}-EA-PANDA-01:",
+        path_provider=get_path_provider(),
+    )


### PR DESCRIPTION
Fixes #1521
Tried to run dodal connect but got an error: 
```
ophyd_async.core._utils.NotConnected: 
panda: NotConnected: pva://BL19I-EA-PANDA-01:PVI
```

### Instructions to reviewer on how to test:
1. Run dodal connect


### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
