### PR TITLE
Make beamsize signals readable

### DIFF
--- a/src/dodal/devices/beamsize/beamsize.py
+++ b/src/dodal/devices/beamsize/beamsize.py
@@ -1,9 +1,6 @@
-from typing import Annotated
-
 from ophyd_async.core import SignalR, StandardReadable
-from ophyd_async.core import StandardReadableFormat as Format
 
 
 class BeamsizeBase(StandardReadable):
-    x_um: Annotated[SignalR[float], Format.HINTED_SIGNAL]
-    y_um: Annotated[SignalR[float], Format.HINTED_SIGNAL]
+    x_um: SignalR[float]
+    y_um: SignalR[float]

--- a/src/dodal/devices/i03/beamsize.py
+++ b/src/dodal/devices/i03/beamsize.py
@@ -10,16 +10,17 @@ class Beamsize(BeamsizeBase):
         super().__init__(name=name)
         self._aperture_scatterguard_ref = Reference(aperture_scatterguard)
 
-        self.x_um = derived_signal_r(
-            self._get_beamsize_x,
-            aperture_radius=self._aperture_scatterguard_ref().radius,
-            derived_units="µm",
-        )
-        self.y_um = derived_signal_r(
-            self._get_beamsize_y,
-            aperture_radius=self._aperture_scatterguard_ref().radius,
-            derived_units="µm",
-        )
+        with self.add_children_as_readables():
+            self.x_um = derived_signal_r(
+                self._get_beamsize_x,
+                aperture_radius=self._aperture_scatterguard_ref().radius,
+                derived_units="µm",
+            )
+            self.y_um = derived_signal_r(
+                self._get_beamsize_y,
+                aperture_radius=self._aperture_scatterguard_ref().radius,
+                derived_units="µm",
+            )
 
     def _get_beamsize_x(
         self,

--- a/src/dodal/devices/i04/beamsize.py
+++ b/src/dodal/devices/i04/beamsize.py
@@ -16,18 +16,19 @@ class Beamsize(BeamsizeBase):
         self._transfocator_ref = Reference(transfocator)
         self._aperture_scatterguard_ref = Reference(aperture_scatterguard)
 
-        self.x_um = derived_signal_r(
-            self._get_beamsize_x,
-            transfocator_size_x=self._transfocator_ref().current_horizontal_size_rbv,
-            aperture_radius=self._aperture_scatterguard_ref().radius,
-            derived_units="µm",
-        )
-        self.y_um = derived_signal_r(
-            self._get_beamsize_y,
-            transfocator_size_y=self._transfocator_ref().current_vertical_size_rbv,
-            aperture_radius=self._aperture_scatterguard_ref().radius,
-            derived_units="µm",
-        )
+        with self.add_children_as_readables():
+            self.x_um = derived_signal_r(
+                self._get_beamsize_x,
+                transfocator_size_x=self._transfocator_ref().current_horizontal_size_rbv,
+                aperture_radius=self._aperture_scatterguard_ref().radius,
+                derived_units="µm",
+            )
+            self.y_um = derived_signal_r(
+                self._get_beamsize_y,
+                transfocator_size_y=self._transfocator_ref().current_vertical_size_rbv,
+                aperture_radius=self._aperture_scatterguard_ref().radius,
+                derived_units="µm",
+            )
 
     def _get_beamsize_x(
         self,


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/1424

Allows beamsize signals to be readable by reading the device as a whole

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
