### PR TITLE
Wrap plans and plan stubs

### DIFF
--- a/src/dodal/plan_stubs/__init__.py
+++ b/src/dodal/plan_stubs/__init__.py
@@ -1,3 +1,21 @@
-from .wrapped import move, move_relative, set_absolute, set_relative, sleep, wait
+from .wrapped import (
+    move,
+    move_relative,
+    rd,
+    set_absolute,
+    set_relative,
+    sleep,
+    stop,
+    wait,
+)
 
-__all__ = ["move", "move_relative", "set_absolute", "set_relative", "sleep", "wait"]
+__all__ = [
+    "move",
+    "move_relative",
+    "rd",
+    "set_absolute",
+    "set_relative",
+    "sleep",
+    "stop",
+    "wait",
+]

--- a/src/dodal/plan_stubs/wrapped.py
+++ b/src/dodal/plan_stubs/wrapped.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from typing import Annotated, TypeVar
 
 import bluesky.plan_stubs as bps
-from bluesky.protocols import Movable
+from bluesky.protocols import Movable, Readable, Stoppable
 from bluesky.utils import MsgGenerator
 
 """
@@ -146,3 +146,27 @@ def wait(
     """
 
     return (yield from bps.wait(group, timeout=timeout))
+
+
+def rd(readable: Readable) -> MsgGenerator:
+    """Reads a single-value non-triggered object, wrapper for `bp.rd`.
+
+    Args:
+        readable (Readable): The device to be read
+
+    Returns:
+        Iterator[MsgGenerator]: Bluesky messages
+    """
+    return (yield from bps.rd(readable))
+
+
+def stop(stoppable: Stoppable) -> MsgGenerator:
+    """Stop a device, wrapper for `bp.stop`.
+
+    Args:
+        stoppable (Stoppable): Device to be stopped
+
+    Returns:
+        Iterator[MsgGenerator]: Bluesky messages
+    """
+    return (yield from bps.stop(stoppable))

