### PR TITLE
Murko: filter out small results with tiny x pixel value

### DIFF
--- a/tests/devices/i04/test_murko_results.py
+++ b/tests/devices/i04/test_murko_results.py
@@ -413,7 +413,7 @@ async def test_correct_movement_given_multiple_angles_and_x_drift(
 ):
     murko_results.PERCENTAGE_TO_USE = 100  # type:ignore
     murko_results.stop_angle = 250
-    x = 0.1
+    x = 0.7
     y = 0.2
     z = 0.3
     xyz = (x, y, z)
@@ -533,7 +533,7 @@ def test_given_n_results_filter_outliers_will_reduce_down_to_smaller_amount(
 ):
     murko_results._results = [
         MurkoResult(
-            centre_px=(i, 100),
+            centre_px=(i + 11, 100),
             x_dist_mm=i,
             y_dist_mm=i,
             omega=i,


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/1340

### Instructions to reviewer on how to test:
1. Check smallest results are being filtered out
2. Check added test passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
