### PR TITLE
Fix so that patched motor dial limits are not none

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async[ca,pva]>=0.13.5",
+    "ophyd-async[ca,pva]>=0.13.7",
     "bluesky>=1.14.5",
     "pyepics",
     "dataclasses-json",

--- a/src/dodal/testing/setup.py
+++ b/src/dodal/testing/setup.py
@@ -39,6 +39,8 @@ def patch_motor(
     set_mock_value(motor.max_velocity, max_velocity)
     set_mock_value(motor.low_limit_travel, low_limit_travel)
     set_mock_value(motor.high_limit_travel, high_limit_travel)
+    set_mock_value(motor.dial_low_limit_travel, low_limit_travel)
+    set_mock_value(motor.dial_high_limit_travel, high_limit_travel)
     return callback_on_mock_put(
         motor.user_setpoint,
         lambda pos, *args, **kwargs: set_mock_value(motor.user_readback, pos),

--- a/tests/devices/test_smargon.py
+++ b/tests/devices/test_smargon.py
@@ -108,18 +108,16 @@ async def test_given_center_disp_low_when_stub_offsets_set_to_center_and_moved_t
 async def test_given_set_with_value_outside_motor_limit(
     smargon: Smargon, test_x, test_y, test_z, test_omega, test_chi, test_phi
 ):
-    set_mock_value(smargon.x.low_limit_travel, -1999)
-    set_mock_value(smargon.y.low_limit_travel, -1999)
-    set_mock_value(smargon.z.low_limit_travel, -1999)
-    set_mock_value(smargon.omega.low_limit_travel, -1999)
-    set_mock_value(smargon.chi.low_limit_travel, -1999)
-    set_mock_value(smargon.phi.low_limit_travel, -1999)
-    set_mock_value(smargon.x.high_limit_travel, 1999)
-    set_mock_value(smargon.y.high_limit_travel, 1999)
-    set_mock_value(smargon.z.high_limit_travel, 1999)
-    set_mock_value(smargon.omega.high_limit_travel, 1999)
-    set_mock_value(smargon.chi.high_limit_travel, 1999)
-    set_mock_value(smargon.phi.high_limit_travel, 1999)
+    for motor in [
+        smargon.x,
+        smargon.y,
+        smargon.z,
+        smargon.omega,
+        smargon.chi,
+        smargon.phi,
+    ]:
+        set_mock_value(motor.low_limit_travel, -1999)
+        set_mock_value(motor.high_limit_travel, 1999)
 
     with pytest.raises(MotorLimitsError):
         await smargon.set(


### PR DESCRIPTION
Makes sure that when we patch motors we set the dial limits so that limits are obeyed based on https://github.com/bluesky/ophyd-async/pull/1124. This was causing issues in https://github.com/DiamondLightSource/dodal/actions/runs/19434405471/job/55603972834?pr=1583

### Instructions to reviewer on how to test:
1. Confirm tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
