### PR TITLE
Mythen fixes

### DIFF
--- a/src/dodal/beamlines/i11.py
+++ b/src/dodal/beamlines/i11.py
@@ -1,9 +1,13 @@
+from pathlib import Path
+
 from dodal.common.beamlines.beamline_utils import (
     device_factory,
     get_path_provider,
+    set_path_provider,
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import DET_SUFFIX
+from dodal.common.visit import RemoteDirectoryServiceClient, StaticVisitPathProvider
 from dodal.devices.cryostream import OxfordCryoStream
 from dodal.devices.eurotherm import (
     EurothermGeneral,
@@ -29,6 +33,19 @@ BL = get_beamline_name("i11")
 PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
+
+# Currently we must hard-code the visit, determining the visit at runtime requires
+# infrastructure that is still WIP.
+# Communication with GDA is also WIP so for now we determine an arbitrary scan number
+# locally and write the commissioning directory. The scan number is not guaranteed to
+# be unique and the data is at risk - this configuration is for testing only.
+set_path_provider(
+    StaticVisitPathProvider(
+        BL,
+        Path(f"/dls/{BL}/data/2025/cm40625-4/bluesky"),
+        client=RemoteDirectoryServiceClient(f"http://{BL}-control:8088/api"),
+    )
+)
 
 
 @device_factory()

--- a/src/dodal/devices/i11/mythen.py
+++ b/src/dodal/devices/i11/mythen.py
@@ -110,7 +110,10 @@ class Mythen3Controller(ADBaseController):
 
     async def prepare(self, trigger_info: TriggerInfo) -> None:
         if (exposure := trigger_info.livetime) is not None:
-            await self._driver.acquire_time.set(exposure)
+            await asyncio.gather(
+                self._driver.acquire_time.set(exposure),
+                self._driver.acquire_period.set(exposure),
+            )
 
         if trigger_info.trigger is DetectorTrigger.INTERNAL:
             await self._driver.trigger_mode.set(Mythen3TriggerMode.INTERNAL)

--- a/src/dodal/devices/i11/mythen.py
+++ b/src/dodal/devices/i11/mythen.py
@@ -112,7 +112,7 @@ class Mythen3Controller(ADBaseController):
         if (exposure := trigger_info.livetime) is not None:
             await asyncio.gather(
                 self._driver.acquire_time.set(exposure),
-                self._driver.acquire_period.set(exposure),
+                self._driver.acquire_period.set(exposure + self.get_deadtime(exposure)),
             )
 
         if trigger_info.trigger is DetectorTrigger.INTERNAL:


### PR DESCRIPTION
Here a some changes that were discovered as issues with the current implementation of the mythen3 detector on i11. 

These attempt to fix the issues preventing successful data acquisition.

For example a prepare method that didn't set the acquire time properly