### PR TITLE
Fix linting issue in CI

### DIFF
--- a/tests/devices/temperature_controller/lakeshore/test_lakeshore.py
+++ b/tests/devices/temperature_controller/lakeshore/test_lakeshore.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 from unittest.mock import ANY
 
 import numpy as np
@@ -95,7 +96,7 @@ async def test_lakeshore_set_control_channel_correctly_set_up_config(
     RE(abs_set(lakeshore.control_channel, control_channel, wait=True))
 
     config = ["user_setpoint", "p", "i", "d", "heater_output_range"]
-    expected_config = {
+    expected_config: dict[str, Any] = {
         f"lakeshore-control_channels-{control_channel}-{pv}": {"value": ANY}
         for pv in config
     }


### PR DESCRIPTION
Fixes type checking issue in `test_lakeshore.py`

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
