### PR TITLE
add support for i16 DCM - there are PVs still missing in EPICS

### DIFF
--- a/src/dodal/beamlines/i16.py
+++ b/src/dodal/beamlines/i16.py
@@ -1,9 +1,5 @@
 from dodal.common.beamlines.beamline_utils import device_factory
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.common.crystal_metadata import (
-    MaterialsEnum,
-    make_crystal_metadata_from_material,
-)
 from dodal.devices.i16.dcm import DCM
 from dodal.devices.synchrotron import Synchrotron
 from dodal.log import set_beamline as set_log_beamline
@@ -19,16 +15,11 @@ set_utils_beamline(BL)
 def synchrotron() -> Synchrotron:
     return Synchrotron()
 
+
 # dodal connect should work again after this https://jira.diamond.ac.uk/browse/I16-960
 @device_factory()
 def dcm() -> DCM:
     return DCM(
-        prefix=f"{PREFIX.beamline_prefix}-OP-DCM-01:",
         temperature_prefix=f"{PREFIX.beamline_prefix}-OP-DCM-01:",
-        crystal_1_metadata=make_crystal_metadata_from_material(
-            MaterialsEnum.Si, (1, 1, 1)
-        ),
-        crystal_2_metadata=make_crystal_metadata_from_material(
-            MaterialsEnum.Si, (1, 1, 1)
-        ),
+        prefix=f"{PREFIX.beamline_prefix}-OP-DCM-01:",
     )

--- a/src/dodal/devices/i16/dcm.py
+++ b/src/dodal/devices/i16/dcm.py
@@ -1,18 +1,7 @@
-import time
-
-import numpy as np
-from bluesky.protocols import Reading
-from event_model.documents.event_descriptor import DataKey
-from ophyd_async.core import Array1D, StandardReadableFormat, soft_signal_r_and_setter
 from ophyd_async.epics.core import epics_signal_r, epics_signal_w
 from ophyd_async.epics.motor import Motor
 
-from dodal.common.crystal_metadata import CrystalMetadata
 from dodal.devices.common_dcm import BaseDCM, PitchAndRollCrystal, RollCrystal
-
-# Conversion constant for energy and wavelength, taken from the X-Ray data booklet
-# Converts between energy in KeV and wavelength in angstrom
-_CONVERSION_CONSTANT = 12.3984
 
 
 class DCM(BaseDCM[RollCrystal, PitchAndRollCrystal]):
@@ -28,8 +17,6 @@ class DCM(BaseDCM[RollCrystal, PitchAndRollCrystal]):
     def __init__(
         self,
         temperature_prefix: str,
-        crystal_1_metadata: CrystalMetadata,
-        crystal_2_metadata: CrystalMetadata,
         prefix: str,
         name: str = "",
     ) -> None:
@@ -60,66 +47,4 @@ class DCM(BaseDCM[RollCrystal, PitchAndRollCrystal]):
             self.crystal_1_temp5 = epics_signal_r(float, temperature_prefix + "TMP5")
             self.crystal_2_temp6 = epics_signal_r(float, temperature_prefix + "TMP6")
 
-        # Soft metadata
-        # If supplied include crystal details in output of read_configuration
-        with self.add_children_as_readables(StandardReadableFormat.CONFIG_SIGNAL):
-            self.crystal_1_usage, _ = soft_signal_r_and_setter(
-                str, initial_value=crystal_1_metadata.usage
-            )
-            self.crystal_1_type, _ = soft_signal_r_and_setter(
-                str, initial_value=crystal_1_metadata.type
-            )
-            self.crystal_1_reflection, _ = soft_signal_r_and_setter(
-                Array1D[np.int32],
-                initial_value=np.array(crystal_1_metadata.reflection),
-            )
-            self.crystal_1_d_spacing, _ = soft_signal_r_and_setter(
-                float,
-                initial_value=crystal_1_metadata.d_spacing[0],
-                units=crystal_1_metadata.d_spacing[1],
-            )
-            self.crystal_2_usage, _ = soft_signal_r_and_setter(
-                str, initial_value=crystal_2_metadata.usage
-            )
-            self.crystal_2_type, _ = soft_signal_r_and_setter(
-                str, initial_value=crystal_2_metadata.type
-            )
-            self.crystal_2_reflection, _ = soft_signal_r_and_setter(
-                Array1D[np.int32],
-                initial_value=np.array(crystal_2_metadata.reflection),
-            )
-            self.crystal_2_d_spacing, _ = soft_signal_r_and_setter(
-                float,
-                initial_value=crystal_2_metadata.d_spacing[0],
-                units=crystal_2_metadata.d_spacing[1],
-            )
-
         super().__init__(prefix, RollCrystal, PitchAndRollCrystal, name)
-
-    async def describe(self) -> dict[str, DataKey]:
-        default_describe = await super().describe()
-        return {
-            f"{self.name}-wavelength_in_a": DataKey(
-                dtype="number",
-                shape=[],
-                source=self.name,
-                units="angstrom",
-            ),
-            **default_describe,
-        }
-
-    async def read(self) -> dict[str, Reading]:
-        default_reading = await super().read()
-        energy: float = default_reading[f"{self.name}-energy_in_kev"]["value"]
-        if energy > 0.0:
-            wavelength = _CONVERSION_CONSTANT / energy
-        else:
-            wavelength = 0.0
-
-        return {
-            **default_reading,
-            f"{self.name}-wavelength_in_a": Reading(
-                value=wavelength,
-                timestamp=time.time(),
-            ),
-        }


### PR DESCRIPTION
Fixes #1568

### Instructions to reviewer on how to test:
1. added additional motors for each crystal
2. waiting for missing PVs in EPICS IOC for i16 DCM

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
