### PR TITLE
Fix test for latest ophyd-async

### DIFF
--- a/tests/devices/i24/test_pmac.py
+++ b/tests/devices/i24/test_pmac.py
@@ -68,15 +68,16 @@ async def test_set_pmac_string_for_enc_reset(fake_pmac: PMAC, run_engine: RunEng
 
 
 async def test_run_program(fake_pmac: PMAC):
-    async def go_high_then_low():
-        set_mock_value(fake_pmac.scanstatus, 1)
-        await asyncio.sleep(0.01)
-        set_mock_value(fake_pmac.scanstatus, 0)
+    def go_high_then_low(value, *_, **__):
+        async def async_go_high_then_low():
+            set_mock_value(fake_pmac.scanstatus, 1)
+            await asyncio.sleep(0.01)
+            set_mock_value(fake_pmac.scanstatus, 0)
 
-    callback_on_mock_put(
-        fake_pmac.pmac_string,
-        lambda *args, **kwargs: asyncio.create_task(go_high_then_low()),  # type: ignore
-    )
+        asyncio.create_task(async_go_high_then_low())
+        return value
+
+    callback_on_mock_put(fake_pmac.pmac_string, go_high_then_low)
 
     set_mock_value(fake_pmac.program_number, 11)
     await fake_pmac.run_program.kickoff()


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/dodal/issues/1692

### Instructions to reviewer on how to test:
1. Update `ophyd-async` (`pip uninstall ophyd-async && pip install ophyd-async[sim]`)
2. Confirm that test fails on main
3. Confirm test passes here

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
