### PR TITLE
Add set to enum attenuator, add device to i24

### DIFF
--- a/src/dodal/beamlines/i24.py
+++ b/src/dodal/beamlines/i24.py
@@ -53,9 +53,7 @@ PREFIX = BeamlinePrefix(BL)
 
 
 @device_factory()
-def attenuator(
-    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
-) -> EnumFilterAttenuator:
+def attenuator() -> EnumFilterAttenuator:
     """Get a read-only attenuator device for i24, instantiate it if it hasn't already
     been. If this is called when already instantiated in i24, it will return the
     existing object."""

--- a/src/dodal/beamlines/i24.py
+++ b/src/dodal/beamlines/i24.py
@@ -7,7 +7,11 @@ from dodal.common.beamlines.beamline_utils import (
     device_factory,
 )
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
-from dodal.devices.attenuator.attenuator import ReadOnlyAttenuator
+from dodal.devices.attenuator.attenuator import EnumFilterAttenuator
+from dodal.devices.attenuator.filter_selections import (
+    I24_FilterOneSelections,
+    I24_FilterTwoSelections,
+)
 from dodal.devices.hutch_shutter import HutchShutter
 from dodal.devices.i24.aperture import Aperture
 from dodal.devices.i24.beam_center import DetectorBeamCenter
@@ -49,12 +53,15 @@ PREFIX = BeamlinePrefix(BL)
 
 
 @device_factory()
-def attenuator() -> ReadOnlyAttenuator:
+def attenuator(
+    wait_for_connection: bool = True, fake_with_ophyd_sim: bool = False
+) -> EnumFilterAttenuator:
     """Get a read-only attenuator device for i24, instantiate it if it hasn't already
     been. If this is called when already instantiated in i24, it will return the
     existing object."""
-    return ReadOnlyAttenuator(
+    return EnumFilterAttenuator(
         f"{PREFIX.beamline_prefix}-OP-ATTN-01:",
+        filter_selection=(I24_FilterOneSelections, I24_FilterTwoSelections),
     )
 
 

--- a/src/dodal/devices/attenuator/attenuator.py
+++ b/src/dodal/devices/attenuator/attenuator.py
@@ -149,6 +149,7 @@ class EnumFilterAttenuator(ReadOnlyAttenuator, Movable[float]):
         # auto move should normally be on, but check here incase it was manually turned off
         await self._auto_move_on_desired_transmission_set.set(YesNo.YES)
 
+        # Currently uncertain if _use_current_energy correctly waits for completion: https://github.com/DiamondLightSource/dodal/issues/1588
         await self._use_current_energy.trigger()
         await self._desired_transmission.set(value)
 

--- a/src/dodal/devices/attenuator/attenuator.py
+++ b/src/dodal/devices/attenuator/attenuator.py
@@ -145,12 +145,15 @@ class EnumFilterAttenuator(ReadOnlyAttenuator, Movable[float]):
         the current beamline energy, the set will only complete when they have all been
         applied.
         """
+
+        # auto move should normally be on, but check here incase it was manually turned off
         await self._auto_move_on_desired_transmission_set.set(YesNo.YES)
+
         await self._use_current_energy.trigger()
         await self._desired_transmission.set(value)
 
         # Give EPICS a chance to start moving the filter motors. Not needed after
-        # a callback is added at the controls level: https://github.com/DiamondLightSource/dodal/issues/972
+        # a transmission readback PV is added at the controls level: https://jira.diamond.ac.uk/browse/I24-725
         await asyncio.sleep(ENUM_ATTENUATOR_SETTLE_TIME_S)
         coros = [
             wait_for_value(self._filters[i].done_move, 1, timeout=DEFAULT_TIMEOUT)

--- a/src/dodal/devices/attenuator/attenuator.py
+++ b/src/dodal/devices/attenuator/attenuator.py
@@ -7,6 +7,7 @@ from ophyd_async.core import (
     DeviceVector,
     SignalR,
     StandardReadable,
+    StrictEnum,
     SubsetEnum,
     wait_for_value,
 )
@@ -26,6 +27,8 @@ class ReadOnlyAttenuator(StandardReadable):
 
     def __init__(self, prefix: str, name: str = "") -> None:
         with self.add_children_as_readables():
+            # This isn't the readback value, but is the closest obtainable transmission to the current desired transmission
+            # given the specific set of filters in the attenuator
             self.actual_transmission = epics_signal_r(float, prefix + "MATCH")
 
         super().__init__(name)
@@ -92,7 +95,17 @@ class BinaryFilterAttenuator(ReadOnlyAttenuator, Movable[float]):
         )
 
 
-class EnumFilterAttenuator(ReadOnlyAttenuator):
+class YesNo(StrictEnum):
+    YES = "YES"
+    NO = "NO"
+
+
+# Time given to allow for motors to begin moving after the desired transmission has been set,
+# so that we can work out when the set is complete.
+ENUM_ATTENUATOR_SETTLE_TIME_S = 0.15
+
+
+class EnumFilterAttenuator(ReadOnlyAttenuator, Movable[float]):
     """The attenuator will insert filters into the beam to reduce its transmission.
 
     This device is currently working, but feature incomplete. See https://github.com/DiamondLightSource/dodal/issues/972
@@ -107,6 +120,12 @@ class EnumFilterAttenuator(ReadOnlyAttenuator):
         filter_selection: tuple[type[SubsetEnum], ...],
         name: str = "",
     ):
