### PR TITLE
Fix PIL typing again

### DIFF
--- a/tests/devices/oav/test_snapshots.py
+++ b/tests/devices/oav/test_snapshots.py
@@ -116,11 +116,12 @@ def image_data_coro(image_bytes: BytesIO) -> AsyncMock:
 
 
 def assert_images_identical(left: Image.Image, right: Image.Image):
-    left_data = list(left.getdata())  # type:ignore # Can remove once https://github.com/python-pillow/Pillow/pull/9261 is released
-    right_data = list(right.getdata())  # type:ignore # Can remove once https://github.com/python-pillow/Pillow/pull/9261 is released
-    assert len(left_data) == len(right_data)
-    for i in range(len(left_data)):
-        assert left_data[i] == right_data[i]
+    assert all(
+        left_px == right_px
+        for left_px, right_px in zip(
+            iter(left.getdata()), iter(right.getdata()), strict=True
+        )
+    )
 
 
 async def test_snapshot_correctly_triggered_and_saved(


### PR DESCRIPTION
See https://github.com/DiamondLightSource/dodal/pull/1630#discussion_r2435333924

### Instructions to reviewer on how to test:
1. Confirm tests pass and pyright is happy

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
