### PR TITLE
chore: Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "click",
     "ophyd",
     "ophyd-async[ca,pva]>=0.13.2",
-    "bluesky==1.14.2",  # https://github.com/bluesky/bluesky/issues/1938
+    "bluesky>=1.14.4",
     "pyepics",
     "dataclasses-json",
     "pillow",
@@ -29,7 +29,6 @@ dependencies = [
     "aiohttp",
     "redis",
     "scanspec>=0.7.3",
-    "event-model>=1.23",             # Until bluesky pins it https://github.com/DiamondLightSource/dodal/issues/1278
     "pyzmq==26.3.0",                 # Until we can move to RHEL 8 https://github.com/DiamondLightSource/mx-bluesky/issues/1139
     "deepdiff",
     "daq-config-server>=v1.0.0-rc.2",# For getting Configuration settings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "click",
     "ophyd",
     "ophyd-async[ca,pva]>=0.13.2",
-    "bluesky>=1.14.4",
+    "bluesky>=1.14.5",
     "pyepics",
     "dataclasses-json",
     "pillow",

--- a/tests/plan_stubs/test_wrapped_stubs.py
+++ b/tests/plan_stubs/test_wrapped_stubs.py
@@ -16,6 +16,8 @@ from dodal.plan_stubs.wrapped import (
     wait,
 )
 
+_EMPTY = ()
+
 
 @pytest.fixture
 def x_axis() -> SimMotor:
@@ -125,23 +127,23 @@ def test_sleep():
 def test_wait():
     # Waits for all groups
     assert list(wait()) == [
-        Msg("wait", group=None, timeout=None, error_on_timeout=True)
+        Msg("wait", group=None, timeout=None, error_on_timeout=True, watch=_EMPTY)
     ]
 
 
 def test_wait_group():
     assert list(wait("foo")) == [
-        Msg("wait", group="foo", timeout=None, error_on_timeout=True)
+        Msg("wait", group="foo", timeout=None, error_on_timeout=True, watch=_EMPTY)
     ]
 
 
 def test_wait_timeout():
     assert list(wait(timeout=5.0)) == [
-        Msg("wait", group=None, timeout=5.0, error_on_timeout=True)
+        Msg("wait", group=None, timeout=5.0, error_on_timeout=True, watch=_EMPTY)
     ]
 
 
 def test_wait_group_and_timeout():
     assert list(wait("foo", 5.0)) == [
-        Msg("wait", group="foo", timeout=5.0, error_on_timeout=True)
+        Msg("wait", group="foo", timeout=5.0, error_on_timeout=True, watch=_EMPTY)
     ]

--- a/tests/plans/test_scanspec.py
+++ b/tests/plans/test_scanspec.py
@@ -5,7 +5,7 @@ from typing import cast
 import pytest
 from bluesky.run_engine import RunEngine
 from event_model.documents import (
-    DocumentType,
+    Document,
     Event,
     EventDescriptor,
     RunStart,
@@ -26,7 +26,7 @@ def documents_from_expected_shape(
     RE: RunEngine,
     x_axis: SimMotor,
     y_axis: SimMotor,
-) -> dict[str, list[DocumentType]]:
+) -> dict[str, list[Document]]:
     shape: Sequence[int] = request.param
     motors = [x_axis, y_axis]
     # Does not support static, https://github.com/bluesky/scanspec/issues/154
@@ -35,7 +35,7 @@ def documents_from_expected_shape(
     for i in range(1, len(shape)):
         spec = spec * Line(motors[i], 0, 5, shape[i])
 
-    docs: dict[str, list[DocumentType]] = {}
+    docs: dict[str, list[Document]] = {}
     RE(
         spec_scan({det}, spec),  # type: ignore
         lambda name, doc: docs.setdefault(name, []).append(doc),
@@ -63,7 +63,7 @@ def length_from_shape(shape: tuple[int, ...]) -> int:
     indirect=["documents_from_expected_shape"],
 )
 def test_plan_produces_expected_start_document(
-    documents_from_expected_shape: dict[str, list[DocumentType]],
+    documents_from_expected_shape: dict[str, list[Document]],
     shape: tuple[int, ...],
     x_axis: SimMotor,
     y_axis: SimMotor,
@@ -93,7 +93,7 @@ def test_plan_produces_expected_start_document(
     indirect=["documents_from_expected_shape"],
 )
 def test_plan_produces_expected_stop_document(
-    documents_from_expected_shape: dict[str, list[DocumentType]], shape: tuple[int, ...]
+    documents_from_expected_shape: dict[str, list[Document]], shape: tuple[int, ...]
 ):
     docs = documents_from_expected_shape.get("stop")
     assert docs and len(docs) == 1
@@ -108,7 +108,7 @@ def test_plan_produces_expected_stop_document(
     indirect=["documents_from_expected_shape"],
 )
 def test_plan_produces_expected_descriptor(
-    documents_from_expected_shape: dict[str, list[DocumentType]],
+    documents_from_expected_shape: dict[str, list[Document]],
     det: StandardDetector,
     shape: tuple[int, ...],
 ):
@@ -126,7 +126,7 @@ def test_plan_produces_expected_descriptor(
     indirect=["documents_from_expected_shape"],
 )
 def test_plan_produces_expected_events(
-    documents_from_expected_shape: dict[str, list[DocumentType]],
+    documents_from_expected_shape: dict[str, list[Document]],
     shape: tuple[int, ...],
     det: StandardDetector,
     x_axis: SimMotor,
@@ -156,7 +156,7 @@ def test_plan_produces_expected_events(
     indirect=["documents_from_expected_shape"],
 )
 def test_plan_produces_expected_resources(
-    documents_from_expected_shape: dict[str, list[DocumentType]],
+    documents_from_expected_shape: dict[str, list[Document]],
     shape: tuple[int, ...],
     det: StandardDetector,
 ):
@@ -174,7 +174,7 @@ def test_plan_produces_expected_resources(
     indirect=["documents_from_expected_shape"],
 )
 def test_plan_produces_expected_datums(
-    documents_from_expected_shape: dict[str, list[DocumentType]],
+    documents_from_expected_shape: dict[str, list[Document]],
     shape: tuple[int, ...],
     det: StandardDetector,
 ):

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -5,7 +5,7 @@ import pytest
 from bluesky.protocols import Readable
 from bluesky.run_engine import RunEngine
 from event_model.documents import (
-    DocumentType,
+    Document,
     Event,
     EventDescriptor,
     RunStart,
@@ -23,8 +23,8 @@ from dodal.plans.wrapped import count
 @pytest.fixture
 def documents_from_num(
     request: pytest.FixtureRequest, det: StandardDetector, RE: RunEngine
-) -> dict[str, list[DocumentType]]:
-    docs: dict[str, list[DocumentType]] = {}
+) -> dict[str, list[Document]]:
+    docs: dict[str, list[Document]] = {}
     RE(
         count({det}, num=request.param),
         lambda name, doc: docs.setdefault(name, []).append(doc),
@@ -81,7 +81,7 @@ def test_count_num_validation(det: StandardDetector, RE):
     "documents_from_num, shape", ([1, (1,)], [3, (3,)]), indirect=["documents_from_num"]
 )
 def test_plan_produces_expected_start_document(
-    documents_from_num: dict[str, list[DocumentType]], shape: tuple[int, ...]
+    documents_from_num: dict[str, list[Document]], shape: tuple[int, ...]
 ):
     docs = documents_from_num.get("start")
     assert docs and len(docs) == 1
@@ -96,7 +96,7 @@ def test_plan_produces_expected_start_document(
     "documents_from_num, length", ([1, 1], [3, 3]), indirect=["documents_from_num"]
 )
 def test_plan_produces_expected_stop_document(
-    documents_from_num: dict[str, list[DocumentType]], length: int
+    documents_from_num: dict[str, list[Document]], length: int
 ):
     docs = documents_from_num.get("stop")
     assert docs and len(docs) == 1
@@ -107,7 +107,7 @@ def test_plan_produces_expected_stop_document(
 
 @pytest.mark.parametrize("documents_from_num", [1], indirect=True)
 def test_plan_produces_expected_descriptor(
-    documents_from_num: dict[str, list[DocumentType]], det: StandardDetector
+    documents_from_num: dict[str, list[Document]], det: StandardDetector
 ):
     docs = documents_from_num.get("descriptor")
     assert docs and len(docs) == 1
@@ -121,7 +121,7 @@ def test_plan_produces_expected_descriptor(
     "documents_from_num, length", ([1, 1], [3, 3]), indirect=["documents_from_num"]
 )
 def test_plan_produces_expected_events(
-    documents_from_num: dict[str, list[DocumentType]],
+    documents_from_num: dict[str, list[Document]],
     length: int,
     det: StandardDetector,
 ):
@@ -135,7 +135,7 @@ def test_plan_produces_expected_events(
 
 @pytest.mark.parametrize("documents_from_num", [1, 3], indirect=True)
 def test_plan_produces_expected_resources(
-    documents_from_num: dict[str, list[DocumentType]],
+    documents_from_num: dict[str, list[Document]],
     det: StandardDetector,
 ):
     docs = documents_from_num.get("stream_resource")
@@ -150,7 +150,7 @@ def test_plan_produces_expected_resources(
     "documents_from_num, length", ([1, 1], [3, 3]), indirect=["documents_from_num"]
 )
 def test_plan_produces_expected_datums(
-    documents_from_num: dict[str, list[DocumentType]],
+    documents_from_num: dict[str, list[Document]],
     length: int,
     det: StandardDetector,
 ):


### PR DESCRIPTION
Updates pinning of bluesky to pick up fixes to `subscribe` signature and remove direct pinning of `event-model`
Closes #1278 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