+        self._auto_move_on_desired_transmission_set = epics_signal_rw(
+            YesNo, prefix + "AUTOMOVE"
+        )
+        self._desired_transmission = epics_signal_rw(float, prefix + "T2A:SETVAL1")
+        self._use_current_energy = epics_signal_x(prefix + "E2WL:USECURRENTENERGY.PROC")
+
         with self.add_children_as_readables():
             self.filters: DeviceVector[FilterMotor] = DeviceVector(
                 {
@@ -115,3 +134,24 @@ class EnumFilterAttenuator(ReadOnlyAttenuator):
                 }
             )
         super().__init__(prefix, name=name)
+
+    @AsyncStatus.wrap
+    async def set(self, value: float):
+        """Set the transmission to the fractional (0-1) value given.
+
+        The attenuator IOC will then insert filters to reach the desired transmission for
+        the current beamline energy, the set will only complete when they have all been
+        applied.
+        """
+        await self._auto_move_on_desired_transmission_set.set(YesNo.YES)
+        await self._use_current_energy.trigger()
+        await self._desired_transmission.set(value)
+
+        # Give EPICS a chance to start moving the filter motors. Not needed after
+        # a callback is added at the controls level: https://github.com/DiamondLightSource/dodal/issues/972
+        await asyncio.sleep(ENUM_ATTENUATOR_SETTLE_TIME_S)
+        coros = [
+            wait_for_value(self.filters[i].done_move, 1, timeout=DEFAULT_TIMEOUT)
+            for i in self.filters
+        ]
+        await asyncio.gather(*coros)

--- a/src/dodal/devices/attenuator/filter.py
+++ b/src/dodal/devices/attenuator/filter.py
@@ -8,4 +8,7 @@ class FilterMotor(StandardReadable):
     ):
         with self.add_children_as_readables():
             self.user_setpoint = epics_signal_rw(filter_selections, f"{prefix}SELECT")
+            self.done_move = epics_signal_rw(
+                int, f"{prefix}DMOV"
+            )  # 1 for yes, 0 for no
         super().__init__(name=name)

--- a/src/dodal/devices/attenuator/filter_selections.py
+++ b/src/dodal/devices/attenuator/filter_selections.py
@@ -70,3 +70,29 @@ class I02_1FilterFourSelections(SubsetEnum):
     TI300 = "Ti300"
     TI400 = "Ti400"
     TI500 = "Ti500"
+
+
+class I24_FilterOneSelections(SubsetEnum):
+    EMPTY = "Empty"
+    AL12_5 = "Al12.5"
+    AL25 = "Al25"
+    AL50 = "Al50"
+    AL75 = "Al75"
+    AL1000 = "Al1000"
+    AL2000 = "Al2000"
+    AL3000 = "Al3000"
+    PT25 = "Pt25"
+    TI500 = "Ti500"
+
+
+class I24_FilterTwoSelections(SubsetEnum):
+    EMPTY = "Empty"
+    AL100 = "Al100"
+    AL200 = "Al200"
+    AL300 = "Al300"
+    AL400 = "Al400"
+    AL500 = "Al500"
+    AL600 = "Al600"
+    AL700 = "Al700"
+    AL800 = "Al800"
+    AL900 = "Al900"

