### PR TITLE
Fix bug in fake zocalo for system tests

### DIFF
--- a/tests/fake_zocalo/__main__.py
+++ b/tests/fake_zocalo/__main__.py
@@ -65,7 +65,7 @@ def get_dcgid_and_prefix(dcid: int, session_maker: sessionmaker) -> tuple[int, s
             assert isinstance(session, Session)
             query = (
                 session.query(
-                    DataCollection.dataCollectionId, DataCollection.imagePrefix
+                    DataCollection.dataCollectionGroupId, DataCollection.imagePrefix
                 )
                 .filter(DataCollection.dataCollectionId == dcid)
                 .first()


### PR DESCRIPTION
Fix bug in fake zocalo that causes the DataCollectionGroupId to be incorrectly reported back in system tests

See
* DiamondLightSource/mx-bluesky#1296
