### PR TITLE
Rename b01_1 panda

### DIFF
--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -37,7 +37,7 @@ def panda() -> HDFPanda:
         HDFPanda: The HDF5-based detector trigger device.
     """
     return HDFPanda(
-        f"{PREFIX.beamline_prefix}-MO-PANDA-01:",
+        f"{PREFIX.beamline_prefix}-MO-PPANDA-01:",
         path_provider=get_path_provider(),
     )
 


### PR DESCRIPTION
Fixes panda connection issue on ViSR (b01-1)

### Instructions to reviewer on how to test:
1. Connect to b01-1-ws001 to access PVs for connection
2. run `dodal connect b01_1` from there
3. Confirm panda connects

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