--- a/src/dodal/plans/__init__.py
+++ b/src/dodal/plans/__init__.py
@@ -9,6 +9,10 @@ from .wrapped import (
     list_scan,
     num_rscan,
     num_scan,
+    step_grid_rscan,
+    step_grid_scan,
+    step_rscan,
+    step_scan,
 )
 
 __all__ = [
@@ -22,4 +26,8 @@ __all__ = [
     "num_rscan",
     "num_scan",
     "spec_scan",
+    "step_grid_rscan",
+    "step_grid_scan",
+    "step_rscan",
+    "step_scan",
 ]

--- a/src/dodal/plans/__init__.py
+++ b/src/dodal/plans/__init__.py
@@ -1,4 +1,25 @@
 from .scanspec import spec_scan
-from .wrapped import count, grid_scan, rel_grid_scan, rel_scan, scan
+from .wrapped import (
+    count,
+    grid_num_rscan,
+    grid_num_scan,
+    list_grid_rscan,
+    list_grid_scan,
+    list_rscan,
+    list_scan,
+    num_rscan,
+    num_scan,
+)
 
-__all__ = ["count", "grid_scan", "rel_grid_scan", "rel_scan", "scan", "spec_scan"]
+__all__ = [
+    "count",
+    "grid_num_rscan",
+    "grid_num_scan",
+    "list_grid_rscan",
+    "list_grid_scan",
+    "list_rscan",
+    "list_scan",
+    "num_rscan",
+    "num_scan",
+    "spec_scan",
+]

--- a/src/dodal/plans/__init__.py
+++ b/src/dodal/plans/__init__.py
@@ -1,4 +1,4 @@
 from .scanspec import spec_scan
-from .wrapped import count
+from .wrapped import count, grid_scan, rel_grid_scan, rel_scan, scan
 
-__all__ = ["count", "spec_scan"]
+__all__ = ["count", "grid_scan", "rel_grid_scan", "rel_scan", "scan", "spec_scan"]

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -29,7 +29,7 @@ Limits and metadata (e.g. units)
 @validate_call(config={"arbitrary_types_allowed": True})
 def count(
     detectors: Annotated[
-        set[Readable] | set[AsyncReadable],
+        set[Readable | AsyncReadable],
         Field(
             description="Set of readable devices, will take a reading at each point",
             min_length=1,
@@ -78,7 +78,7 @@ def _make_args(movables, params, num_params):
 @validate_call(config={"arbitrary_types_allowed": True})
 def scan(
     detectors: Annotated[
-        set[Readable] | set[AsyncReadable],
+        set[Readable | AsyncReadable],
         Field(
             description="Set of readable devices, will take a reading at each point",
             min_length=1,
@@ -109,7 +109,7 @@ def scan(
 @validate_call(config={"arbitrary_types_allowed": True})
 def rel_scan(
     detectors: Annotated[
-        set[Readable] | set[AsyncReadable],
+        set[Readable | AsyncReadable],
         Field(
             description="Set of readable devices, will take a reading at each point",
             min_length=1,
@@ -140,7 +140,7 @@ def rel_scan(
 @validate_call(config={"arbitrary_types_allowed": True})
 def grid_scan(
     detectors: Annotated[
-        set[Readable] | set[AsyncReadable],
+        set[Readable | AsyncReadable],
         Field(
             description="Set of readable devices, will take a reading at each point",
             min_length=1,
@@ -170,7 +170,7 @@ def grid_scan(
 @validate_call(config={"arbitrary_types_allowed": True})
 def rel_grid_scan(
     detectors: Annotated[
-        set[Readable] | set[AsyncReadable],
+        set[Readable | AsyncReadable],
         Field(
             description="Set of readable devices, will take a reading at each point",
             min_length=1,

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -349,6 +349,9 @@ def _make_stepped_list(
     if len(params) == 3:
         stop = params[1]
         step = params[2]
+        if abs(step) > abs(stop - start):
+            step = abs(stop - start)
+        step = abs(step) * np.sign(stop - start)
         stepped_list = np.arange(start=start, stop=stop, step=step).tolist()
         if abs((stepped_list[-1] + step) - stop) <= abs(step * 0.01):
             stepped_list.append(stepped_list[-1] + step)

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -55,3 +55,111 @@ def count(
     metadata = metadata or {}
     metadata["shape"] = (num,)
     yield from bp.count(tuple(detectors), num, delay=delay, md=metadata)
+
+
+def scan(
+    detectors: Annotated[
+        set[Readable] | list[Readable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    args: Annotated[
+        tuple,
+        Field(
+            description="For one or more dimensions, 'motor1, start1, stop1, ..., "
+            "motorN, startN, stopN'. Motors can be any 'settable' object (motor, "
+            "temp controller, etc.)"
+        ),
+    ],
+    num: Annotated[int, Field(description="Number of points")],
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over one multi-motor trajectory.
+    Wraps bluesky.plans.scan(det, *args, num, md=metadata)"""
+    metadata = metadata or {}
+    metadata["shape"] = (num,)
+    yield from bp.scan(tuple(detectors), *args, num=num, md=metadata)
+
+
+def rel_scan(
+    detectors: Annotated[
+        set[Readable] | list[Readable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    args: Annotated[
+        tuple,
+        Field(
+            description="For one or more dimensions, 'motor1, start1, stop1, ..., "
+            "motorN, startN, stopN'. Motors can be any 'settable' object (motor, "
+            "temp controller, etc.)"
+        ),
+    ],
+    num: Annotated[int, Field(description="Number of points")],
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over one multi-motor trajectory, relative to current position.
+    Wraps bluesky.plans.rel_scan(det, *args, num, md=metadata)"""
+    metadata = metadata or {}
+    metadata["shape"] = (num,)
+    yield from bp.rel_scan(tuple(detectors), *args, num=num, md=metadata)
+
+
+def grid_scan(
+    detectors: Annotated[
+        set[Readable] | list[Readable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    args: Annotated[
+        tuple,
+        Field(
+            description="Patterend like (motor1, start1, stop1, num1, ..., motorN, "
+            "startN, stopN, numN). The first motor is the 'slowest', the outer loop. "
+            "For all motors except the first motor, there is a 'snake' argument: a"
+            "boolean indicating whether to follow snake-like, winding trajectory or a"
+            "simple left to right."
+        ),
+    ],
+    snake_axes: list | bool | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over a mesh; each motor is on an independent trajectory.
+    Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata)"""
+    metadata = metadata or {}
+    yield from bp.grid_scan(tuple(detectors), *args, snake_axes=snake_axes, md=metadata)
+
+
+def rel_grid_scan(
+    detectors: Annotated[
+        set[Readable] | list[Readable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    args: Annotated[
+        tuple,
+        Field(
+            description="Patterend like (motor1, start1, stop1, num1, ..., motorN, "
+            "startN, stopN, numN). The first motor is the 'slowest', the outer loop. "
+            "For all motors except the first motor, there is a 'snake' argument: a"
+            "boolean indicating whether to follow snake-like, winding trajectory or a"
+            "simple left to right."
+        ),
+    ],
+    snake_axes: list | bool | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over a mesh relative to current position.
+    Wraps bluesky.plans.rel_grid_scan(det, *args, snake_axes, md=metadata)"""
+    metadata = metadata or {}
+    yield from bp.rel_grid_scan(
+        tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+    )

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -62,37 +62,6 @@ def count(
     yield from bp.count(tuple(detectors), num, delay=delay, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
-@validate_call(config={"arbitrary_types_allowed": True})
-def mapping_num_scan(
-    detectors: Annotated[
-        Sequence[Readable | AsyncReadable],
-        Field(
-            description="Set of readable devices, will take a reading at each point",
-            min_length=1,
-        ),
-    ],
-    params: dict[Movable | Motor, list[float | int]],
-    num: Annotated[int, Field(description="Number of points")],
-    metadata: dict[str, Any] | None = None,
-):
-    """Scan over one multi-motor trajectory.
-    Wraps bluesky.plans.scan(det, *args, num, md=metadata)"""
-    metadata = metadata or {}
-    metadata["shape"] = (num,)
-
-    args = _make_new_args(params)
-    yield from bp.scan(tuple(detectors), *args, num=num, md=metadata)
-
-
-def _make_new_args(params: dict[Movable | Motor, list[float | int]]):
-    args = []
-    for param in params:
-        args.append(param)
-        args.extend(params[param])
-    return args
-
-
 def _make_args(
     movers: Sequence[Movable | Motor],
     params: list[Any] | Sequence[Any],

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import Annotated, Any
 
 import bluesky.plans as bp
+import numpy as np
 from bluesky.protocols import Movable, Readable
 from ophyd_async.core import AsyncReadable
 from pydantic import Field, NonNegativeFloat, validate_call
@@ -67,15 +68,15 @@ def _make_args(
 ):
     movers_len = len(movers)
     params_len = len(params)
-    if params_len % movers_len != 0 or params_len % num_params != 0:
-        raise ValueError(f"params must contain {num_params} values for each movable")
-
     args = []
-    it = iter(params)
-    param_chunks = iter(lambda: tuple(itertools.islice(it, num_params)), ())
-    for movable, param_chunk in zip(movers, param_chunks, strict=False):
-        args.append(movable)
-        args.extend(param_chunk)
+    if params_len % movers_len == 0 and params_len % num_params == 0:
+        it = iter(params)
+        param_chunks = iter(lambda: tuple(itertools.islice(it, num_params)), ())
+        for movable, param_chunk in zip(movers, param_chunks, strict=False):
+            args.append(movable)
+            args.extend(param_chunk)
+    else:
+        raise ValueError(f"params must contain {num_params} values for each movable")
     return args
 
 
@@ -160,8 +161,8 @@ def grid_num_scan(
     params: Annotated[
         Sequence[float | int],
         Field(
-            description="Start and stop points for each movable, 'start1, stop1, ...,"
-            "startN, stopN' for every movable in `movers`."
+            description="Start and stop and number of points for each movable, 'start1,"
+            "stop1, num1, ..., startN, stopN, numN' for every movable in `movers`."
         ),
     ],
     snake_axes: list | bool | None = None,
@@ -191,8 +192,8 @@ def grid_num_rscan(
     params: Annotated[
         Sequence[float | int],
         Field(
-            description="Start and stop points for each movable, 'start1, stop1, ...,"
-            "startN, stopN' for every movable in `movers`."
+            description="Start and stop and number of points for each movable, 'start1,"
+            "stop1, num1, ..., startN, stopN, numN' for every movable in `movers`."
         ),
     ],
     snake_axes: list | bool | None = None,
@@ -233,8 +234,6 @@ def list_scan(
     """Scan over one or more variables in steps simultaneously.
     Wraps bluesky.plans.list_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
-    shape = [len(positions) for positions in params]
-    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
     yield from bp.list_scan(tuple(detectors), *args, md=metadata)
 
@@ -265,8 +264,6 @@ def list_rscan(
     """Scan over one or more variables simultaneously relative to current position.
     Wraps bluesky.plans.rel_list_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
-    shape = [len(positions) for positions in params]
-    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
     yield from bp.rel_list_scan(tuple(detectors), *args, md=metadata)
 
@@ -298,8 +295,6 @@ def list_grid_scan(
     """Scan over one or more variables for each given point on independent trajectories.
     Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
-    shape = [len(positions) for positions in params]
-    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
     yield from bp.list_grid_scan(
         tuple(detectors), *args, snake_axes=snake_axes, md=metadata
@@ -333,9 +328,218 @@ def list_grid_rscan(
     """Scan over some variables for each given point relative to current position.
     Wraps bluesky.plans.rel_list_grid_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
-    shape = [len(positions) for positions in params]
-    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
+    yield from bp.rel_list_grid_scan(
+        tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+    )
+
+
+def _make_stepped_list(
+    params: list[Any] | Sequence[Any],
+    num: int | None = None,
+):
+    start = params[0]
+    if len(params) == 3:
+        stop = params[1]
+        step = params[2]
+        stepped_list = np.arange(start=start, stop=stop, step=step).tolist()
+        if abs((stepped_list[-1] + step) - stop) <= (step * 0.01):
+            stepped_list.append(stepped_list[-1] + step)
+    elif len(params) == 2 and num:
+        step = params[1]
+        stepped_list = [start + (n * step) for n in range(num)]
+    else:
+        stepped_list = []
+    return stepped_list
+
+
+def _make_concurrently_stepped_lists(
+    movers_len: int,
+    params: list[Any] | Sequence[Any],
+):
+    # separate out the first three elements
+    # separate the rest of the elements into chunks of two
+    stepped_lists = []
+    params_len = len(params)
+    if movers_len == 1 and params_len == 3:
+        stepped_lists.append(_make_stepped_list(params))
+    elif movers_len > 1 and (params_len - 3) % 2 == 0:
+        leader_params = params[:3]
+        follower_params = params[3:]
+        stepped_lists.append(_make_stepped_list(leader_params))
+        num = len(stepped_lists[0])
+        it = iter(follower_params)
+        param_chunks = iter(lambda: tuple(itertools.islice(it, 2)), ())
+        for param_chunk in param_chunks:
+            stepped_lists.append(_make_stepped_list(param_chunk, num=num))
+    else:
+        raise ValueError(
+            "params must contain 3 values for the first movable and 2 values for each "
+            "successive movable."
+        )
+    return stepped_lists
+
+
+def _make_independently_stepped_lists(
+    movers_len: int,
+    params: list[Any] | Sequence[Any],
+):
+    num_params = 3  # It will always be start stop step for each axis
+    stepped_lists = []
+    params_len = len(params)
+    if params_len % movers_len == 0 and params_len % num_params == 0:
+        it = iter(params)
+        param_chunks = iter(lambda: tuple(itertools.islice(it, num_params)), ())
+        for param_chunk in param_chunks:
+            stepped_lists.append(_make_stepped_list(param_chunk))
+    else:
+        raise ValueError(f"params must contain {num_params} values for each movable")
+    return stepped_lists
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def step_scan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    movers: Annotated[
+        Sequence[Movable | Motor],
+        Field(description="One or more movable to move during the scan."),
+    ],
+    params: Annotated[
+        list[Any],
+        Field(
+            description="Start, stop, and step values for the first movable, and start "
+            "and step values for each successive movable, 'start1, stop1, step1, "
+            "start2, step 2, ..., startN, stepN' for every movable in `movers`."
+        ),
+    ],
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over one multi-motor trajectory with specified step size.
+    Generates lists of points for each trajectory for bp.list_scan.
+    """
+    movers_len = len(movers)
+    stepped_lists = _make_concurrently_stepped_lists(
+        movers_len=movers_len, params=params
+    )
+    metadata = metadata or {}
+    args = _make_args(movers=movers, params=stepped_lists, num_params=1)
+    yield from bp.list_scan(tuple(detectors), *args, md=metadata)
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def step_rscan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    movers: Annotated[
+        Sequence[Movable | Motor],
+        Field(description="One or more movable to move during the scan."),
+    ],
+    params: Annotated[
+        list[Any],
+        Field(
+            description="Start, stop, and step values for the first movable, and start "
+            "and step values for each successive movable, 'start1, stop1, step1, "
+            "start2, step 2, ..., startN, stepN' for every movable in `movers`."
+        ),
+    ],
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over multi-motor trajectory relative to position with specified step size.
+    Generates lists of points for each trajectory for bp.rel_list_scan.
+    """
+    movers_len = len(movers)
+    stepped_lists = _make_concurrently_stepped_lists(
+        movers_len=movers_len, params=params
+    )
+    metadata = metadata or {}
+    args = _make_args(movers=movers, params=stepped_lists, num_params=1)
+    yield from bp.rel_list_scan(tuple(detectors), *args, md=metadata)
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def step_grid_scan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    movers: Annotated[
+        Sequence[Movable | Motor],
+        Field(description="One or more movable to move during the scan."),
+    ],
+    params: Annotated[
+        list[Any],
+        Field(
+            description="Start, stop, and step values 'start1, stop1, step1, ..., "
+            "startN, stepN' for every movable in `movers`."
+        ),
+    ],
+    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over independent multi-motor trajectories with specified step size.
+    Generates lists of points for each trajectory for bp.list_grid_scan.
+    """
+    movers_len = len(movers)
+    stepped_lists = _make_independently_stepped_lists(
+        movers_len=movers_len, params=params
+    )
+    metadata = metadata or {}
+    args = _make_args(movers=movers, params=stepped_lists, num_params=1)
+    yield from bp.list_grid_scan(
+        tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+    )
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def step_grid_rscan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    movers: Annotated[
+        Sequence[Movable | Motor],
+        Field(description="One or more movable to move during the scan."),
+    ],
+    params: Annotated[
+        list[Any],
+        Field(
+            description="Start, stop, and step values 'start1, stop1, step1, ..., "
+            "startN, stepN' for every movable in `movers`."
+        ),
+    ],
+    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over independent multi-motor relative trajectories with specified step size.
+    Generates lists of points for each trajectory for bp.rel_list_grid_scan.
+    """
+    movers_len = len(movers)
+    stepped_lists = _make_independently_stepped_lists(
+        movers_len=movers_len, params=params
+    )
+    metadata = metadata or {}
+    args = _make_args(movers=movers, params=stepped_lists, num_params=1)
     yield from bp.rel_list_grid_scan(
         tuple(detectors), *args, snake_axes=snake_axes, md=metadata
     )

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -233,6 +233,8 @@ def list_scan(
     """Scan over one or more variables in steps simultaneously.
     Wraps bluesky.plans.list_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
+    shape = [len(positions) for positions in params]
+    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
     yield from bp.list_scan(tuple(detectors), *args, md=metadata)
 
@@ -263,6 +265,8 @@ def list_rscan(
     """Scan over one or more variables simultaneously relative to current position.
     Wraps bluesky.plans.rel_list_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
+    shape = [len(positions) for positions in params]
+    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
     yield from bp.rel_list_scan(tuple(detectors), *args, md=metadata)
 
@@ -294,6 +298,8 @@ def list_grid_scan(
     """Scan over one or more variables for each given point on independent trajectories.
     Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
+    shape = [len(positions) for positions in params]
+    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
     yield from bp.list_grid_scan(
         tuple(detectors), *args, snake_axes=snake_axes, md=metadata
@@ -327,6 +333,8 @@ def list_grid_rscan(
     """Scan over some variables for each given point relative to current position.
     Wraps bluesky.plans.rel_list_grid_scan(det, *args, md=metadata)."""
     metadata = metadata or {}
+    shape = [len(positions) for positions in params]
+    metadata["shape"] = (shape,)
     args = _make_args(movers=movers, params=params, num_params=1)
     yield from bp.rel_list_grid_scan(
         tuple(detectors), *args, snake_axes=snake_axes, md=metadata

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -62,6 +62,37 @@ def count(
     yield from bp.count(tuple(detectors), num, delay=delay, md=metadata)
 
 
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def mapping_num_scan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    params: dict[Movable | Motor, list[float | int]],
+    num: Annotated[int, Field(description="Number of points")],
+    metadata: dict[str, Any] | None = None,
+):
+    """Scan over one multi-motor trajectory.
+    Wraps bluesky.plans.scan(det, *args, num, md=metadata)"""
+    metadata = metadata or {}
+    metadata["shape"] = (num,)
+
+    args = _make_new_args(params)
+    yield from bp.scan(tuple(detectors), *args, num=num, md=metadata)
+
+
+def _make_new_args(params: dict[Movable | Motor, list[float | int]]):
+    args = []
+    for param in params:
+        args.append(param)
+        args.extend(params[param])
+    return args
+
+
 def _make_args(
     movers: Sequence[Movable | Motor],
     params: list[Any] | Sequence[Any],

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -81,7 +81,7 @@ def _make_args(
 
 @attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
-def scan(
+def num_scan(
     detectors: Annotated[
         Sequence[Readable | AsyncReadable],
         Field(
@@ -113,7 +113,7 @@ def scan(
 
 @attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
-def rel_scan(
+def num_rscan(
     detectors: Annotated[
         Sequence[Readable | AsyncReadable],
         Field(
@@ -145,7 +145,7 @@ def rel_scan(
 
 @attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
-def grid_scan(
+def grid_num_scan(
     detectors: Annotated[
         Sequence[Readable | AsyncReadable],
         Field(
@@ -176,7 +176,7 @@ def grid_scan(
 
 @attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
-def rel_grid_scan(
+def grid_num_rscan(
     detectors: Annotated[
         Sequence[Readable | AsyncReadable],
         Field(
@@ -239,7 +239,7 @@ def list_scan(
 
 @attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
-def rel_list_scan(
+def list_rscan(
     detectors: Annotated[
         Sequence[Readable | AsyncReadable],
         Field(
@@ -302,7 +302,7 @@ def list_grid_scan(
 
 @attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
-def rel_list_grid_scan(
+def list_grid_rscan(
     detectors: Annotated[
         Sequence[Readable | AsyncReadable],
         Field(

--- a/system_tests/test_adsim.py
+++ b/system_tests/test_adsim.py
@@ -87,7 +87,7 @@ def documents_from_num(
 ) -> dict[str, list[DocumentType]]:
     docs: dict[str, list[DocumentType]] = {}
     run_engine(
-        count({det}, num=request.param),
+        count([det], num=request.param),
         lambda name, doc: docs.setdefault(name, []).append(doc),
     )
     return docs

--- a/tests/plan_stubs/test_wrapped_stubs.py
+++ b/tests/plan_stubs/test_wrapped_stubs.py
@@ -10,9 +10,11 @@ from ophyd_async.sim import SimMotor
 from dodal.plan_stubs.wrapped import (
     move,
     move_relative,
+    rd,
     set_absolute,
     set_relative,
     sleep,
+    stop,
     wait,
 )
 
@@ -147,3 +149,11 @@ def test_wait_group_and_timeout():
     assert list(wait("foo", 5.0)) == [
         Msg("wait", group="foo", timeout=5.0, error_on_timeout=True, watch=_EMPTY)
     ]
+
+
+def test_rd(x_axis: SimMotor):
+    assert list(rd(x_axis)) == [Msg("locate", obj=x_axis)]
+
+
+def test_stop(x_axis: SimMotor):
+    assert list(stop(x_axis)) == [Msg("stop", obj=x_axis)]

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -16,6 +16,7 @@ from ophyd_async.core import (
     AsyncReadable,
     StandardDetector,
 )
+from ophyd_async.sim import SimMotor
 from pydantic import ValidationError
 
 from dodal.devices.motors import Motor
@@ -23,6 +24,7 @@ from dodal.plans.wrapped import (
     _make_args,
     _make_concurrently_stepped_lists,
     _make_independently_stepped_lists,
+    _make_new_args,
     _make_stepped_list,
     count,
     grid_num_rscan,
@@ -31,6 +33,7 @@ from dodal.plans.wrapped import (
     list_grid_scan,
     list_rscan,
     list_scan,
+    mapping_num_scan,
     num_rscan,
     num_scan,
     step_grid_rscan,
@@ -177,6 +180,22 @@ def test_plan_produces_expected_datums(
     docs = documents_from_num.get("stream_datum")
     data_keys = [det.name, f"{det.name}-sum"]
     assert docs and len(docs) == len(data_keys) * length
+
+
+def test_make_new_args(x_axis: Motor, y_axis: Motor):
+    args = _make_new_args({x_axis: [0, 1], y_axis: [2, 3]})
+    assert args[0] == x_axis
+    assert args[1] == 0
+    assert args[2] == 1
+    assert args[3] == y_axis
+    assert args[4] == 2
+    assert args[5] == 3
+
+
+def test_mapping_num_scan(
+    run_engine: RunEngine, det: StandardDetector, x_axis: SimMotor
+):
+    run_engine(mapping_num_scan(detectors=[det], params={x_axis: [1, 2]}, num=3))
 
 
 @pytest.mark.parametrize(

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -798,18 +798,22 @@ def test_list_grid_rscan_when_given_bad_info(
         )
 
 
-def test_make_stepped_list_when_given_three_params():
-    stepped_list = _make_stepped_list(params=[0, 1, 0.1])
-    assert len(stepped_list) == 11
-    assert stepped_list[0] == 0
-    assert stepped_list[-1] == 1
+@pytest.mark.parametrize(
+    "params", ([-1, 1, 0.1], [-2, 2, 0.2], [1, -1, -0.1], [2, -2, -0.2])
+)
+def test_make_stepped_list_when_given_three_params(params: list[Any]):
+    stepped_list = _make_stepped_list(params=params)
+    assert len(stepped_list) == 21
+    assert stepped_list[0] / stepped_list[-1] == -1
+    assert stepped_list[10] == 0
 
 
-def test_make_stepped_list_when_given_two_params():
-    stepped_list = _make_stepped_list(params=[0, 0.1], num=11)
-    assert len(stepped_list) == 11
-    assert stepped_list[0] == 0
-    assert stepped_list[-1] == 1
+@pytest.mark.parametrize("params", ([-1, 0.1], [-2, 0.2], [1, -0.1], [2, -0.2]))
+def test_make_stepped_list_when_given_two_params(params: list[Any]):
+    stepped_list = _make_stepped_list(params=params, num=21)
+    assert len(stepped_list) == 21
+    assert stepped_list[0] / stepped_list[-1] == -1
+    assert stepped_list[10] == 0
 
 
 def test_make_concurrently_stepped_lists():

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -871,7 +871,7 @@ def test_step_scan_fails_when_given_incorrect_number_of_params(
         run_engine(step_scan(detectors=[det], movers=[x_axis, y_axis], params=params))
 
 
-@pytest.mark.parametrize("params", ([0, 1, 0.1], [-1, 1, 0.1], [0, 10, 1]))
+@pytest.mark.parametrize("params", ([0, 1, 0.25], [-1, 1, 0.5], [0, 10, 2.5]))
 def test_step_rscan(
     run_engine: RunEngine,
     det: StandardDetector,
@@ -882,7 +882,7 @@ def test_step_rscan(
 
 
 @pytest.mark.parametrize(
-    "params", ([0, 1, 0.1, 0, 0.1], [-1, 1, 0.1, -1, 0.1], [0, 10, 1, 0, 1])
+    "params", ([0, 1, 0.25, 0, 0.25], [-1, 1, 0.5, -1, 0.5], [0, 10, 2.5, 0, 2.5])
 )
 def test_step_rscan_with_multiple_movers(
     run_engine: RunEngine,
@@ -894,7 +894,7 @@ def test_step_rscan_with_multiple_movers(
     run_engine(step_rscan(detectors=[det], movers=[x_axis, y_axis], params=params))
 
 
-@pytest.mark.parametrize("params", ([0, 1, 0.1, 0, 1, 0.1], [0, 1, 0.1, 0]))
+@pytest.mark.parametrize("params", ([0, 1, 0.5, 0, 1, 0.5], [0, 1, 0.5, 0]))
 def test_step_rscan_fails_when_given_incorrect_number_of_params(
     run_engine: RunEngine,
     det: StandardDetector,
@@ -906,7 +906,7 @@ def test_step_rscan_fails_when_given_incorrect_number_of_params(
         run_engine(step_rscan(detectors=[det], movers=[x_axis, y_axis], params=params))
 
 
-@pytest.mark.parametrize("params", ([0, 1, 0.1, 0, 1, 0.1], [0, 10, 1, 0, 10, 1]))
+@pytest.mark.parametrize("params", ([0, 1, 0.5, 0, 1, 0.5], [0, 10, 5, 0, 10, 5]))
 def test_step_grid_scan(
     run_engine: RunEngine,
     det: StandardDetector,
@@ -917,7 +917,7 @@ def test_step_grid_scan(
     run_engine(step_grid_scan(detectors=[det], movers=[y_axis, x_axis], params=params))
 
 
-@pytest.mark.parametrize("params", ([0, 1, 0.1, 0, 1, 0.1], [0, 10, 1, 0, 10, 1]))
+@pytest.mark.parametrize("params", ([0, 1, 0.5, 0, 1, 0.5], [0, 10, 5, 0, 10, 5]))
 def test_step_grid_scan_when_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
@@ -932,7 +932,7 @@ def test_step_grid_scan_when_snaking(
     )
 
 
-@pytest.mark.parametrize("params", ([0, 1, 0.1, 0, 1], [0, 10, 1, 0]))
+@pytest.mark.parametrize("params", ([0, 1, 0.25, 0, 1], [0, 10, 2.5, 0]))
 def test_step_grid_scan_fails_when_given_incorrect_number_of_params(
     run_engine: RunEngine,
     det: StandardDetector,
@@ -948,7 +948,7 @@ def test_step_grid_scan_fails_when_given_incorrect_number_of_params(
         )
 
 
-@pytest.mark.parametrize("params", ([0, 1, 0.1, 0, 1, 0.1], [0, 10, 1, 0, 10, 1]))
+@pytest.mark.parametrize("params", ([0, 1, 0.5, 0, 1, 0.5], [0, 10, 5, 0, 10, 5]))
 def test_step_grid_rscan(
     run_engine: RunEngine,
     det: StandardDetector,
@@ -959,7 +959,7 @@ def test_step_grid_rscan(
     run_engine(step_grid_rscan(detectors=[det], movers=[y_axis, x_axis], params=params))
 
 
-@pytest.mark.parametrize("params", ([0, 1, 0.1, 0, 1, 0.1], [0, 10, 1, 0, 10, 1]))
+@pytest.mark.parametrize("params", ([0, 1, 0.5, 0, 1, 0.5], [0, 10, 5, 0, 10, 5]))
 def test_step_grid_rscan_when_snaking(
     run_engine: RunEngine,
     det: StandardDetector,

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -23,7 +23,6 @@ from dodal.plans.wrapped import (
     _make_args,
     _make_concurrently_stepped_lists,
     _make_independently_stepped_lists,
-    _make_new_args,
     _make_stepped_list,
     count,
     grid_num_rscan,

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -22,14 +22,14 @@ from dodal.devices.motors import Motor
 from dodal.plans.wrapped import (
     _make_args,
     count,
-    grid_scan,
+    grid_num_rscan,
+    grid_num_scan,
+    list_grid_rscan,
     list_grid_scan,
+    list_rscan,
     list_scan,
-    rel_grid_scan,
-    rel_list_grid_scan,
-    rel_list_scan,
-    rel_scan,
-    scan,
+    num_rscan,
+    num_scan,
 )
 
 
@@ -199,7 +199,7 @@ def test_make_args_when_given_lists(x_axis: Motor, y_axis: Motor):
 
 
 @pytest.mark.parametrize("x_start, x_stop, num", ([0, 2, 5], [1, -1, 3]))
-def test_scan(
+def test_num_scan(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -208,14 +208,14 @@ def test_scan(
     num: int,
 ):
     run_engine(
-        scan(detectors=[det], movers=[x_axis], params=[x_start, x_stop], num=num)
+        num_scan(detectors=[det], movers=[x_axis], params=[x_start, x_stop], num=num)
     )
 
 
 @pytest.mark.parametrize(
     "x_start, x_stop, y_start, y_stop, num", ([0, 2, 2, 0, 5], [-1, 1, -1, 1, 3])
 )
-def test_scan_with_two_axes(
+def test_num_scan_with_two_axes(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -227,7 +227,7 @@ def test_scan_with_two_axes(
     num: int,
 ):
     run_engine(
-        scan(
+        num_scan(
             detectors=[det],
             movers=[x_axis, y_axis],
             params=[x_start, x_stop, y_start, y_stop],
@@ -236,19 +236,19 @@ def test_scan_with_two_axes(
     )
 
 
-def test_scan_fails_when_given_wrong_number_of_params(
+def test_num_scan_fails_when_given_wrong_number_of_params(
     run_engine: RunEngine, det: StandardDetector, x_axis: Motor, y_axis: Motor
 ):
     with pytest.raises(ValueError):
         run_engine(
-            scan(detectors=[det], movers=[x_axis, y_axis], params=[0, 1, 2], num=3)
+            num_scan(detectors=[det], movers=[x_axis, y_axis], params=[0, 1, 2], num=3)
         )
 
 
 @pytest.mark.parametrize(
     "x_start, x_stop, y_start, y_stop, num", ([-1, 1, 2, 0, 0], [-1, 1, -1, 1, 3.5])
 )
-def test_scan_fails_when_given_bad_info(
+def test_num_scan_fails_when_given_bad_info(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -261,7 +261,7 @@ def test_scan_fails_when_given_bad_info(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            scan(
+            num_scan(
                 detectors=[det],
                 movers=[x_axis, y_axis],
                 params=[x_start, x_stop, y_start, y_stop],
@@ -271,7 +271,7 @@ def test_scan_fails_when_given_bad_info(
 
 
 @pytest.mark.parametrize("x_start, x_stop, num", ([0, 2, 5], [1, -1, 3]))
-def test_rel_scan(
+def test_num_rscan(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -280,14 +280,14 @@ def test_rel_scan(
     num: int,
 ):
     run_engine(
-        rel_scan(detectors=[det], movers=[x_axis], params=[x_start, x_stop], num=num)
+        num_rscan(detectors=[det], movers=[x_axis], params=[x_start, x_stop], num=num)
     )
 
 
 @pytest.mark.parametrize(
     "x_start, x_stop, y_start, y_stop, num", ([0, 2, 2, 0, 5], [-1, 1, -1, 1, 3])
 )
-def test_rel_scan_with_two_axes(
+def test_num_rscan_with_two_axes(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -299,7 +299,7 @@ def test_rel_scan_with_two_axes(
     num: int,
 ):
     run_engine(
-        rel_scan(
+        num_rscan(
             detectors=[det],
             movers=[x_axis, y_axis],
             params=[x_start, x_stop, y_start, y_stop],
@@ -311,7 +311,7 @@ def test_rel_scan_with_two_axes(
 @pytest.mark.parametrize(
     "x_start, x_stop, y_start, y_stop, num", ([-1, 1, 2, 0, 0], [-1, 1, -1, 1, 3.5])
 )
-def test_rel_scan_fails_when_given_bad_info(
+def test_num_rscan_fails_when_given_bad_info(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -324,7 +324,7 @@ def test_rel_scan_fails_when_given_bad_info(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            rel_scan(
+            num_rscan(
                 detectors=[det],
                 movers=[x_axis, y_axis],
                 params=[x_start, x_stop, y_start, y_stop],
@@ -337,7 +337,7 @@ def test_rel_scan_fails_when_given_bad_info(
     "x_start, x_stop, x_num, y_start, y_stop, y_num",
     ([0, 2, 3, 0, 2, 3], [-1, 1, 5, 1, -1, 5]),
 )
-def test_grid_scan(
+def test_grid_num_scan(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -350,7 +350,7 @@ def test_grid_scan(
     y_num: int,
 ):
     run_engine(
-        grid_scan(
+        grid_num_scan(
             detectors=[det],
             movers=[y_axis, x_axis],
             params=[y_start, y_stop, y_num, x_start, x_stop, x_num],
@@ -362,7 +362,7 @@ def test_grid_scan(
     "x_start, x_stop, x_num, y_start, y_stop, y_num",
     ([0, 2, 3, 0, 2, 3], [-1, 1, 5, 1, -1, 5]),
 )
-def test_grid_scan_when_snaking(
+def test_grid_num_scan_when_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -375,7 +375,7 @@ def test_grid_scan_when_snaking(
     y_num: int,
 ):
     run_engine(
-        grid_scan(
+        grid_num_scan(
             detectors=[det],
             movers=[y_axis, x_axis],
             params=[y_start, y_stop, y_num, x_start, x_stop, x_num],
@@ -388,7 +388,7 @@ def test_grid_scan_when_snaking(
     "x_start, x_stop, x_num, y_start, y_stop, y_num",
     ([0, 2, 3, 0, 2, 3], [-1, 1, 5, 1, -1, 5]),
 )
-def test_grid_scan_when_snaking_subset_of_axes(
+def test_grid_num_scan_when_snaking_subset_of_axes(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -401,7 +401,7 @@ def test_grid_scan_when_snaking_subset_of_axes(
     y_num: int,
 ):
     run_engine(
-        grid_scan(
+        grid_num_scan(
             detectors=[det],
             movers=[y_axis, x_axis],
             params=[y_start, y_stop, y_num, x_start, x_stop, x_num],
@@ -410,7 +410,7 @@ def test_grid_scan_when_snaking_subset_of_axes(
     )
 
 
-def test_grid_scan_fails_when_snaking_slow_axis(
+def test_grid_num_scan_fails_when_snaking_slow_axis(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -418,7 +418,7 @@ def test_grid_scan_fails_when_snaking_slow_axis(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            grid_scan(
+            grid_num_scan(
                 detectors=[det],
                 movers=[y_axis, x_axis],
                 params=[0, 2, 3, 0, 2, 3],
@@ -427,7 +427,7 @@ def test_grid_scan_fails_when_snaking_slow_axis(
         )
 
 
-def test_grid_scan_fails_when_given_length_of_zero(
+def test_grid_num_scan_fails_when_given_length_of_zero(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -435,7 +435,7 @@ def test_grid_scan_fails_when_given_length_of_zero(
 ):
     with pytest.raises(RuntimeError):
         run_engine(
-            grid_scan(
+            grid_num_scan(
                 detectors=[det],
                 movers=[y_axis, x_axis],
                 params=[0, 2, 0, 0, 2, 3],
@@ -443,7 +443,7 @@ def test_grid_scan_fails_when_given_length_of_zero(
         )
 
 
-def test_grid_scan_fails_when_given_non_integer_length(
+def test_grid_num_scan_fails_when_given_non_integer_length(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -451,7 +451,7 @@ def test_grid_scan_fails_when_given_non_integer_length(
 ):
     with pytest.raises(TypeError):
         run_engine(
-            grid_scan(
+            grid_num_scan(
                 detectors=[det],
                 movers=[y_axis, x_axis],
                 params=[0, 2, 3.5, 0, 2, 3],
@@ -463,7 +463,7 @@ def test_grid_scan_fails_when_given_non_integer_length(
     "x_start, x_stop, x_num, y_start, y_stop, y_num",
     ([0, 2, 3, 0, 2, 3], [-1, 1, 5, 1, -1, 5]),
 )
-def test_rel_grid_scan(
+def test_grid_num_rscan(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -476,7 +476,7 @@ def test_rel_grid_scan(
     y_num: int,
 ):
     run_engine(
-        rel_grid_scan(
+        grid_num_rscan(
             detectors=[det],
             movers=[y_axis, x_axis],
             params=[y_start, y_stop, y_num, x_start, x_stop, x_num],
@@ -488,7 +488,7 @@ def test_rel_grid_scan(
     "x_start, x_stop, x_num, y_start, y_stop, y_num",
     ([0, 2, 3, 0, 2, 3], [-1, 1, 5, 1, -1, 5]),
 )
-def test_rel_grid_scan_when_snaking(
+def test_grid_num_rscan_when_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -501,7 +501,7 @@ def test_rel_grid_scan_when_snaking(
     y_num: int,
 ):
     run_engine(
-        rel_grid_scan(
+        grid_num_rscan(
             detectors=[det],
             movers=[y_axis, x_axis],
             params=[y_start, y_stop, y_num, x_start, x_stop, x_num],
@@ -514,7 +514,7 @@ def test_rel_grid_scan_when_snaking(
     "x_start, x_stop, x_num, y_start, y_stop, y_num",
     ([0, 2, 3, 0, 2, 3], [-1, 1, 5, 1, -1, 5]),
 )
-def test_rel_grid_scan_when_snaking_subset_of_axes(
+def test_grid_num_rscan_when_snaking_subset_of_axes(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -527,7 +527,7 @@ def test_rel_grid_scan_when_snaking_subset_of_axes(
     y_num: int,
 ):
     run_engine(
-        rel_grid_scan(
+        grid_num_rscan(
             detectors=[det],
             movers=[y_axis, x_axis],
             params=[y_start, y_stop, y_num, x_start, x_stop, x_num],
@@ -536,7 +536,7 @@ def test_rel_grid_scan_when_snaking_subset_of_axes(
     )
 
 
-def test_rel_grid_scan_fails_when_snaking_slow_axis(
+def test_grid_num_rscan_fails_when_snaking_slow_axis(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -544,7 +544,7 @@ def test_rel_grid_scan_fails_when_snaking_slow_axis(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            rel_grid_scan(
+            grid_num_rscan(
                 detectors=[det],
                 movers=[y_axis, x_axis],
                 params=[0, 2, 3, 0, 2, 3],
@@ -553,7 +553,7 @@ def test_rel_grid_scan_fails_when_snaking_slow_axis(
         )
 
 
-def test_rel_grid_scan_fails_when_given_length_of_zero(
+def test_grid_num_rscan_fails_when_given_length_of_zero(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -561,7 +561,7 @@ def test_rel_grid_scan_fails_when_given_length_of_zero(
 ):
     with pytest.raises(RuntimeError):
         run_engine(
-            rel_grid_scan(
+            grid_num_rscan(
                 detectors=[det],
                 movers=[y_axis, x_axis],
                 params=[0, 2, 0, 0, 2, 3],
@@ -569,7 +569,7 @@ def test_rel_grid_scan_fails_when_given_length_of_zero(
         )
 
 
-def test_rel_grid_scan_fails_when_given_non_integer_length(
+def test_grid_num_rscan_fails_when_given_non_integer_length(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -577,7 +577,7 @@ def test_rel_grid_scan_fails_when_given_non_integer_length(
 ):
     with pytest.raises(TypeError):
         run_engine(
-            rel_grid_scan(
+            grid_num_rscan(
                 detectors=[det], movers=[y_axis, x_axis], params=[0, 2, 3.5, 0, 2, 3]
             )
         )
@@ -627,10 +627,10 @@ def test_list_scan_with_two_axes_fails_when_given_differnt_list_lengths(
 
 
 @pytest.mark.parametrize("x_list", ([[0, 1, 2, 3]], [[1.1, 2.2, 3.3]]))
-def test_rel_list_scan(
+def test_list_rscan(
     run_engine: RunEngine, det: StandardDetector, x_axis: Motor, x_list: Any
 ):
-    run_engine(rel_list_scan(detectors=[det], movers=[x_axis], params=x_list))
+    run_engine(list_rscan(detectors=[det], movers=[x_axis], params=x_list))
 
 
 @pytest.mark.parametrize(
@@ -640,7 +640,7 @@ def test_rel_list_scan(
         [[-1.1, -2.2, -3.3, -4.4, -5.5], [1.1, 2.2, 3.3, 4.4, 5.5]],
     ),
 )
-def test_rel_list_scan_with_two_axes(
+def test_list_rscan_with_two_axes(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -649,11 +649,11 @@ def test_rel_list_scan_with_two_axes(
     y_list: list,
 ):
     run_engine(
-        rel_list_scan(detectors=[det], movers=[x_axis, y_axis], params=[x_list, y_list])
+        list_rscan(detectors=[det], movers=[x_axis, y_axis], params=[x_list, y_list])
     )
 
 
-def test_rel_list_scan_with_two_axes_fails_when_given_differnt_list_lengths(
+def test_list_rscan_with_two_axes_fails_when_given_differnt_list_lengths(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -661,7 +661,7 @@ def test_rel_list_scan_with_two_axes_fails_when_given_differnt_list_lengths(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            rel_list_scan(
+            list_rscan(
                 detectors=[det],
                 movers=[x_axis, y_axis],
                 params=[[1, 2, 3, 4, 5], [1, 2, 3, 4]],
@@ -729,7 +729,7 @@ def test_list_grid_scan_when_given_bad_info(
         [[-1.1, -2.2, -3.3, -4.4, -5.5], [1.1, 2.2, 3.3, 4.4, 5.5]],
     ),
 )
-def test_rel_list_grid_scan(
+def test_list_grid_rscan(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -738,20 +738,20 @@ def test_rel_list_grid_scan(
     y_list: list,
 ):
     run_engine(
-        rel_list_grid_scan(
+        list_grid_rscan(
             detectors=[det], movers=[x_axis, y_axis], params=[x_list, y_list]
         )
     )
 
 
-def test_rel_list_grid_scan_with_two_axes_when_snaking(
+def test_list_grid_rscan_with_two_axes_when_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
     y_axis: Motor,
 ):
     run_engine(
-        rel_list_grid_scan(
+        list_grid_rscan(
             detectors=[det],
             movers=[x_axis, y_axis],
             params=[[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]],
@@ -760,14 +760,14 @@ def test_rel_list_grid_scan_with_two_axes_when_snaking(
     )
 
 
-def test_rel_list_grid_scan_when_given_differnt_list_lengths(
+def test_list_grid_rscan_when_given_differnt_list_lengths(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
     y_axis: Motor,
 ):
     run_engine(
-        rel_list_grid_scan(
+        list_grid_rscan(
             detectors=[det],
             movers=[x_axis, y_axis],
             params=[[1, 2, 3, 4, 5], [1, 2, 3, 4]],
@@ -775,7 +775,7 @@ def test_rel_list_grid_scan_when_given_differnt_list_lengths(
     )
 
 
-def test_rel_list_grid_scan_when_given_bad_info(
+def test_list_grid_rscan_when_given_bad_info(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -783,7 +783,7 @@ def test_rel_list_grid_scan_when_given_bad_info(
 ):
     with pytest.raises(TypeError):
         run_engine(
-            list_grid_scan(
+            list_grid_rscan(
                 detectors=[det],
                 movers=[x_axis, y_axis],
                 params=[[1, 2, 3, 4, 5], ["one", 2, 3, 4, 5]],

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -179,16 +179,6 @@ def test_plan_produces_expected_datums(
     assert docs and len(docs) == len(data_keys) * length
 
 
-def test_make_new_args(x_axis: Motor, y_axis: Motor):
-    args = _make_new_args({x_axis: [0, 1], y_axis: [2, 3]})
-    assert args[0] == x_axis
-    assert args[1] == 0
-    assert args[2] == 1
-    assert args[3] == y_axis
-    assert args[4] == 2
-    assert args[5] == 3
-
-
 @pytest.mark.parametrize(
     "num_params, params", ([2, [1, 2, 3, 4]], [3, [1, 2, 3, 3, 4, 3]])
 )

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -16,7 +16,6 @@ from ophyd_async.core import (
     AsyncReadable,
     StandardDetector,
 )
-from ophyd_async.sim import SimMotor
 from pydantic import ValidationError
 
 from dodal.devices.motors import Motor
@@ -33,7 +32,6 @@ from dodal.plans.wrapped import (
     list_grid_scan,
     list_rscan,
     list_scan,
-    mapping_num_scan,
     num_rscan,
     num_scan,
     step_grid_rscan,
@@ -190,12 +188,6 @@ def test_make_new_args(x_axis: Motor, y_axis: Motor):
     assert args[3] == y_axis
     assert args[4] == 2
     assert args[5] == 3
-
-
-def test_mapping_num_scan(
-    run_engine: RunEngine, det: StandardDetector, x_axis: SimMotor
-):
-    run_engine(mapping_num_scan(detectors=[det], params={x_axis: [1, 2]}, num=3))
 
 
 @pytest.mark.parametrize(

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -13,6 +13,7 @@ from event_model.documents import (
     StreamResource,
 )
 from ophyd_async.core import (
+    AsyncReadable,
     StandardDetector,
 )
 from pydantic import ValidationError
@@ -63,7 +64,7 @@ def test_count_delay_validation(det: StandardDetector, run_engine: RunEngine):
 
 
 def test_count_detectors_validation(run_engine: RunEngine):
-    args: dict[str, set[Readable]] = {
+    args: dict[str, set[Readable | AsyncReadable]] = {
         # No device to read
         "Set should have at least 1 item after validation, not 0": set(),
         # Not Readable

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -816,6 +816,11 @@ def test_make_stepped_list_when_given_two_params(params: list[Any]):
     assert stepped_list[10] == 0
 
 
+def test_make_stepped_list_when_given_wrong_number_of_params():
+    stepped_list = _make_stepped_list(params=[1])
+    assert stepped_list == []
+
+
 def test_make_concurrently_stepped_lists():
     stepped_lists = _make_concurrently_stepped_lists(
         movers_len=2, params=[0, 1, 0.1, 0, 1]


### PR DESCRIPTION
Closes #1498

Wraps bluesky plans (`scan`, `rel_scan`, `grid_scan`, `rel_grid_scan`) and plan stubs (`rd`, `stop`) for use in blueapi. Intended as a replacement for gda-style `start stop step` scans until `spec_scan` is stable and supports `start stop step` rather than `start stop num`. 

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
