### PR TITLE
Murko filter by x pixel value 

### DIFF
--- a/src/dodal/devices/i04/murko_results.py
+++ b/src/dodal/devices/i04/murko_results.py
@@ -42,6 +42,7 @@ class Coord(Enum):
 
 @dataclass
 class MurkoResult:
+    centre_px: tuple
     x_dist_mm: float
     y_dist_mm: float
     omega: float
@@ -175,6 +176,7 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
             )
             self.results.append(
                 MurkoResult(
+                    centre_px=centre_px,
                     x_dist_mm=beam_dist_px[0] * metadata["microns_per_x_pixel"] / 1000,
                     y_dist_mm=beam_dist_px[1] * metadata["microns_per_y_pixel"] / 1000,
                     omega=omega,
@@ -190,7 +192,7 @@ class MurkoResultsDevice(StandardReadable, Triggerable, Stageable):
         remove many of the outliers.
         """
         LOGGER.info(f"Number of results before filtering: {len(self.results)}")
-        sorted_results = sorted(self.results, key=lambda item: item.x_dist_mm)
+        sorted_results = sorted(self.results, key=lambda item: item.centre_px[0])
 
         worst_results = [
             r.uuid for r in sorted_results[-self.NUMBER_OF_WRONG_RESULTS_TO_LOG :]

--- a/tests/devices/i04/test_murko_results.py
+++ b/tests/devices/i04/test_murko_results.py
@@ -510,7 +510,9 @@ def test_given_n_results_filter_outliers_will_reduce_down_to_smaller_amount(
     murko_results: MurkoResultsDevice,
 ):
     murko_results.results = [
-        MurkoResult(x_dist_mm=i, y_dist_mm=i, omega=i, uuid=str(i))
+        MurkoResult(
+            centre_px=(100, 100), x_dist_mm=i, y_dist_mm=i, omega=i, uuid=str(i)
+        )
         for i in range(total_from_murko)
     ]
 
@@ -522,18 +524,23 @@ def test_given_n_results_filter_outliers_will_reduce_down_to_smaller_amount(
     assert len(murko_results.results) == expected_left
 
 
-def test_when_results_filtered_then_smallest_x_kept(murko_results: MurkoResultsDevice):
+def test_when_results_filtered_then_smallest_x_pixels_kept(
+    murko_results: MurkoResultsDevice,
+):
     murko_results.results = [
-        MurkoResult(x_dist_mm=4, y_dist_mm=8, omega=0, uuid="a"),
-        MurkoResult(x_dist_mm=0, y_dist_mm=90, omega=10, uuid="b"),
-        MurkoResult(x_dist_mm=6, y_dist_mm=63, omega=20, uuid="c"),
-        MurkoResult(x_dist_mm=7, y_dist_mm=8, omega=30, uuid="d"),
+        MurkoResult(centre_px=(100, 200), x_dist_mm=4, y_dist_mm=8, omega=0, uuid="a"),
+        MurkoResult(
+            centre_px=(300, 200), x_dist_mm=0, y_dist_mm=90, omega=10, uuid="b"
+        ),
+        MurkoResult(centre_px=(50, 200), x_dist_mm=6, y_dist_mm=63, omega=20, uuid="c"),
+        MurkoResult(centre_px=(300, 200), x_dist_mm=7, y_dist_mm=8, omega=30, uuid="d"),
     ]
 
     murko_results.filter_outliers()
     assert len(murko_results.results) == 1
     results = murko_results.results[0]
-    assert results.x_dist_mm == 0
-    assert results.y_dist_mm == 90
-    assert results.omega == 10
-    assert results.uuid == "b"
+    assert results.centre_px == (50, 200)
+    assert results.x_dist_mm == 6
+    assert results.y_dist_mm == 63
+    assert results.omega == 20
+    assert results.uuid == "c"


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/1313

### Instructions to reviewer on how to test:
1. Confirm results are being filtered by the x pixel value rather than distance to beam centre (should keep small x, discard large x)
2. Confirm test has been correctly altered to test this

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
