### PR TITLE
Separate dspacing from base dcm and rename to common dcm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,7 @@
     "python.analysis.extraPaths": [
         "./src"
     ],
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.pythonProjects": []
 }

--- a/src/dodal/devices/common_dcm.py
+++ b/src/dodal/devices/common_dcm.py
@@ -31,18 +31,22 @@ Xtal_1 = TypeVar("Xtal_1", bound=StationaryCrystal)
 Xtal_2 = TypeVar("Xtal_2", bound=StationaryCrystal)
 
 
-class BaseDCM(StandardReadable, Generic[Xtal_1, Xtal_2]):
+class DualCrystalMonoEnergyBase(StandardReadable, Generic[Xtal_1, Xtal_2]):
     """
-    Common device for the double crystal monochromator (DCM), used to select the energy of the beam.
+    Device for a double crystal monochromators (DCM), which only allow energy of thebeam to be selected.
 
     Features common across all DCM's should include virtual motors to set energy/wavelength and contain two crystals,
-    each of which can be movable. Some DCM's contain crystals with roll motors, and some contain crystals with roll and pitch motors.
-    This base device accounts for all combinations of this.
+    each of which can be movable, but this base device only requires ENERGY and crystal.
+    Some DCM's contain crystals with roll motors, and some contain crystals with roll and pitch motors, but these can be defined
+    independently of this class.
 
-    This device should act as a parent for beamline-specific DCM's, in which any other missing signals can be added.
+    This device should act as a parent for beamline-specific DCM's, which aren't supported by BaseDCM.
+
+    This device is more able to act as a parent for beamline-specific DCM's, in which any other missing signals can be added,
+    as it doesn't assume WAVELENGTH, BRAGG, OFFSET and DSPACING:RBV are all available for all DCM deivces, as BaseDCM does.
 
     Bluesky plans using DCM's should be typed to specify which types of crystals are required. For example, a plan
-    which only requires one crystal which can roll should be typed 'def my_plan(dcm: BaseDCM[RollCrystal, StationaryCrystal])`
+    which only requires one crystal which can roll should be typed 'def my_plan(dcm: DualCrystalMonoEnergyBase[RollCrystal, StationaryCrystal])`
     """
 
     def __init__(
@@ -52,17 +56,6 @@ class BaseDCM(StandardReadable, Generic[Xtal_1, Xtal_2]):
             # Virtual motor PV's which set the physical motors so that the DCM produces requested
             # wavelength/energy
             self.energy_in_kev = Motor(prefix + "ENERGY")
-            self.wavelength_in_a = Motor(prefix + "WAVELENGTH")
-
-            # Real motors
-            self.bragg_in_degrees = Motor(prefix + "BRAGG")
-            # Offset ensures that the beam exits the DCM at the same point, regardless of energy.
-            self.offset_in_mm = Motor(prefix + "OFFSET")
-
-            self.crystal_metadata_d_spacing_a = epics_signal_r(
-                float, prefix + "DSPACING:RBV"
-            )
-
             self._make_crystals(prefix, xtal_1, xtal_2)
 
         super().__init__(name)
@@ -75,3 +68,37 @@ class BaseDCM(StandardReadable, Generic[Xtal_1, Xtal_2]):
         else:
             self.xtal_1 = xtal_1(prefix)
             self.xtal_2 = xtal_2(prefix)
+
+
+class BaseDCM(DualCrystalMonoEnergyBase, Generic[Xtal_1, Xtal_2]):
+    """
+    Device for a common subset of double crystal monochromator (DCM) devices, used to select the energy of the beam.
+
+    Features common across many DCM's include virtual motors to set energy/wavelength and contain two crystals,
+    each of which can be movable. Some DCM's contain crystals with roll motors, and some contain crystals with roll and pitch motors.
+    This device accounts for all combinations of this.
+
+    This device should act as a parent for beamline-specific DCM's, which support all reauired PVs, otherwise DualCrystalMonoEnergyBase should be used.
+
+    Bluesky plans using DCM's should be typed to specify which types of crystals are required. For example, a plan
+    which only requires one crystal which can roll should be typed 'def my_plan(dcm: BaseDCM[RollCrystal, StationaryCrystal])`
+    """
+
+    def __init__(
+        self, prefix: str, xtal_1: type[Xtal_1], xtal_2: type[Xtal_2], name: str = ""
+    ) -> None:
+        with self.add_children_as_readables():
+            # Virtual motor PV's which set the physical motors so that the DCM produces requested
+            # wavelength/energy
+            self.wavelength_in_a = Motor(prefix + "WAVELENGTH")
+
+            # Real motors
+            self.bragg_in_degrees = Motor(prefix + "BRAGG")
+            # Offset ensures that the beam exits the DCM at the same point, regardless of energy.
+            self.offset_in_mm = Motor(prefix + "OFFSET")
+
+            self.crystal_metadata_d_spacing_a = epics_signal_r(
+                float, prefix + "DSPACING:RBV"
+            )
+
+        super().__init__(prefix, xtal_1, xtal_2, name)

--- a/src/dodal/devices/common_dcm.py
+++ b/src/dodal/devices/common_dcm.py
@@ -33,17 +33,17 @@ Xtal_2 = TypeVar("Xtal_2", bound=StationaryCrystal)
 
 class DualCrystalMonoEnergyBase(StandardReadable, Generic[Xtal_1, Xtal_2]):
     """
-    Device for a double crystal monochromators (DCM), which only allow energy of thebeam to be selected.
+    Device for a double crystal monochromators (DCM), which only allow energy of the beam to be selected.
 
     Features common across all DCM's should include virtual motors to set energy/wavelength and contain two crystals,
     each of which can be movable, but this base device only requires ENERGY and crystal.
     Some DCM's contain crystals with roll motors, and some contain crystals with roll and pitch motors, but these can be defined
     independently of this class.
 
-    This device should act as a parent for beamline-specific DCM's, which aren't supported by BaseDCM.
+    This device should act as a parent for beamline-specific DCM's, which aren't supported by CommonDCM.
 
     This device is more able to act as a parent for beamline-specific DCM's, in which any other missing signals can be added,
-    as it doesn't assume WAVELENGTH, BRAGG, OFFSET and DSPACING:RBV are all available for all DCM deivces, as BaseDCM does.
+    as it doesn't assume WAVELENGTH, BRAGG, OFFSET and DSPACING:RBV are all available for all DCM deivces, as CommonDCM does.
 
     Bluesky plans using DCM's should be typed to specify which types of crystals are required. For example, a plan
     which only requires one crystal which can roll should be typed 'def my_plan(dcm: DualCrystalMonoEnergyBase[RollCrystal, StationaryCrystal])`
@@ -78,7 +78,8 @@ class BaseDCM(DualCrystalMonoEnergyBase, Generic[Xtal_1, Xtal_2]):
     each of which can be movable. Some DCM's contain crystals with roll motors, and some contain crystals with roll and pitch motors.
     This device accounts for all combinations of this.
 
-    This device should act as a parent for beamline-specific DCM's, which support all reauired PVs, otherwise DualCrystalMonoEnergyBase should be used.
+    This device is suitable as a parent for beamline-specific DCM's which do not collect DSPACING as metadata via EPICS.  If the
+    beamline has this PV avaliable CommonDCM (which includes it) should be used as the standard.
 
     Bluesky plans using DCM's should be typed to specify which types of crystals are required. For example, a plan
     which only requires one crystal which can roll should be typed 'def my_plan(dcm: BaseDCM[RollCrystal, StationaryCrystal])`
@@ -97,8 +98,27 @@ class BaseDCM(DualCrystalMonoEnergyBase, Generic[Xtal_1, Xtal_2]):
             # Offset ensures that the beam exits the DCM at the same point, regardless of energy.
             self.offset_in_mm = Motor(prefix + "OFFSET")
 
+        super().__init__(prefix, xtal_1, xtal_2, name)
+
+
+class CommonDCM(BaseDCM):
+    """
+    Device for a common subset of double crystal monochromator (DCM) devices, used to select the energy of the beam.
+
+    Features common across many DCM's include virtual motors to set energy/wavelength and contain two crystals,
+    each of which can be movable. Some DCM's contain crystals with roll motors, and some contain crystals with roll and pitch motors.
+    This device accounts for all combinations of this.
+
+    This device should act as a parent for beamline-specific DCM's, which support all required PVs, otherwise DualCrystalMonoEnergyBase
+    or BaseDCM should be used.
+
+    Bluesky plans using DCM's should be typed to specify which types of crystals are required. For example, a plan
+    which only requires one crystal which can roll should be typed 'def my_plan(dcm: CommonDCM[RollCrystal, StationaryCrystal])`
+    """
+
+    def __init__(self, prefix: str, xtal_1: type, xtal_2: type, name: str = "") -> None:
+        with self.add_children_as_readables():
             self.crystal_metadata_d_spacing_a = epics_signal_r(
                 float, prefix + "DSPACING:RBV"
             )
-
         super().__init__(prefix, xtal_1, xtal_2, name)

--- a/src/dodal/devices/i15/dcm.py
+++ b/src/dodal/devices/i15/dcm.py
@@ -1,9 +1,7 @@
-from typing import Generic, TypeVar
-
-from ophyd_async.core import StandardReadable
 from ophyd_async.epics.motor import Motor
 
 from dodal.devices.common_dcm import (
+    DualCrystalMonoEnergyBase,
     StationaryCrystal,
 )
 
@@ -24,47 +22,7 @@ class ThetaRollYZCrystal(ThetaYCrystal):
         super().__init__(prefix)
 
 
-Xtal_1 = TypeVar("Xtal_1", bound=StationaryCrystal)
-Xtal_2 = TypeVar("Xtal_2", bound=StationaryCrystal)
-
-
-class DualCrystalMonoSimple(StandardReadable, Generic[Xtal_1, Xtal_2]):
-    """
-    Device for simple double crystal monochromators (DCM), which only allow energy of the beam to be selected.
-
-    Features common across all DCM's should include virtual motors to set energy/wavelength and contain two crystals,
-    each of which can be movable. Some DCM's contain crystals with roll motors, and some contain crystals with roll and pitch motors.
-    This base device accounts for all combinations of this.
-
-    This device is more able to act as a parent for beamline-specific DCM's, in which any other missing signals can be added,
-    as it doesn't assume WAVELENGTH, BRAGG and OFFSET are available for all DCM deivces, as BaseDCM does.
-
-    Bluesky plans using DCM's should be typed to specify which types of crystals are required. For example, a plan
-    which only requires one crystal which can roll should be typed 'def my_plan(dcm: BaseDCM[RollCrystal, StationaryCrystal])`
-    """
-
-    def __init__(
-        self, prefix: str, xtal_1: type[Xtal_1], xtal_2: type[Xtal_2], name: str = ""
-    ) -> None:
-        with self.add_children_as_readables():
-            # Virtual motor PV's which set the physical motors so that the DCM produces requested
-            # wavelength/energy
-            self.energy_in_kev = Motor(prefix + "ENERGY")
-            self._make_crystals(prefix, xtal_1, xtal_2)
-
-        super().__init__(name)
-
-    # Prefix convention is different depending on whether there are one or two controllable crystals
-    def _make_crystals(self, prefix: str, xtal_1: type[Xtal_1], xtal_2: type[Xtal_2]):
-        if StationaryCrystal not in [xtal_1, xtal_2]:
-            self.xtal_1 = xtal_1(f"{prefix}XTAL1:")
-            self.xtal_2 = xtal_2(f"{prefix}XTAL2:")
-        else:
-            self.xtal_1 = xtal_1(prefix)
-            self.xtal_2 = xtal_2(prefix)
-
-
-class DCM(DualCrystalMonoSimple[ThetaRollYZCrystal, ThetaYCrystal]):
+class DCM(DualCrystalMonoEnergyBase[ThetaRollYZCrystal, ThetaYCrystal]):
     """
     A double crystal monocromator device, used to select the beam energy.
     """

--- a/src/dodal/devices/i15/focussing_mirror.py
+++ b/src/dodal/devices/i15/focussing_mirror.py
@@ -21,11 +21,7 @@ class FocusingMirrorBase(StandardReadable):
 class FocusingMirrorHorizontal(FocusingMirrorBase):
     """Focusing Mirror with curve, ellip, pitch & X"""
 
-    def __init__(
-        self,
-        prefix: str,
-        name: str = "",
-    ):
+    def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.x = Motor(prefix + "X")
 

--- a/src/dodal/devices/i15/jack.py
+++ b/src/dodal/devices/i15/jack.py
@@ -5,11 +5,7 @@ from ophyd_async.epics.motor import Motor
 class JackX(StandardReadable):
     """Focusing Mirror"""
 
-    def __init__(
-        self,
-        prefix: str,
-        name: str = "",
-    ):
+    def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.rotation = Motor(prefix + "Ry")
             self.transx = Motor(prefix + "X")
@@ -23,11 +19,7 @@ class JackX(StandardReadable):
 class JackY(StandardReadable):
     """Focusing Mirror"""
 
-    def __init__(
-        self,
-        prefix: str,
-        name: str = "",
-    ):
+    def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.j1 = Motor(prefix + "J1")
             self.j2 = Motor(prefix + "J2")

--- a/src/dodal/devices/i15/laue.py
+++ b/src/dodal/devices/i15/laue.py
@@ -3,11 +3,7 @@ from ophyd_async.epics.motor import Motor
 
 
 class LaueMonochrometer(StandardReadable):
-    def __init__(
-        self,
-        prefix: str,
-        name: str = "",
-    ):
+    def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.bend = Motor(prefix + "BENDER")
             self.bragg = Motor(prefix + "PITCH")

--- a/src/dodal/devices/i15/multilayer_mirror.py
+++ b/src/dodal/devices/i15/multilayer_mirror.py
@@ -5,11 +5,7 @@ from ophyd_async.epics.motor import Motor
 class MultiLayerMirror(StandardReadable):
     """Multilayer Mirror"""
 
-    def __init__(
-        self,
-        prefix: str,
-        name: str = "",
-    ):
+    def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.ds_x = Motor(prefix + "X2")
             self.ds_y = Motor(prefix + "J3")

--- a/src/dodal/devices/i15/rail.py
+++ b/src/dodal/devices/i15/rail.py
@@ -3,11 +3,7 @@ from ophyd_async.epics.motor import Motor
 
 
 class Rail(StandardReadable):
-    def __init__(
-        self,
-        prefix: str,
-        name: str = "",
-    ):
+    def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
             self.pitch = Motor(prefix + "PITCH")
             self.y = Motor(prefix + "Y")

--- a/tests/devices/i15/test_dcm.py
+++ b/tests/devices/i15/test_dcm.py
@@ -1,7 +1,0 @@
-from dodal.devices.common_dcm import RollCrystal, StationaryCrystal
-from dodal.devices.i15.dcm import DualCrystalMonoSimple
-
-
-def test_make_crystals():
-    dcm = DualCrystalMonoSimple("prefix:", RollCrystal, StationaryCrystal)
-    assert dcm.xtal_1.roll_in_mrad.user_setpoint.source == "ca://prefix:ROLL.VAL"


### PR DESCRIPTION
Fixes #1555 

I have also renamed the classes so CommonDCM should be used by most beamlines and BaseDCM is its parent.  This is only in draft because a) it's waiting for the conclusion of the discussion here https://github.com/DiamondLightSource/dodal/pull/1601 (there is a meeting about this planned) and b) I have not yet been through the beamline files to replace "BaseDCM" with "CommonDCM".  If we decide to go with this approach I will do both of these.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