--- a/src/dodal/devices/zebra/zebra.py
+++ b/src/dodal/devices/zebra/zebra.py
@@ -82,6 +82,7 @@ class ArmDemand(Enum):
     DISARM = 0
 
 
+# Replace with ophyd-async enum after https://github.com/bluesky/ophyd-async/pull/1067
 class SoftInState(StrictEnum):
     YES = "Yes"
     NO = "No"

--- a/tests/devices/test_attenuator.py
+++ b/tests/devices/test_attenuator.py
@@ -91,7 +91,7 @@ async def test_enum_attenuator_set():
 
     async def _move_filter_after_short_delay(_):
         await asyncio.sleep(MOCK_TIMEOUT_S / 2)
-        await attenuator.filters[0].done_move.set(0)
+        await attenuator._filters[0].done_move.set(0)
 
     attenuator._auto_move_on_desired_transmission_set.set = AsyncMock()
     attenuator._use_current_energy.trigger = AsyncMock()
@@ -101,8 +101,8 @@ async def test_enum_attenuator_set():
     status = attenuator.set(0.2)
     await asyncio.sleep(MOCK_TIMEOUT_S)
     assert not status.done
-    await attenuator.filters[0].done_move.set(1)
-    await attenuator.filters[1].done_move.set(1)
+    await attenuator._filters[0].done_move.set(1)
+    await attenuator._filters[1].done_move.set(1)
     await status
     attenuator._auto_move_on_desired_transmission_set.set.assert_awaited_once_with(
         YesNo.YES

--- a/tests/devices/test_attenuator.py
+++ b/tests/devices/test_attenuator.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from bluesky import plan_stubs as bps
@@ -6,7 +7,15 @@ from bluesky.run_engine import RunEngine
 from ophyd_async.core import init_devices
 from ophyd_async.testing import callback_on_mock_put, set_mock_value
 
-from dodal.devices.attenuator.attenuator import BinaryFilterAttenuator
+from dodal.devices.attenuator.attenuator import (
+    BinaryFilterAttenuator,
+    EnumFilterAttenuator,
+    YesNo,
+)
+from dodal.devices.attenuator.filter_selections import (
+    I24_FilterOneSelections,
+    I24_FilterTwoSelections,
+)
 
 CALCULATED_VALUE = [True, False, True] * 6  # Some "random" values
 
@@ -65,3 +74,37 @@ async def test_attenuator_set_only_complete_once_all_filters_in_position(
     assert not status.done
     fake_set_complete.set()
     await status
+
+
+MOCK_TIMEOUT_S = 0.01
+
+
+@patch(
+    "dodal.devices.attenuator.attenuator.ENUM_ATTENUATOR_SETTLE_TIME_S", MOCK_TIMEOUT_S
+)
+async def test_enum_attenuator_set():
+    with init_devices(mock=True):
+        attenuator = EnumFilterAttenuator(
+            prefix="",
+            filter_selection=(I24_FilterOneSelections, I24_FilterTwoSelections),
+        )
+
+    async def _move_filter_after_short_delay(_):
+        await asyncio.sleep(MOCK_TIMEOUT_S / 2)
+        await attenuator.filters[0].done_move.set(0)
+
+    attenuator._auto_move_on_desired_transmission_set.set = AsyncMock()
+    attenuator._use_current_energy.trigger = AsyncMock()
+    attenuator._desired_transmission.set = AsyncMock(
+        side_effect=_move_filter_after_short_delay
+    )
+    status = attenuator.set(0.2)
+    await asyncio.sleep(MOCK_TIMEOUT_S)
+    assert not status.done
+    await attenuator.filters[0].done_move.set(1)
+    await attenuator.filters[1].done_move.set(1)
+    await status
+    attenuator._auto_move_on_desired_transmission_set.set.assert_awaited_once_with(
+        YesNo.YES
+    )
+    attenuator._use_current_energy.trigger.assert_called_once()


### PR DESCRIPTION
Part of #972 

### Instructions to reviewer on how to test:
1. Confirm dodal connect i24 and dodal connect i02_1 connects to attenuator
2. Confirm new set and test is sensible

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
