### PR TITLE
Tidy up test_when_beamsize_set_then_set_correctly_on_device_and_waited_on

### DIFF
--- a/tests/devices/i04/test_transfocator.py
+++ b/tests/devices/i04/test_transfocator.py
@@ -53,9 +53,7 @@ async def test_when_beamsize_set_then_set_correctly_on_device(
     fake_transfocator: Transfocator,
 ):
     given_predicted_lenses_is_half_of_beamsize(fake_transfocator)
-    set_status = fake_transfocator.set(315)
-
-    await set_status
+    await fake_transfocator.set(315)
 
     assert fake_transfocator.predicted_vertical_num_lenses.get_value() == 157
     assert fake_transfocator.number_filters_sp.get_value() == 157


### PR DESCRIPTION
Fixes #1687 

It's not obvious where the flakiness is coming from but this simplifies the test at least

### Instructions to reviewer on how to test:
1. Confirm test still passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
