### PR TITLE
Pin pyright to 1.1.406

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "pre-commit",
     "psutil",
     "pydata-sphinx-theme>=0.12",
-    "pyright",
+    "pyright==1.1.406",          # Pinned due to https://github.com/microsoft/pyright/issues/11060
     "pytest",
     "pytest-asyncio",
     "pytest-cov",


### PR DESCRIPTION
Dodal is experiencing weird linting failures e.g https://github.com/DiamondLightSource/dodal/actions/runs/18841924696/job/53762673654

As discussed on slack https://diamondlightsource.slack.com/archives/C051NDJH6BZ/p1761574539268019, we have agreed to pin pyright 1.1.406 as this appears to be a bug https://github.com/microsoft/pyright/issues/11060

### Instructions to reviewer on how to test:
1. Check tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
