### PR TITLE
Wrap plans and plan stubs with lists of tuples

### DIFF
--- a/src/dodal/plan_stubs/__init__.py
+++ b/src/dodal/plan_stubs/__init__.py
@@ -1,3 +1,21 @@
-from .wrapped import move, move_relative, set_absolute, set_relative, sleep, wait
+from .wrapped import (
+    move,
+    move_relative,
+    rd,
+    set_absolute,
+    set_relative,
+    sleep,
+    stop,
+    wait,
+)
 
-__all__ = ["move", "move_relative", "set_absolute", "set_relative", "sleep", "wait"]
+__all__ = [
+    "move",
+    "move_relative",
+    "rd",
+    "set_absolute",
+    "set_relative",
+    "sleep",
+    "stop",
+    "wait",
+]

--- a/src/dodal/plan_stubs/wrapped.py
+++ b/src/dodal/plan_stubs/wrapped.py
@@ -1,6 +1,6 @@
 import itertools
 from collections.abc import Mapping
-from typing import Annotated, TypeVar
+from typing import Annotated, Any, TypeVar
 
 import bluesky.plan_stubs as bps
 from bluesky.protocols import Movable, Readable, Stoppable
@@ -133,7 +133,7 @@ def wait(
     return (yield from bps.wait(group, timeout=timeout))
 
 
-def rd(readable: Readable) -> MsgGenerator:
+def rd(readable: Readable) -> MsgGenerator[Any]:
     """Reads a single-value non-triggered object, wrapper for `bp.rd`.
 
     Args:

--- a/src/dodal/plan_stubs/wrapped.py
+++ b/src/dodal/plan_stubs/wrapped.py
@@ -14,7 +14,7 @@ T = TypeVar("T")
 
 
 def set_absolute(
-    movable: Movable[T], value: T, group: Group | None = None, wait: bool = False
+    movable: Movable[T], value: T, group: Group | None = None, wait: bool = True
 ) -> MsgGenerator:
     """Set a device, wrapper for `bp.abs_set`.
 
@@ -36,7 +36,7 @@ def set_absolute(
 
 
 def set_relative(
-    movable: Movable[T], value: T, group: Group | None = None, wait: bool = False
+    movable: Movable[T], value: T, group: Group | None = None, wait: bool = True
 ) -> MsgGenerator:
     """Change a device, wrapper for `bp.rel_set`.
 

--- a/src/dodal/plan_stubs/wrapped.py
+++ b/src/dodal/plan_stubs/wrapped.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from typing import Annotated, TypeVar
 
 import bluesky.plan_stubs as bps
-from bluesky.protocols import Movable
+from bluesky.protocols import Movable, Readable, Stoppable
 from bluesky.utils import MsgGenerator
 
 """Wrappers for Bluesky built-in plan stubs with type hinting."""
@@ -131,3 +131,27 @@ def wait(
         Iterator[MsgGenerator]: Bluesky messages.
     """
     return (yield from bps.wait(group, timeout=timeout))
+
+
+def rd(readable: Readable) -> MsgGenerator:
+    """Reads a single-value non-triggered object, wrapper for `bp.rd`.
+
+    Args:
+        readable (Readable): The device to be read
+
+    Returns:
+        Iterator[MsgGenerator]: Bluesky messages
+    """
+    return (yield from bps.rd(readable))
+
+
+def stop(stoppable: Stoppable) -> MsgGenerator:
+    """Stop a device, wrapper for `bp.stop`.
+
+    Args:
+        stoppable (Stoppable): Device to be stopped
+
+    Returns:
+        Iterator[MsgGenerator]: Bluesky messages
+    """
+    return (yield from bps.stop(stoppable))

--- a/src/dodal/plan_stubs/wrapped.py
+++ b/src/dodal/plan_stubs/wrapped.py
@@ -134,7 +134,7 @@ def wait(
 
 
 def rd(readable: Readable) -> MsgGenerator[Any]:
-    """Reads a single-value non-triggered object, wrapper for `bp.rd`.
+    """Reads a single-value non-triggered object, wrapper for `bps.rd`.
 
     Args:
         readable (Readable): The device to be read
@@ -149,7 +149,7 @@ def rd(readable: Readable) -> MsgGenerator[Any]:
 
 
 def stop(stoppable: Stoppable) -> MsgGenerator:
-    """Stop a device, wrapper for `bp.stop`.
+    """Stop a device, wrapper for `bps.stop`.
 
     Args:
         stoppable (Stoppable): Device to be stopped

--- a/src/dodal/plan_stubs/wrapped.py
+++ b/src/dodal/plan_stubs/wrapped.py
@@ -140,7 +140,10 @@ def rd(readable: Readable) -> MsgGenerator[Any]:
         readable (Readable): The device to be read
 
     Returns:
-        Iterator[MsgGenerator]: Bluesky messages
+        MsgGenerator: Plan.
+
+    Yields:
+        Iterator[MsgGenerator]: Bluesky messages.
     """
     return (yield from bps.rd(readable))
 
@@ -152,6 +155,9 @@ def stop(stoppable: Stoppable) -> MsgGenerator:
         stoppable (Stoppable): Device to be stopped
 
     Returns:
-        Iterator[MsgGenerator]: Bluesky messages
+        MsgGenerator: Plan.
+
+    Yields:
+        Iterator[MsgGenerator]: Bluesky messages.
     """
     return (yield from bps.stop(stoppable))

--- a/src/dodal/plans/__init__.py
+++ b/src/dodal/plans/__init__.py
@@ -1,4 +1,21 @@
 from .spec_path import spec_scan
-from .wrapped import count
+from .wrapped import (
+    count,
+    list_rscan,
+    list_scan,
+    num_rscan,
+    num_scan,
+    step_rscan,
+    step_scan,
+)
 
-__all__ = ["count", "spec_scan"]
+__all__ = [
+    "count",
+    "list_rscan",
+    "list_scan",
+    "num_rscan",
+    "num_scan",
+    "spec_scan",
+    "step_rscan",
+    "step_scan",
+]

--- a/src/dodal/plans/__init__.py
+++ b/src/dodal/plans/__init__.py
@@ -1,21 +1,33 @@
 from .spec_path import spec_scan
 from .wrapped import (
     count,
+    list_grid_rscan,
+    list_grid_scan,
     list_rscan,
     list_scan,
+    num_grid_rscan,
+    num_grid_scan,
     num_rscan,
     num_scan,
+    step_grid_rscan,
+    step_grid_scan,
     step_rscan,
     step_scan,
 )
 
 __all__ = [
     "count",
+    "list_grid_rscan",
+    "list_grid_scan",
     "list_rscan",
     "list_scan",
+    "num_grid_rscan",
+    "num_grid_scan",
     "num_rscan",
     "num_scan",
     "spec_scan",
+    "step_grid_rscan",
+    "step_grid_scan",
     "step_rscan",
     "step_scan",
 ]

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -147,8 +147,8 @@ def num_grid_scan(
 ) -> MsgGenerator:
     """Scan independent multi-motor trajectories.
 
-    Snakes all fast axes by default. The scan is defined by number of points along scan
-    trajectories. Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).
+    The scan is defined by number of points along scan trajectories. Snakes all fast
+    axes by default. Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
@@ -215,8 +215,8 @@ def num_grid_rscan(
 ) -> MsgGenerator:
     """Scan independent trajectories, relative to current positions.
 
-    Snakes all fast axes by default. The scan is defined by number of points along scan
-    trajectories. Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata).
+    The scan is defined by number of points along scan trajectories. Snakes all fast
+    axes by default. Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
@@ -302,8 +302,8 @@ def list_grid_scan(
 ) -> MsgGenerator:
     """Scan independent trajectories.
 
-    Snakes slow axes by default. The scan is defined by providing a list of points for
-    each scan trajectory. Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    The scan is defined by providing a list of points for each scan trajectory. Snakes
+    slow axes by default. Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata).
     """
     args, shape = _make_list_scan_args(params=params, grid=True)
     metadata = metadata or {}
@@ -370,8 +370,9 @@ def list_grid_rscan(
 ) -> MsgGenerator:
     """Scan independent trajectories, relative to current positions.
 
-    The scan is defined by providing a list of points for each scan trajectory.
-    Wraps bluesky.plans.rel_list_grid_scan(det, *args, md=metadata).
+    The scan is defined by providing a list of points for each scan trajectory. Snakes
+    all fast axes by default. Wraps bluesky.plans.rel_list_grid_scan(det, *args,
+    md=metadata).
     """
     args, shape = _make_list_scan_args(params=params, grid=True)
     metadata = metadata or {}
@@ -520,8 +521,9 @@ def step_grid_scan(
 ) -> MsgGenerator:
     """Scan independent trajectories with specified step size.
 
-    Snakes all slow axes by default. Generates list(s) of points for each trajectory,
-    used with bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    Generates list(s) of points for each trajectory, used with
+    bluesky.plans.list_grid_scan(det, *args, md=metadata). Snakes all fast axes by
+    default.
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)
@@ -589,8 +591,9 @@ def step_grid_rscan(
 ) -> MsgGenerator:
     """Scan independent trajectories with specified step size, relative to position.
 
-    Snakes all slow axes by default. Generates list(s) of points for each trajectory,
-    used with bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    Generates list(s) of points for each trajectory, used with
+    bluesky.plans.list_grid_scan(det, *args, md=metadata). Snakes all fast axes by
+    default.
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -96,7 +96,7 @@ def num_scan(
             "numN]}'."
         ),
     ],
-    snake_axes: list | bool | None = None,
+    snake_axes: list | bool = True,
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan over concurrent or independent multi-motor trajectories.
@@ -134,7 +134,7 @@ def num_rscan(
             "numN]}'."
         ),
     ],
-    snake_axes: list | bool | None = None,
+    snake_axes: list | bool = True,
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan over concurrent or independent trajectories relative to current position.
@@ -184,7 +184,7 @@ def list_scan(
         ),
     ],
     grid: bool = False,
-    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    snake_axes: bool = True,  # Currently specifying axes to snake is not supported
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan over concurrent or independent trajectories relative to current position.
@@ -223,7 +223,7 @@ def list_rscan(
         ),
     ],
     grid: bool = False,
-    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    snake_axes: bool = True,  # Currently specifying axes to snake is not supported
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan over concurrent or independent trajectories relative to current position.
@@ -257,6 +257,10 @@ def _make_stepped_list(
     if len(params) == 3:
         stop = params[1]
         step = params[2]
+        if start == stop:
+            raise ValueError(
+                f"Start ({start}) and stop ({stop}) values cannot be the same."
+            )
         if abs(step) > abs(stop - start):
             step = stop - start
         step = abs(step) * np.sign(stop - start)
@@ -339,7 +343,7 @@ def step_scan(
             "[startN, stopN, stepN]}'."
         ),
     ],
-    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    snake_axes: bool = True,  # Currently specifying axes to snake is not supported
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan over multi-motor trajectories with specified step size.
@@ -378,7 +382,7 @@ def step_rscan(
             "[startN, stopN, stepN]}'."
         ),
     ],
-    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    snake_axes: bool = True,  # Currently specifying axes to snake is not supported
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan over multi-motor trajectories with specified step size.

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -50,6 +50,7 @@ def count(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Reads from a number of devices.
+
     Wraps bluesky.plans.count(det, num, delay, md=metadata) exposing only serializable
     parameters and metadata.
     """
@@ -111,8 +112,10 @@ def num_scan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan concurrent single or multi-motor trajector(y/ies).
+
     The scan is defined by number of points along scan trajector(y/ies).
-    Wraps bluesky.plans.scan(det, *args, num, md=metadata)."""
+    Wraps bluesky.plans.scan(det, *args, num, md=metadata).
+    """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params, num)
     metadata = metadata or {}
@@ -143,8 +146,10 @@ def num_grid_scan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan independent multi-motor trajectories.
+
     The scan is defined by number of points along scan trajectories.
-    Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata)."""
+    Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).
+    """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
     metadata = metadata or {}
@@ -175,8 +180,10 @@ def num_rscan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan concurrent trajector(y/ies), relative to current position(s).
+
     The scan is defined by number of points along scan trajector(y/ies).
-    Wraps bluesky.plans.rel_scan(det, *args, num, md=metadata)."""
+    Wraps bluesky.plans.rel_scan(det, *args, num, md=metadata).
+    """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params, num)
     metadata = metadata or {}
@@ -207,8 +214,10 @@ def num_grid_rscan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan independent trajectories, relative to current positions.
+
     The scan is defined by number of points along scan trajectories.
-    Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata)."""
+    Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata).
+    """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
     metadata = metadata or {}
@@ -258,8 +267,10 @@ def list_scan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan concurrent single or multi-motor trajector(y/ies).
+
     The scan is defined by providing a list of points for each scan trajectory.
-    Wraps bluesky.plans.list_scan(det, *args, md=metadata)."""
+    Wraps bluesky.plans.list_scan(det, *args, md=metadata).
+    """
     args, shape = _make_list_scan_args(params=params)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -289,8 +300,10 @@ def list_grid_scan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan independent trajectories.
+
     The scan is defined by providing a list of points for each scan trajectory.
-    Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
+    Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    """
     args, shape = _make_list_scan_args(params=params, grid=True)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -321,8 +334,10 @@ def list_rscan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan concurrent trajector(y/ies), relative to current position.
+
     The scan is defined by providing a list of points for each scan trajectory.
-    Wraps bluesky.plans.rel_list_scan(det, *args, md=metadata)."""
+    Wraps bluesky.plans.rel_list_scan(det, *args, md=metadata).
+    """
     args, shape = _make_list_scan_args(params=params)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -352,8 +367,10 @@ def list_grid_rscan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan independent trajectories, relative to current positions.
+
     The scan is defined by providing a list of points for each scan trajectory.
-    Wraps bluesky.plans.rel_list_grid_scan(det, *args, md=metadata)."""
+    Wraps bluesky.plans.rel_list_grid_scan(det, *args, md=metadata).
+    """
     args, shape = _make_list_scan_args(params=params, grid=True)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -384,7 +401,7 @@ def _make_stepped_list(
         if abs(step) > abs(stop - start):
             step = stop - start
         step = abs(step) * np.sign(stop - start)
-        stepped_list = np.arange(start=start, stop=stop, step=step).tolist()
+        stepped_list = np.arange(start, stop, step).tolist()
         if abs((stepped_list[-1] + step) - stop) <= abs(step * 0.05):
             stepped_list.append(stepped_list[-1] + step)
         rounded_stepped_list = round_list_elements(stepped_list=stepped_list, step=step)
@@ -468,8 +485,10 @@ def step_scan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan concurrent trajectories with specified step size.
+
     Generates list(s) of points for each trajectory, used with
-    bluesky.plans.list_scan(det, *args, md=metadata)."""
+    bluesky.plans.list_scan(det, *args, md=metadata).
+    """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params)
     metadata = metadata or {}
@@ -500,8 +519,10 @@ def step_grid_scan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan independent trajectories with specified step size.
+
     Generates list(s) of points for each trajectory, used with
-    bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
+    bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)
     metadata = metadata or {}
@@ -533,8 +554,10 @@ def step_rscan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan concurrent trajectories with specified step size, relative to position.
+
     Generates list(s) of points for each trajectory, used with
-    bluesky.plans.rel_list_scan(det, *args, md=metadata)."""
+    bluesky.plans.rel_list_scan(det, *args, md=metadata).
+    """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params)
     metadata = metadata or {}
@@ -565,8 +588,10 @@ def step_grid_rscan(
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan independent trajectories with specified step size, relative to position.
+
     Generates list(s) of points for each trajectory, used with
-    bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
+    bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)
     metadata = metadata or {}

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -113,8 +113,8 @@ def num_scan(
 ) -> MsgGenerator:
     """Scan concurrent single or multi-motor trajector(y/ies).
 
-    The scan is defined by number of points along scan trajector(y/ies).
-    Wraps bluesky.plans.scan(det, *args, num, md=metadata).
+    The scan is defined by number of points along scan trajector(y/ies). Wraps
+    bluesky.plans.scan(det, *args, num, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params, num)
@@ -147,8 +147,8 @@ def num_grid_scan(
 ) -> MsgGenerator:
     """Scan independent multi-motor trajectories.
 
-    The scan is defined by number of points along scan trajectories.
-    Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).
+    Snakes all fast axes by default. The scan is defined by number of points along scan
+    trajectories. Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
@@ -181,8 +181,8 @@ def num_rscan(
 ) -> MsgGenerator:
     """Scan concurrent trajector(y/ies), relative to current position(s).
 
-    The scan is defined by number of points along scan trajector(y/ies).
-    Wraps bluesky.plans.rel_scan(det, *args, num, md=metadata).
+    The scan is defined by number of points along scan trajector(y/ies). Wraps
+    bluesky.plans.rel_scan(det, *args, num, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params, num)
@@ -215,8 +215,8 @@ def num_grid_rscan(
 ) -> MsgGenerator:
     """Scan independent trajectories, relative to current positions.
 
-    The scan is defined by number of points along scan trajectories.
-    Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata).
+    Snakes all fast axes by default. The scan is defined by number of points along scan
+    trajectories. Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
@@ -229,14 +229,14 @@ def num_grid_rscan(
 
 
 def _make_list_scan_args(
-    params: dict[Movable | Motor, list[float | int]], grid: bool | None = None
+    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool | None = None
 ):
     shape = []
     args = []
     for param in params:
-        shape.append(len(params[param]))
-        args.append(param)
-        args.append(params[param])
+        shape.append(len(param[1]))
+        args.append(param[0])
+        args.append(param[1])
 
     if not grid:
         shape = list(set(shape))
@@ -257,11 +257,12 @@ def list_scan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, \
-            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
-            ...]}'. Number of points for each movable must be equal."
+            description="List of tuples (device, parameter). For concurrent \
+            trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
+            [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'. Number \
+            of points for each movable must be equal."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -289,11 +290,11 @@ def list_grid_scan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, \
-            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
-            ...]}'."
+            description="List of tuples (device, parameter). For independent \
+            trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
+            [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -301,8 +302,8 @@ def list_grid_scan(
 ) -> MsgGenerator:
     """Scan independent trajectories.
 
-    The scan is defined by providing a list of points for each scan trajectory.
-    Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    Snakes slow axes by default. The scan is defined by providing a list of points for
+    each scan trajectory. Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata).
     """
     args, shape = _make_list_scan_args(params=params, grid=True)
     metadata = metadata or {}
@@ -324,11 +325,12 @@ def list_rscan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, \
-            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
-            ...]}'. Number of points for each movable must be equal."
+            description="List of tuples (device, parameter). For concurrent \
+            trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
+            [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'. Number \
+            of points for each movable must be equal."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -356,11 +358,11 @@ def list_grid_rscan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, \
-            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
-            ...]}'."
+            description="List of tuples (device, parameter). For independent \
+            trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
+            [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -418,47 +420,45 @@ def _make_stepped_list(
 
 
 def _make_step_scan_args(
-    params: dict[Movable | Motor, list[float | int]], grid: bool | None = None
+    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool | None = None
 ):
     args = []
     shape = []
     stepped_list_length = None
     for param, movable_num in zip(params, range(len(params)), strict=True):
         if movable_num == 0:
-            if len(params[param]) == 3:
-                stepped_list, stepped_list_length = _make_stepped_list(
-                    params=params[param]
-                )
-                args.append(param)
+            if len(param[1]) == 3:
+                stepped_list, stepped_list_length = _make_stepped_list(params=param[1])
+                args.append(param[0])
                 args.append(stepped_list)
                 shape.append(stepped_list_length)
             else:
                 raise ValueError(
-                    f"You provided {len(params[param])} parameters, rather than 3."
+                    f"You provided {len(param[1])} parameters, rather than 3."
                 )
         elif movable_num >= 1:
             if grid:
-                if len(params[param]) == 3:
+                if len(param[1]) == 3:
                     stepped_list, stepped_list_length = _make_stepped_list(
-                        params=params[param]
+                        params=param[1]
                     )
-                    args.append(param)
+                    args.append(param[0])
                     args.append(stepped_list)
                     shape.append(stepped_list_length)
                 else:
                     raise ValueError(
-                        f"You provided {len(params[param])} parameters, rather than 3."
+                        f"You provided {len(param[1])} parameters, rather than 3."
                     )
             else:
-                if len(params[param]) == 2:
+                if len(param[1]) == 2:
                     stepped_list, stepped_list_length = _make_stepped_list(
-                        params=params[param], num=stepped_list_length
+                        params=param[1], num=stepped_list_length
                     )
-                    args.append(param)
+                    args.append(param[0])
                     args.append(stepped_list)
                 else:
                     raise ValueError(
-                        f"You provided {len(params[param])} parameters, rather than 2."
+                        f"You provided {len(param[1])} parameters, rather than 2."
                     )
 
     return args, shape
@@ -475,11 +475,11 @@ def step_scan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent \
-            trajectories, provide '{movable1: [start1, stop1, step1], movable2: \
-            [start2, step2], ... , movableN: [startN, stepN]}'."
+            description="List of tuples (device, parameter). For concurrent \
+            trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \
+            [start2, step2]), ... , (movableN, [startN, stepN])]'."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -508,11 +508,11 @@ def step_grid_scan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent \
-            trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: \
-            [startN, stopN, stepN]}'."
+            description="List of tuples (device, parameter). For independent \
+            trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \
+            [start2, stop2, step2]), ... , (movableN, [startN, stopN, stepN])]'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -520,8 +520,8 @@ def step_grid_scan(
 ) -> MsgGenerator:
     """Scan independent trajectories with specified step size.
 
-    Generates list(s) of points for each trajectory, used with
-    bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    Snakes all slow axes by default. Generates list(s) of points for each trajectory,
+    used with bluesky.plans.list_grid_scan(det, *args, md=metadata).
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)
@@ -544,11 +544,11 @@ def step_rscan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent \
-            trajectories, provide '{movable1: [start1, stop1, step1], movable2: \
-            [start2, step2], ... , movableN: [startN, stepN]}'."
+            description="List of tuples (device, parameter). For concurrent \
+            trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \
+            [start2, step2]), ... , (movableN, [startN, stepN])]'."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -577,11 +577,11 @@ def step_grid_rscan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent \
-            trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: \
-            [startN, stopN, stepN]}'."
+            description="List of tuples (device, parameter). For independent \
+            trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \
+            [start2, stop2, step2]), ... , (movableN, [startN, stopN, stepN])]'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -589,8 +589,8 @@ def step_grid_rscan(
 ) -> MsgGenerator:
     """Scan independent trajectories with specified step size, relative to position.
 
-    Generates list(s) of points for each trajectory, used with
-    bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    Snakes all slow axes by default. Generates list(s) of points for each trajectory,
+    used with bluesky.plans.list_grid_scan(det, *args, md=metadata).
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -102,9 +102,9 @@ def num_scan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent "
-            "trajectories, provide '{movable1: [start1, stop1], movable2: [start2,"
-            "stop2], ... , movableN: [startN, stopN]}'."
+            description="Dictionary of 'device: parameter' keys. For concurrent \
+            trajectories, provide '{movable1: [start1, stop1], movable2: [start2, \
+            stop2], ... , movableN: [startN, stopN]}'."
         ),
     ],
     num: int | None = None,
@@ -113,6 +113,7 @@ def num_scan(
     """Scan concurrent single or multi-motor trajector(y/ies).
     The scan is defined by number of points along scan trajector(y/ies).
     Wraps bluesky.plans.scan(det, *args, num, md=metadata)."""
+    # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params, num)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -133,9 +134,9 @@ def num_grid_scan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent "
-            "trajectories, provide '{movable1: [start1, stop1, num1], ... , movableN: "
-            "[startN, stopN, numN]}'."
+            description="Dictionary of 'device: parameter' keys. For independent \
+            trajectories, provide '{movable1: [start1, stop1, num1], ... , movableN: \
+            [startN, stopN, numN]}'."
         ),
     ],
     snake_axes: list | bool = True,
@@ -144,6 +145,7 @@ def num_grid_scan(
     """Scan independent multi-motor trajectories.
     The scan is defined by number of points along scan trajectories.
     Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata)."""
+    # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -164,9 +166,9 @@ def num_rscan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent "
-            "trajectories, provide '{movable1: [start1, stop1], movable2: [start2,"
-            "stop2], ... , movableN: [startN, stopN]}'."
+            description="Dictionary of 'device: parameter' keys. For concurrent \
+            trajectories, provide '{movable1: [start1, stop1], movable2: [start2, \
+            stop2], ... , movableN: [startN, stopN]}'."
         ),
     ],
     num: int | None = None,
@@ -175,6 +177,7 @@ def num_rscan(
     """Scan concurrent trajector(y/ies), relative to current position(s).
     The scan is defined by number of points along scan trajector(y/ies).
     Wraps bluesky.plans.rel_scan(det, *args, num, md=metadata)."""
+    # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params, num)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -195,9 +198,9 @@ def num_grid_rscan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent "
-            "trajectories, provide '{movable1: [start1, stop1, num1], ... , movableN: "
-            "[startN, stopN, numN]}'."
+            description="Dictionary of 'device: parameter' keys. For independent \
+            trajectories, provide '{movable1: [start1, stop1, num1], ... , movableN: \
+            [startN, stopN, numN]}'."
         ),
     ],
     snake_axes: list | bool = True,
@@ -206,6 +209,7 @@ def num_grid_rscan(
     """Scan independent trajectories, relative to current positions.
     The scan is defined by number of points along scan trajectories.
     Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata)."""
+    # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -246,9 +250,9 @@ def list_scan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, "
-            "provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, "
-            "...]}'. Number of points for each movable must be equal."
+            description="Dictionary of 'device: parameter' keys. For all trajectories, \
+            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
+            ...]}'. Number of points for each movable must be equal."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -276,9 +280,9 @@ def list_grid_scan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, "
-            "provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, "
-            "...]}'."
+            description="Dictionary of 'device: parameter' keys. For all trajectories, \
+            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
+            ...]}'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -309,9 +313,9 @@ def list_rscan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, "
-            "provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, "
-            "...]}'. Number of points for each movable must be equal."
+            description="Dictionary of 'device: parameter' keys. For all trajectories, \
+            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
+            ...]}'. Number of points for each movable must be equal."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -339,9 +343,9 @@ def list_grid_rscan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For all trajectories, "
-            "provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, "
-            "...]}'."
+            description="Dictionary of 'device: parameter' keys. For all trajectories, \
+            provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, \
+            ...]}'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -456,9 +460,9 @@ def step_scan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent "
-            "trajectories, provide '{movable1: [start1, stop1, step1], movable2: "
-            "[start2, step2], ... , movableN: [startN, stepN]}'."
+            description="Dictionary of 'device: parameter' keys. For concurrent \
+            trajectories, provide '{movable1: [start1, stop1, step1], movable2: \
+            [start2, step2], ... , movableN: [startN, stepN]}'."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -466,6 +470,7 @@ def step_scan(
     """Scan concurrent trajectories with specified step size.
     Generates list(s) of points for each trajectory, used with
     bluesky.plans.list_scan(det, *args, md=metadata)."""
+    # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -486,9 +491,9 @@ def step_grid_scan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent "
-            "trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: "
-            "[startN, stopN, stepN]}'."
+            description="Dictionary of 'device: parameter' keys. For independent \
+            trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: \
+            [startN, stopN, stepN]}'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -497,6 +502,7 @@ def step_grid_scan(
     """Scan independent trajectories with specified step size.
     Generates list(s) of points for each trajectory, used with
     bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
+    # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -519,9 +525,9 @@ def step_rscan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent "
-            "trajectories, provide '{movable1: [start1, stop1, step1], movable2: "
-            "[start2, step2], ... , movableN: [startN, stepN]}'."
+            description="Dictionary of 'device: parameter' keys. For concurrent \
+            trajectories, provide '{movable1: [start1, stop1, step1], movable2: \
+            [start2, step2], ... , movableN: [startN, stepN]}'."
         ),
     ],
     metadata: dict[str, Any] | None = None,
@@ -529,6 +535,7 @@ def step_rscan(
     """Scan concurrent trajectories with specified step size, relative to position.
     Generates list(s) of points for each trajectory, used with
     bluesky.plans.rel_list_scan(det, *args, md=metadata)."""
+    # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params)
     metadata = metadata or {}
     metadata["shape"] = shape
@@ -549,9 +556,9 @@ def step_grid_rscan(
     params: Annotated[
         dict[Movable | Motor, list[float | int]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent "
-            "trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: "
-            "[startN, stopN, stepN]}'."
+            description="Dictionary of 'device: parameter' keys. For independent \
+            trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: \
+            [startN, stopN, stepN]}'."
         ),
     ],
     snake_axes: bool = True,  # Currently specifying axes to snake is not supported
@@ -560,6 +567,7 @@ def step_grid_rscan(
     """Scan independent trajectories with specified step size, relative to position.
     Generates list(s) of points for each trajectory, used with
     bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
+    # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)
     metadata = metadata or {}
     metadata["shape"] = shape

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -64,20 +64,20 @@ def count(
 
 
 def _make_num_scan_args(
-    params: dict[Movable | Motor, list[float | int]], num: int | None = None
+    params: list[tuple[Movable | Motor, list[float | int]]], num: int | None = None
 ):
     shape = []
     if num:
         shape = [num]
         for param in params:
-            if len(params[param]) == 2:
+            if len(param[1]) == 2:
                 pass
             else:
                 raise ValueError("You must provide 'start stop' for each motor.")
     else:
         for param in params:
-            if len(params[param]) == 3:
-                shape.append(params[param][-1])
+            if len(param[1]) == 3:
+                shape.append(param[1][-1])
             else:
                 raise ValueError(
                     "You must provide 'start stop step' for each motor in a grid scan."
@@ -85,8 +85,8 @@ def _make_num_scan_args(
 
     args = []
     for param in params:
-        args.append(param)
-        args.extend(params[param])
+        args.append(param[0])
+        args.extend(param[1])
     return args, shape
 
 
@@ -101,11 +101,11 @@ def num_scan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent \
-            trajectories, provide '{movable1: [start1, stop1], movable2: [start2, \
-            stop2], ... , movableN: [startN, stopN]}'."
+            description="List of tuples (device, parameter). For concurrent \
+            trajectories, provide '[(movable1, [start1, stop1]), (movable2, [start2, \
+            stop2]), ... , (movableN, [startN, stopN])]'."
         ),
     ],
     num: int | None = None,
@@ -135,11 +135,11 @@ def num_grid_scan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent \
-            trajectories, provide '{movable1: [start1, stop1, num1], ... , movableN: \
-            [startN, stopN, numN]}'."
+            description="List of tuples (device, parameter). For independent \
+            trajectories, provide '[(movable1, [start1, stop1, num1]), (movable2, \
+            [start2, stop2, num2]), ... , (movableN, [startN, stopN, numN])]'."
         ),
     ],
     snake_axes: list | bool = True,
@@ -169,11 +169,11 @@ def num_rscan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For concurrent \
-            trajectories, provide '{movable1: [start1, stop1], movable2: [start2, \
-            stop2], ... , movableN: [startN, stopN]}'."
+            description="List of tuples (device, parameter). For concurrent \
+            trajectories, provide '[(movable1, [start1, stop1]), (movable2, [start2, \
+            stop2]), ... , (movableN, [startN, stopN])]'."
         ),
     ],
     num: int | None = None,
@@ -203,11 +203,11 @@ def num_grid_rscan(
         ),
     ],
     params: Annotated[
-        dict[Movable | Motor, list[float | int]],
+        list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="Dictionary of 'device: parameter' keys. For independent \
-            trajectories, provide '{movable1: [start1, stop1, num1], ... , movableN: \
-            [startN, stopN, numN]}'."
+            description="List of tuples (device, parameter). For independent \
+            trajectories, provide '[(movable1, [start1, stop1, num1]), (movable2, \
+            [start2, stop2, num2]), ... , (movableN, [startN, stopN, numN])]'."
         ),
     ],
     snake_axes: list | bool = True,

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -1,11 +1,15 @@
 from collections.abc import Sequence
+from decimal import Decimal
 from typing import Annotated, Any
 
 import bluesky.plans as bp
-from bluesky.protocols import Readable
+import numpy as np
+from bluesky.protocols import Movable, Readable
+from ophyd_async.core import AsyncReadable
 from pydantic import Field, NonNegativeFloat, validate_call
 
 from dodal.common import MsgGenerator
+from dodal.devices.motors import Motor
 from dodal.plan_stubs.data_session import attach_data_session_metadata_decorator
 
 """This module wraps plan(s) from bluesky.plans until required handling for them is
@@ -27,7 +31,7 @@ We may also need other adjustments for UI purposes, e.g.
 @validate_call(config={"arbitrary_types_allowed": True})
 def count(
     detectors: Annotated[
-        set[Readable],
+        Sequence[Readable | AsyncReadable],
         Field(
             description="Set of readable devices, will take a reading at each point",
             min_length=1,
@@ -56,3 +60,338 @@ def count(
     metadata = metadata or {}
     metadata["shape"] = (num,)
     yield from bp.count(tuple(detectors), num, delay=delay, md=metadata)
+
+
+def _make_num_scan_args(params: dict[Movable | Motor, list[float | int]]):
+    shape = []
+    for param in params:
+        if len(params[param]) == 3:
+            shape.append(params[param][-1])
+    args = []
+    for param, movable_num in zip(params, range(len(params)), strict=True):
+        args.append(param)
+        if movable_num == 0 and len(shape) == 1:
+            params[param].pop()
+        args.extend(params[param])
+    return args, shape
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def num_scan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    params: Annotated[
+        dict[Movable | Motor, list[float | int]],
+        Field(
+            description="Dictionary of 'device: paramater' keys. For concurrent "
+            "trajectories, provide '{movable1: [start1, stop1, num], movable2: [start2,"
+            "stop2], ... , movableN: [startN, stopN]}'. For independent trajectories,"
+            "provide '{movable1: [start1, stop1, num1], ... , movableN: [startN, stopN,"
+            "numN]}'."
+        ),
+    ],
+    snake_axes: list | bool | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over concurrent or independent multi-motor trajectories.
+    Wraps bluesky.plans.scan(det, *args, num, md=metadata) and
+    bluesky.plans.grid_scan(det, *args, md=metadata)"""
+    args, shape = _make_num_scan_args(params)
+    metadata = metadata or {}
+    metadata["shape"] = shape
+
+    if len(shape) == 1:
+        yield from bp.scan(tuple(detectors), *args, num=shape[0], md=metadata)
+    elif len(shape) > 1:
+        yield from bp.grid_scan(
+            tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+        )
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def num_rscan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    params: Annotated[
+        dict[Movable | Motor, list[float | int]],
+        Field(
+            description="Dictionary of 'device: paramater' keys. For concurrent "
+            "trajectories, provide '{movable1: [start1, stop1, num], movable2: [start2,"
+            "stop2], ... , movableN: [startN, stopN]}'. For independent trajectories,"
+            "provide '{movable1: [start1, stop1, num1], ... , movableN: [startN, stopN,"
+            "numN]}'."
+        ),
+    ],
+    snake_axes: list | bool | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over concurrent or independent trajectories relative to current position.
+    Wraps bluesky.plans.rel_scan(det, *args, num, md=metadata) and
+    bluesky.plans.rel_grid_scan(det, *args, md=metadata)"""
+    args, shape = _make_num_scan_args(params)
+    metadata = metadata or {}
+    metadata["shape"] = shape
+
+    if len(shape) == 1:
+        yield from bp.rel_scan(tuple(detectors), *args, num=shape[0], md=metadata)
+    elif len(shape) > 1:
+        yield from bp.rel_grid_scan(
+            tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+        )
+
+
+def _make_list_scan_args(params: dict[Movable | Motor, list[float | int]], grid: bool):
+    shape = []
+    args = []
+    for param, num in zip(params, range(len(params)), strict=True):
+        if num == 0:
+            shape.append(len(params[param]))
+        elif num >= 1 and grid:
+            shape.append(len(params[param]))
+        args.append(param)
+        args.append(params[param])
+    return args, shape
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def list_scan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    params: Annotated[
+        dict[Movable | Motor, list[float | int]],
+        Field(
+            description="Dictionary of 'device: paramater' keys. For all trajectories, "
+            "provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, "
+            "...]}'."
+        ),
+    ],
+    grid: bool = False,
+    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over concurrent or independent trajectories relative to current position.
+    To scan over concurrent trajectories, grid = False, and independent trajectories,
+    grid = True.
+    Wraps bluesky.plans.list_scan(det, *args, num, md=metadata) and
+    bluesky.plans.list_grid_scan(det, *args, md=metadata)"""
+    args, shape = _make_list_scan_args(params=params, grid=grid)
+    metadata = metadata or {}
+    metadata["shape"] = shape
+
+    if len(shape) == 1:
+        yield from bp.list_scan(tuple(detectors), *args, md=metadata)
+    elif len(shape) > 1:
+        yield from bp.list_grid_scan(
+            tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+        )
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def list_rscan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    params: Annotated[
+        dict[Movable | Motor, list[float | int]],
+        Field(
+            description="Dictionary of 'device: paramater' keys. For all trajectories, "
+            "provide '{movable1: [point1, point2, ... ], movableN: [point1, point2, "
+            "...]}'."
+        ),
+    ],
+    grid: bool = False,
+    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over concurrent or independent trajectories relative to current position.
+    To scan over concurrent trajectories, grid = False, and independent trajectories,
+    grid = True.
+    Wraps bluesky.plans.rel_list_scan(det, *args, num, md=metadata) and
+    bluesky.plans.rel_list_grid_scan(det, *args, md=metadata)"""
+    args, shape = _make_list_scan_args(params=params, grid=grid)
+    metadata = metadata or {}
+    metadata["shape"] = shape
+
+    if len(shape) == 1:
+        yield from bp.rel_list_scan(tuple(detectors), *args, md=metadata)
+    elif len(shape) > 1:
+        yield from bp.rel_list_grid_scan(
+            tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+        )
+
+
+def _make_stepped_list(
+    params: list[Any] | Sequence[Any],
+    num: int | None = None,
+):
+    def round_list_elements(stepped_list, step):
+        d = Decimal(str(step))
+        exponent = d.as_tuple().exponent
+        decimal_places = -exponent  # type: ignore
+        return np.round(stepped_list, decimals=decimal_places).tolist()
+
+    start = params[0]
+    if len(params) == 3:
+        stop = params[1]
+        step = params[2]
+        if abs(step) > abs(stop - start):
+            step = stop - start
+        step = abs(step) * np.sign(stop - start)
+        stepped_list = np.arange(start=start, stop=stop, step=step).tolist()
+        if abs((stepped_list[-1] + step) - stop) <= abs(step * 0.01):
+            stepped_list.append(stepped_list[-1] + step)
+        rounded_stepped_list = round_list_elements(stepped_list=stepped_list, step=step)
+    elif len(params) == 2 and num:
+        step = params[1]
+        stepped_list = [start + (n * step) for n in range(num)]
+        rounded_stepped_list = round_list_elements(stepped_list=stepped_list, step=step)
+    else:
+        raise ValueError(
+            f"You provided {len(params)}, rather than 3, or 2 and number of points."
+        )
+
+    return rounded_stepped_list, len(rounded_stepped_list)
+
+
+def _make_step_scan_args(params: dict[Movable | Motor, list[float | int]]):
+    args = []
+    shape = []
+    stepped_list_length = None
+    for param, movable_num in zip(params, range(len(params)), strict=True):
+        if movable_num == 0:
+            if len(params[param]) == 3:
+                stepped_list, stepped_list_length = _make_stepped_list(
+                    params=params[param]
+                )
+                args.append(param)
+                args.append(stepped_list)
+                shape.append(stepped_list_length)
+            else:
+                raise ValueError(
+                    f"You provided {len(params[param])} parameters, rather than 3."
+                )
+        elif movable_num >= 1:
+            if len(params[param]) == 2:
+                stepped_list, stepped_list_length = _make_stepped_list(
+                    params=params[param], num=stepped_list_length
+                )
+                args.append(param)
+                args.append(stepped_list)
+            elif len(params[param]) == 3:
+                stepped_list, stepped_list_length = _make_stepped_list(
+                    params=params[param]
+                )
+                args.append(param)
+                args.append(stepped_list)
+                shape.append(stepped_list_length)
+            else:
+                raise ValueError(
+                    f"You provided {len(params[param])} parameters, rather than 2 or 3."
+                )
+    if (len(args) / len(shape)) not in [2, len(args)]:
+        raise ValueError(
+            "Incorrect number of parameters, unsure if scan is concurrent/independent."
+        )
+
+    return args, shape
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def step_scan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    params: Annotated[
+        dict[Movable | Motor, list[float | int]],
+        Field(
+            description="Dictionary of 'device: paramater' keys. For concurrent "
+            "trajectories, provide '{movable1: [start1, stop1, step1], movable2: "
+            "[start2, step2], ... , movableN: [startN, stepN]}'. For independent "
+            "trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: "
+            "[startN, stopN, stepN]}'."
+        ),
+    ],
+    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over multi-motor trajectories with specified step size.
+    Generates lists of points for each trajectory for
+    bluesky.plans.list_scan(det, *args, num, md=metadata) and
+    bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
+    args, shape = _make_step_scan_args(params)
+    metadata = metadata or {}
+    metadata["shape"] = shape
+
+    if len(shape) == 1:
+        yield from bp.list_scan(tuple(detectors), *args, md=metadata)
+    elif len(shape) > 1:
+        yield from bp.list_grid_scan(
+            tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+        )
+
+
+@attach_data_session_metadata_decorator()
+@validate_call(config={"arbitrary_types_allowed": True})
+def step_rscan(
+    detectors: Annotated[
+        Sequence[Readable | AsyncReadable],
+        Field(
+            description="Set of readable devices, will take a reading at each point",
+            min_length=1,
+        ),
+    ],
+    params: Annotated[
+        dict[Movable | Motor, list[float | int]],
+        Field(
+            description="Dictionary of 'device: paramater' keys. For concurrent "
+            "trajectories, provide '{movable1: [start1, stop1, step1], movable2: "
+            "[start2, step2], ... , movableN: [startN, stepN]}'. For independent "
+            "trajectories, provide '{movable1: [start1, stop1, step1], ... , movableN: "
+            "[startN, stopN, stepN]}'."
+        ),
+    ],
+    snake_axes: bool = False,  # Currently specifying axes to snake is not supported
+    metadata: dict[str, Any] | None = None,
+) -> MsgGenerator:
+    """Scan over multi-motor trajectories with specified step size.
+    Generates lists of points for each trajectory for
+    bluesky.plans.list_scan(det, *args, num, md=metadata) and
+    bluesky.plans.list_grid_scan(det, *args, md=metadata)."""
+    args, shape = _make_step_scan_args(params)
+    metadata = metadata or {}
+    metadata["shape"] = shape
+
+    if len(shape) == 1:
+        yield from bp.rel_list_scan(tuple(detectors), *args, md=metadata)
+    elif len(shape) > 1:
+        yield from bp.rel_list_grid_scan(
+            tuple(detectors), *args, snake_axes=snake_axes, md=metadata
+        )

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -90,7 +90,6 @@ def _make_num_scan_args(
     return args, shape
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def num_scan(
     detectors: Annotated[
@@ -124,7 +123,6 @@ def num_scan(
     yield from bp.scan(tuple(detectors), *args, num=num, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def num_grid_scan(
     detectors: Annotated[
@@ -158,7 +156,6 @@ def num_grid_scan(
     yield from bp.grid_scan(tuple(detectors), *args, snake_axes=snake_axes, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def num_rscan(
     detectors: Annotated[
@@ -192,7 +189,6 @@ def num_rscan(
     yield from bp.rel_scan(tuple(detectors), *args, num=num, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def num_grid_rscan(
     detectors: Annotated[
@@ -246,7 +242,6 @@ def _make_list_scan_args(
     return args, shape
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def list_scan(
     detectors: Annotated[
@@ -279,7 +274,6 @@ def list_scan(
     yield from bp.list_scan(tuple(detectors), *args, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def list_grid_scan(
     detectors: Annotated[
@@ -314,7 +308,6 @@ def list_grid_scan(
     )
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def list_rscan(
     detectors: Annotated[
@@ -347,7 +340,6 @@ def list_rscan(
     yield from bp.rel_list_scan(tuple(detectors), *args, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def list_grid_rscan(
     detectors: Annotated[
@@ -465,7 +457,6 @@ def _make_step_scan_args(
     return args, shape
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def step_scan(
     detectors: Annotated[
@@ -498,7 +489,6 @@ def step_scan(
     yield from bp.list_scan(tuple(detectors), *args, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def step_grid_scan(
     detectors: Annotated[
@@ -535,7 +525,6 @@ def step_grid_scan(
     )
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def step_rscan(
     detectors: Annotated[
@@ -568,7 +557,6 @@ def step_rscan(
     yield from bp.rel_list_scan(tuple(detectors), *args, md=metadata)
 
 
-@attach_data_session_metadata_decorator()
 @validate_call(config={"arbitrary_types_allowed": True})
 def step_grid_rscan(
     detectors: Annotated[

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -102,12 +102,12 @@ def num_scan(
     params: Annotated[
         list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="List of tuples (device, parameter). For concurrent \
-            trajectories, provide '[(movable1, [start1, stop1]), (movable2, [start2, \
-            stop2]), ... , (movableN, [startN, stopN])]'."
+            description="List of tuples (device, parameter). For concurrent "
+            "trajectories, provide '[(movable1, [start1, stop1]), (movable2, [start2, "
+            "stop2]), ... , (movableN, [startN, stopN])]'."
         ),
     ],
-    num: int | None = None,
+    num: int,
     metadata: dict[str, Any] | None = None,
 ) -> MsgGenerator:
     """Scan concurrent single or multi-motor trajector(y/ies).

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -379,7 +379,7 @@ def list_grid_rscan(
 
 
 def _make_stepped_list(
-    params: list[Any] | Sequence[Any],
+    params: list[Any],
     num: int | None = None,
 ):
     def round_list_elements(stepped_list, step):

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -421,8 +421,23 @@ def _make_step_scan_args(
     args = []
     shape = []
     stepped_list_length = None
-    for param, movable_num in zip(params, range(len(params)), strict=True):
-        if movable_num == 0:
+
+    if not params:
+        return [], []
+    first_movable_param, *additional_movable_params = params
+    if len(first_movable_param[1]) == 3:
+        stepped_list, stepped_list_length = _make_stepped_list(
+            params=first_movable_param[1]
+        )
+        args.append(first_movable_param[0])
+        args.append(stepped_list)
+        shape.append(stepped_list_length)
+    else:
+        raise ValueError(
+            f"You provided {len(first_movable_param[1])} parameters, rather than 3."
+        )
+    for param in additional_movable_params:
+        if grid:
             if len(param[1]) == 3:
                 stepped_list, stepped_list_length = _make_stepped_list(params=param[1])
                 args.append(param[0])
@@ -432,30 +447,17 @@ def _make_step_scan_args(
                 raise ValueError(
                     f"You provided {len(param[1])} parameters, rather than 3."
                 )
-        elif movable_num >= 1:
-            if grid:
-                if len(param[1]) == 3:
-                    stepped_list, stepped_list_length = _make_stepped_list(
-                        params=param[1]
-                    )
-                    args.append(param[0])
-                    args.append(stepped_list)
-                    shape.append(stepped_list_length)
-                else:
-                    raise ValueError(
-                        f"You provided {len(param[1])} parameters, rather than 3."
-                    )
+        else:
+            if len(param[1]) == 2:
+                stepped_list, stepped_list_length = _make_stepped_list(
+                    params=param[1], num=stepped_list_length
+                )
+                args.append(param[0])
+                args.append(stepped_list)
             else:
-                if len(param[1]) == 2:
-                    stepped_list, stepped_list_length = _make_stepped_list(
-                        params=param[1], num=stepped_list_length
-                    )
-                    args.append(param[0])
-                    args.append(stepped_list)
-                else:
-                    raise ValueError(
-                        f"You provided {len(param[1])} parameters, rather than 2."
-                    )
+                raise ValueError(
+                    f"You provided {len(param[1])} parameters, rather than 2."
+                )
 
     return args, shape
 

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -9,7 +9,6 @@ from ophyd_async.core import AsyncReadable
 from pydantic import Field, NonNegativeFloat, validate_call
 
 from dodal.common import MsgGenerator
-from dodal.devices.motors import Motor
 from dodal.plan_stubs.data_session import attach_data_session_metadata_decorator
 
 """This module wraps plan(s) from bluesky.plans until required handling for them is
@@ -64,7 +63,7 @@ def count(
 
 
 def _make_num_scan_args(
-    params: list[tuple[Movable | Motor, list[float | int]]], num: int | None = None
+    params: list[tuple[Movable, list[float | int]]], num: int | None = None
 ):
     shape = []
     if num:
@@ -100,7 +99,7 @@ def num_scan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For concurrent "
             "trajectories, provide '[(movable1, [start1, stop1]), (movable2, [start2, "
@@ -133,7 +132,7 @@ def num_grid_scan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For independent \
             trajectories, provide '[(movable1, [start1, stop1, num1]), (movable2, \
@@ -167,7 +166,7 @@ def num_rscan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For concurrent \
             trajectories, provide '[(movable1, [start1, stop1]), (movable2, [start2, \
@@ -200,7 +199,7 @@ def num_grid_rscan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For independent \
             trajectories, provide '[(movable1, [start1, stop1, num1]), (movable2, \
@@ -226,9 +225,7 @@ def num_grid_rscan(
     )
 
 
-def _make_list_scan_args(
-    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool
-):
+def _make_list_scan_args(params: list[tuple[Movable, list[float | int]]], grid: bool):
     shape = []
     args = []
     for param in params:
@@ -254,7 +251,7 @@ def list_scan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, positions). For concurrent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
@@ -286,7 +283,7 @@ def list_grid_scan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, positions). For independent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
@@ -321,7 +318,7 @@ def list_rscan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, positions). For concurrent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
@@ -353,7 +350,7 @@ def list_grid_rscan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, positions). For independent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
@@ -412,7 +409,7 @@ def _make_stepped_list_num(start, step, num) -> list:
 
 
 def _make_step_scan_args(
-    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool
+    params: list[tuple[Movable, list[float | int]]], grid: bool
 ) -> tuple[list[Any], list[float]]:
     args = []
     shape = []
@@ -466,7 +463,7 @@ def step_scan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For concurrent \
             trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \
@@ -498,7 +495,7 @@ def step_grid_scan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For independent \
             trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \
@@ -534,7 +531,7 @@ def step_rscan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For concurrent \
             trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \
@@ -566,7 +563,7 @@ def step_grid_rscan(
         ),
     ],
     params: Annotated[
-        list[tuple[Movable | Motor, list[float | int]]],
+        list[tuple[Movable, list[float | int]]],
         Field(
             description="List of tuples (device, parameter). For independent \
             trajectories, provide '[(movable1, [start1, stop1, step1]), (movable2, \

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -212,7 +212,8 @@ def num_grid_rscan(
     """Scan independent trajectories, relative to current positions.
 
     The scan is defined by number of points along scan trajectories. Snakes all fast
-    axes by default. Wraps bluesky.plans.rel_grid_scan(det, *args, md=metadata).
+    axes by default. Wraps bluesky.plans.rel_grid_scan(det, *args, snake_axes,
+    md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -255,7 +255,7 @@ def list_scan(
     params: Annotated[
         list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="List of tuples (device, parameter). For concurrent \
+            description="List of tuples (device, positions). For concurrent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
             [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'. Number \
             of points for each movable must be equal."
@@ -287,7 +287,7 @@ def list_grid_scan(
     params: Annotated[
         list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="List of tuples (device, parameter). For independent \
+            description="List of tuples (device, positions). For independent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
             [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'."
         ),
@@ -321,7 +321,7 @@ def list_rscan(
     params: Annotated[
         list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="List of tuples (device, parameter). For concurrent \
+            description="List of tuples (device, positions). For concurrent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
             [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'. Number \
             of points for each movable must be equal."
@@ -353,7 +353,7 @@ def list_grid_rscan(
     params: Annotated[
         list[tuple[Movable | Motor, list[float | int]]],
         Field(
-            description="List of tuples (device, parameter). For independent \
+            description="List of tuples (device, positions). For independent \
             trajectories, provide '[(movable1, [point1, point2, ...]), (movable2, \
             [point1, point2, ...]), ... , (movableN, [point1, point2, ...])]'."
         ),

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -146,7 +146,8 @@ def num_grid_scan(
     """Scan independent multi-motor trajectories.
 
     The scan is defined by number of points along scan trajectories. Snakes all fast
-    axes by default. Wraps bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).
+    axes by default (all axes but the first axis provided). Wraps
+    bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
@@ -212,8 +213,8 @@ def num_grid_rscan(
     """Scan independent trajectories, relative to current positions.
 
     The scan is defined by number of points along scan trajectories. Snakes all fast
-    axes by default. Wraps bluesky.plans.rel_grid_scan(det, *args, snake_axes,
-    md=metadata).
+    axes by default (all axes but the first axis provided). Wraps
+    bluesky.plans.rel_grid_scan(det, *args, snake_axes, md=metadata).
     """
     # TODO: move to using Range spec and spec_scan when stable and tested at v1.0
     args, shape = _make_num_scan_args(params)
@@ -298,7 +299,8 @@ def list_grid_scan(
     """Scan independent trajectories.
 
     The scan is defined by providing a list of points for each scan trajectory. Snakes
-    slow axes by default. Wraps bluesky.plans.list_grid_scan(det, *args, md=metadata).
+    all fast axes by default (all axes but the first axis provided). Wraps
+    bluesky.plans.list_grid_scan(det, *args, md=metadata).
     """
     args, shape = _make_list_scan_args(params=params, grid=True)
     metadata = metadata or {}
@@ -364,8 +366,8 @@ def list_grid_rscan(
     """Scan independent trajectories, relative to current positions.
 
     The scan is defined by providing a list of points for each scan trajectory. Snakes
-    all fast axes by default. Wraps bluesky.plans.rel_list_grid_scan(det, *args,
-    md=metadata).
+    all fast axes by default (all axes but the first axis provided). Wraps
+    bluesky.plans.rel_list_grid_scan(det, *args, md=metadata).
     """
     args, shape = _make_list_scan_args(params=params, grid=True)
     metadata = metadata or {}
@@ -514,7 +516,7 @@ def step_grid_scan(
 
     Generates list(s) of points for each trajectory, used with
     bluesky.plans.list_grid_scan(det, *args, md=metadata). Snakes all fast axes by
-    default.
+    default (all axes but the first axis provided).
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)
@@ -582,7 +584,7 @@ def step_grid_rscan(
 
     Generates list(s) of points for each trajectory, used with
     bluesky.plans.list_grid_scan(det, *args, md=metadata). Snakes all fast axes by
-    default.
+    default (all axes but the first axis provided).
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
     args, shape = _make_step_scan_args(params, grid=True)

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -378,7 +378,7 @@ def list_grid_rscan(
     )
 
 
-def _round_list_elements(stepped_list, params):
+def _round_list_elements(stepped_list, params) -> list[float]:
     decimals = [Decimal(str(param)) for param in params]
     exponents = [d.as_tuple().exponent for d in decimals]
     decimal_places = [-exponent for exponent in exponents]  # type: ignore
@@ -413,13 +413,11 @@ def _make_stepped_list_num(start, step, num) -> list:
 
 def _make_step_scan_args(
     params: list[tuple[Movable | Motor, list[float | int]]], grid: bool
-):
+) -> tuple[list[Any], list[float]]:
     args = []
     shape = []
     stepped_list_length = None
 
-    if not params:
-        return [], []
     first_movable_param, *additional_movable_params = params
     if len(first_movable_param[1]) == 3:
         start, stop, step = first_movable_param[1]

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -378,45 +378,41 @@ def list_grid_rscan(
     )
 
 
-def _make_stepped_list(
-    params: list[Any],
-    num: int | None = None,
-):
-    def round_list_elements(stepped_list, step):
-        d = Decimal(str(step))
-        exponent = d.as_tuple().exponent
-        decimal_places = -exponent  # type: ignore
-        return np.round(stepped_list, decimals=decimal_places).tolist()
+def _round_list_elements(stepped_list, params):
+    decimals = [Decimal(str(param)) for param in params]
+    exponents = [d.as_tuple().exponent for d in decimals]
+    decimal_places = [-exponent for exponent in exponents]  # type: ignore
+    max_decimal_places = max(decimal_places)
+    return np.round(stepped_list, decimals=max_decimal_places).tolist()
 
-    start = params[0]
-    if len(params) == 3:
-        stop = params[1]
-        step = params[2]
-        if start == stop:
-            raise ValueError(
-                f"Start ({start}) and stop ({stop}) values cannot be the same."
-            )
-        if abs(step) > abs(stop - start):
-            step = stop - start
-        step = abs(step) * np.sign(stop - start)
-        stepped_list = np.arange(start, stop, step).tolist()
-        if abs((stepped_list[-1] + step) - stop) <= abs(step * 0.05):
-            stepped_list.append(stepped_list[-1] + step)
-        rounded_stepped_list = round_list_elements(stepped_list=stepped_list, step=step)
-    elif len(params) == 2 and num:
-        step = params[1]
-        stepped_list = [start + (n * step) for n in range(num)]
-        rounded_stepped_list = round_list_elements(stepped_list=stepped_list, step=step)
-    else:
+
+def _make_stepped_list_step(start: float, stop: float, step: float) -> list:
+    if start == stop:
         raise ValueError(
-            f"You provided {len(params)}, rather than 3, or 2 and number of points."
+            f"Start ({start}) and stop ({stop}) values cannot be the same."
         )
+    if abs(step) > abs(stop - start):
+        step = stop - start
+    step = abs(step) * np.sign(stop - start)
+    stepped_list = np.arange(start, stop, step).tolist()
+    if abs((stepped_list[-1] + step) - stop) <= abs(step * 0.05):
+        stepped_list.append(stepped_list[-1] + step)
+    rounded_stepped_list = _round_list_elements(
+        stepped_list=stepped_list, params=[start, stop, step]
+    )
+    return rounded_stepped_list
 
-    return rounded_stepped_list, len(rounded_stepped_list)
+
+def _make_stepped_list_num(start, step, num) -> list:
+    stepped_list = [start + (n * step) for n in range(num)]
+    rounded_stepped_list = _round_list_elements(
+        stepped_list=stepped_list, params=[start, step]
+    )
+    return rounded_stepped_list
 
 
 def _make_step_scan_args(
-    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool | None = None
+    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool
 ):
     args = []
     shape = []
@@ -426,9 +422,9 @@ def _make_step_scan_args(
         return [], []
     first_movable_param, *additional_movable_params = params
     if len(first_movable_param[1]) == 3:
-        stepped_list, stepped_list_length = _make_stepped_list(
-            params=first_movable_param[1]
-        )
+        start, stop, step = first_movable_param[1]
+        stepped_list = _make_stepped_list_step(start, stop, step)
+        stepped_list_length = len(stepped_list)
         args.append(first_movable_param[0])
         args.append(stepped_list)
         shape.append(stepped_list_length)
@@ -439,19 +435,19 @@ def _make_step_scan_args(
     for param in additional_movable_params:
         if grid:
             if len(param[1]) == 3:
-                stepped_list, stepped_list_length = _make_stepped_list(params=param[1])
+                start, stop, step = param[1]
+                stepped_list = _make_stepped_list_step(start, stop, step)
                 args.append(param[0])
                 args.append(stepped_list)
-                shape.append(stepped_list_length)
+                shape.append(len(stepped_list))
             else:
                 raise ValueError(
                     f"You provided {len(param[1])} parameters for {param[0]}, rather than 3."
                 )
         else:
             if len(param[1]) == 2:
-                stepped_list, stepped_list_length = _make_stepped_list(
-                    params=param[1], num=stepped_list_length
-                )
+                start, step = param[1]
+                stepped_list = _make_stepped_list_num(start, step, stepped_list_length)
                 args.append(param[0])
                 args.append(stepped_list)
             else:
@@ -487,7 +483,7 @@ def step_scan(
     bluesky.plans.list_scan(det, *args, md=metadata).
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
-    args, shape = _make_step_scan_args(params)
+    args, shape = _make_step_scan_args(params, grid=False)
     metadata = metadata or {}
     metadata["shape"] = shape
 
@@ -555,7 +551,7 @@ def step_rscan(
     bluesky.plans.rel_list_scan(det, *args, md=metadata).
     """
     # TODO: move to using Linspace spec and spec_scan when stable and tested at v1.0
-    args, shape = _make_step_scan_args(params)
+    args, shape = _make_step_scan_args(params, grid=False)
     metadata = metadata or {}
     metadata["shape"] = shape
 

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -434,7 +434,7 @@ def _make_step_scan_args(
         shape.append(stepped_list_length)
     else:
         raise ValueError(
-            f"You provided {len(first_movable_param[1])} parameters, rather than 3."
+            f"You provided {len(first_movable_param[1])} parameters for {first_movable_param[0]}, rather than 3."
         )
     for param in additional_movable_params:
         if grid:
@@ -445,7 +445,7 @@ def _make_step_scan_args(
                 shape.append(stepped_list_length)
             else:
                 raise ValueError(
-                    f"You provided {len(param[1])} parameters, rather than 3."
+                    f"You provided {len(param[1])} parameters for {param[0]}, rather than 3."
                 )
         else:
             if len(param[1]) == 2:
@@ -456,7 +456,7 @@ def _make_step_scan_args(
                 args.append(stepped_list)
             else:
                 raise ValueError(
-                    f"You provided {len(param[1])} parameters, rather than 2."
+                    f"You provided {len(param[1])} parameters {param[0]}, rather than 2."
                 )
 
     return args, shape

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -80,7 +80,7 @@ def _make_num_scan_args(
                 shape.append(param[1][-1])
             else:
                 raise ValueError(
-                    "You must provide 'start stop step' for each motor in a grid scan."
+                    "You must provide 'start stop num' for each motor in a grid scan."
                 )
 
     args = []

--- a/src/dodal/plans/wrapped.py
+++ b/src/dodal/plans/wrapped.py
@@ -226,7 +226,7 @@ def num_grid_rscan(
 
 
 def _make_list_scan_args(
-    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool | None = None
+    params: list[tuple[Movable | Motor, list[float | int]]], grid: bool
 ):
     shape = []
     args = []
@@ -268,7 +268,7 @@ def list_scan(
     The scan is defined by providing a list of points for each scan trajectory.
     Wraps bluesky.plans.list_scan(det, *args, md=metadata).
     """
-    args, shape = _make_list_scan_args(params=params)
+    args, shape = _make_list_scan_args(params=params, grid=False)
     metadata = metadata or {}
     metadata["shape"] = shape
 
@@ -334,7 +334,7 @@ def list_rscan(
     The scan is defined by providing a list of points for each scan trajectory.
     Wraps bluesky.plans.rel_list_scan(det, *args, md=metadata).
     """
-    args, shape = _make_list_scan_args(params=params)
+    args, shape = _make_list_scan_args(params=params, grid=False)
     metadata = metadata or {}
     metadata["shape"] = shape
 

--- a/system_tests/test_adsim.py
+++ b/system_tests/test_adsim.py
@@ -76,7 +76,7 @@ def test_plan_produces_expected_start_document(
     run_engine_documents: Mapping[str, list[DocumentType]],
     det: StandardDetector,
 ):
-    run_engine(count({det}, num=num))
+    run_engine(count([det], num=num))
 
     docs = run_engine_documents.get("start")
     assert docs and len(docs) == 1
@@ -101,7 +101,7 @@ def test_plan_produces_expected_stop_document(
     run_engine_documents: Mapping[str, list[DocumentType]],
     det: StandardDetector,
 ):
-    run_engine(count({det}, num=num))
+    run_engine(count([det], num=num))
 
     docs = run_engine_documents.get("stop")
     assert docs and len(docs) == 1
@@ -118,7 +118,7 @@ def test_plan_produces_expected_descriptor(
     run_engine_documents: Mapping[str, list[DocumentType]],
     det: StandardDetector,
 ):
-    run_engine(count({det}, num=num))
+    run_engine(count([det], num=num))
 
     docs = run_engine_documents.get("descriptor")
     assert docs and len(docs) == 1
@@ -137,7 +137,7 @@ def test_plan_produces_expected_events(
     run_engine_documents: Mapping[str, list[DocumentType]],
     det: StandardDetector,
 ):
-    run_engine(count({det}, num=num))
+    run_engine(count([det], num=num))
 
     docs = run_engine_documents.get("event")
     assert docs and len(docs) == length
@@ -155,7 +155,7 @@ def test_plan_produces_expected_resources(
     run_engine_documents: Mapping[str, list[DocumentType]],
     det: StandardDetector,
 ):
-    run_engine(count({det}, num=num))
+    run_engine(count([det], num=num))
     docs = run_engine_documents.get("stream_resource")
     data_keys = [det.name]
     assert docs and len(docs) == len(data_keys)
@@ -178,7 +178,7 @@ def test_plan_produces_expected_datums(
     run_engine_documents: Mapping[str, list[DocumentType]],
     det: StandardDetector,
 ):
-    run_engine(count({det}, num=num))
+    run_engine(count([det], num=num))
     docs = cast(list[StreamDatum], run_engine_documents.get("stream_datum"))
     data_keys = [det.name]  # If we enable e.g. Stats plugin add to this
     assert (

--- a/tests/plan_stubs/test_wrapped_stubs.py
+++ b/tests/plan_stubs/test_wrapped_stubs.py
@@ -10,9 +10,11 @@ from ophyd_async.sim import SimMotor
 from dodal.plan_stubs.wrapped import (
     move,
     move_relative,
+    rd,
     set_absolute,
     set_relative,
     sleep,
+    stop,
     wait,
 )
 
@@ -147,3 +149,11 @@ def test_wait_group_and_timeout():
     assert list(wait("foo", 5.0)) == [
         Msg("wait", group="foo", timeout=5.0, error_on_timeout=True, watch=_EMPTY)
     ]
+
+
+def test_rd(x_axis: SimMotor):
+    assert list(rd(x_axis)) == [Msg("locate", obj=x_axis)]
+
+
+def test_stop(x_axis: SimMotor):
+    assert list(stop(x_axis)) == [Msg("stop", obj=x_axis)]

--- a/tests/plan_stubs/test_wrapped_stubs.py
+++ b/tests/plan_stubs/test_wrapped_stubs.py
@@ -36,33 +36,36 @@ def y_axis() -> SimMotor:
 
 
 def test_set_absolute(x_axis: SimMotor):
-    assert list(set_absolute(x_axis, 0.5)) == [Msg("set", x_axis, 0.5, group=None)]
-
-
-def test_set_absolute_with_group(x_axis: SimMotor):
-    assert list(set_absolute(x_axis, 0.5, group="foo")) == [
-        Msg("set", x_axis, 0.5, group="foo")
-    ]
-
-
-def test_set_absolute_with_wait(x_axis: SimMotor):
     msgs = list(set_absolute(x_axis, 0.5, wait=True))
     assert len(msgs) == 2
     assert msgs[0] == Msg("set", x_axis, 0.5, group=ANY)
     assert msgs[1] == Msg("wait", group=msgs[0].kwargs["group"])
 
 
-def test_set_absolute_with_group_and_wait(x_axis: SimMotor):
-    assert list(set_absolute(x_axis, 0.5, group="foo", wait=True)) == [
-        Msg("set", x_axis, 0.5, group="foo"),
-        Msg("wait", group="foo"),
+def test_set_absolute_without_wait(x_axis: SimMotor):
+    assert list(set_absolute(x_axis, 0.5, wait=False)) == [
+        Msg("set", x_axis, 0.5, group=None)
+    ]
+
+
+def test_set_absolute_with_group(x_axis: SimMotor):
+    msgs = list(set_absolute(x_axis, 0.5, group="foo"))
+    assert len(msgs) == 2
+    assert msgs[0] == Msg("set", x_axis, 0.5, group="foo")
+    assert msgs[1] == Msg("wait", group=msgs[0].kwargs["group"])
+
+
+def test_set_absolute_with_group_and_without_wait(x_axis: SimMotor):
+    assert list(set_absolute(x_axis, 0.5, group="foo", wait=False)) == [
+        Msg("set", x_axis, 0.5, group="foo")
     ]
 
 
 def test_set_relative(x_axis: SimMotor):
     assert list(set_relative(x_axis, 0.5)) == [
         Msg("locate", x_axis),
-        Msg("set", x_axis, 0.5, group=None),
+        Msg("set", x_axis, 0.5, group=ANY),
+        Msg("wait", group=ANY),
     ]
 
 
@@ -70,22 +73,21 @@ def test_set_relative_with_group(x_axis: SimMotor):
     assert list(set_relative(x_axis, 0.5, group="foo")) == [
         Msg("locate", x_axis),
         Msg("set", x_axis, 0.5, group="foo"),
+        Msg("wait", group="foo"),
     ]
 
 
-def test_set_relative_with_wait(x_axis: SimMotor):
-    msgs = list(set_relative(x_axis, 0.5, wait=True))
-    assert len(msgs) == 3
+def test_set_relative_without_wait(x_axis: SimMotor):
+    msgs = list(set_relative(x_axis, 0.5, wait=False))
+    assert len(msgs) == 2
     assert msgs[0] == Msg("locate", x_axis)
     assert msgs[1] == Msg("set", x_axis, 0.5, group=ANY)
-    assert msgs[2] == Msg("wait", group=msgs[1].kwargs["group"])
 
 
-def test_set_relative_with_group_and_wait(x_axis: SimMotor):
-    assert list(set_relative(x_axis, 0.5, group="foo", wait=True)) == [
+def test_set_relative_with_group_and_without_wait(x_axis: SimMotor):
+    assert list(set_relative(x_axis, 0.5, group="foo", wait=False)) == [
         Msg("locate", x_axis),
         Msg("set", x_axis, 0.5, group="foo"),
-        Msg("wait", group="foo"),
     ]
 
 

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -81,6 +81,13 @@ def y_axis() -> SimMotor:
 
 
 @pytest.fixture
+def z_axis() -> SimMotor:
+    with init_devices(mock=True):
+        z_axis = SimMotor()
+    return z_axis
+
+
+@pytest.fixture
 def path_provider(static_path_provider: PathProvider):
     # Prevents issue with leftover state from beamline tests
     with patch("dodal.plan_stubs.data_session.get_path_provider") as mock:

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -597,6 +597,12 @@ def test_make_stepped_list_when_given_wrong_number_of_params():
         _make_stepped_list(params=[1])
 
 
+def test_make_stepped_list_when_given_step_larger_than_range():
+    stepped_list, stepped_list_length = _make_stepped_list(params=[1, 2, 3])
+    assert stepped_list_length == 2
+    assert stepped_list == [1, 2]
+
+
 @pytest.mark.parametrize(
     "x_args, y_args, final_shape, final_length",
     (

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -245,7 +245,7 @@ def test_num_scan_with_two_axes_and_independent_trajectories(
 @pytest.mark.parametrize(
     "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
 )
-def test_num_scan_with_two_axes_and_independent_trajectories_when_snaking(
+def test_num_scan_with_two_axes_and_independent_trajectories_when_not_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -255,7 +255,7 @@ def test_num_scan_with_two_axes_and_independent_trajectories_when_snaking(
 ):
     run_engine(
         num_scan(
-            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=False
         )
     )
 
@@ -361,7 +361,7 @@ def test_num_rscan_with_two_axes_and_independent_trajectories(
 @pytest.mark.parametrize(
     "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
 )
-def test_num_rscan_with_two_axes_and_independent_trajectories_when_snaking(
+def test_num_rscan_with_two_axes_and_independent_trajectories_when_not_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -371,7 +371,7 @@ def test_num_rscan_with_two_axes_and_independent_trajectories_when_snaking(
 ):
     run_engine(
         num_rscan(
-            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=False
         )
     )
 
@@ -603,6 +603,11 @@ def test_make_stepped_list_when_given_step_larger_than_range():
     assert stepped_list == [1, 2]
 
 
+def test_make_stepped_list_fails_when_given_equal_start_and_stop_values():
+    with pytest.raises(ValueError):
+        _make_stepped_list(params=[1.1, 1.1, 0.25])
+
+
 @pytest.mark.parametrize(
     "x_args, y_args, final_shape, final_length",
     (
@@ -699,7 +704,7 @@ def test_step_scan_with_multiple_axes_and_independent_trajectories(
         [[-1, 1, 0.25], [1, -1, -0.5]],
     ),
 )
-def test_step_scan_with_multiple_axes_and_independent_trajectories_when_snaking(
+def test_step_scan_with_multiple_axes_and_independent_trajectories_when_not_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -709,7 +714,7 @@ def test_step_scan_with_multiple_axes_and_independent_trajectories_when_snaking(
 ):
     run_engine(
         step_scan(
-            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=False
         )
     )
 
@@ -780,7 +785,7 @@ def test_step_rscan_with_multiple_axes_and_independent_trajectories(
         [[-1, 1, 0.25], [1, -1, -0.5]],
     ),
 )
-def test_step_rscan_with_multiple_axes_and_independent_trajectories_when_snaking(
+def test_step_rscan_with_multiple_axes_and_independent_trajectories_when_not_snaking(
     run_engine: RunEngine,
     det: StandardDetector,
     x_axis: Motor,
@@ -790,7 +795,7 @@ def test_step_rscan_with_multiple_axes_and_independent_trajectories_when_snaking
 ):
     run_engine(
         step_rscan(
-            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=False
         )
     )
 

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from bluesky.protocols import Readable
@@ -13,11 +13,25 @@ from event_model.documents import (
     StreamResource,
 )
 from ophyd_async.core import (
+    AsyncReadable,
     StandardDetector,
 )
 from pydantic import ValidationError
 
-from dodal.plans.wrapped import count
+from dodal.devices.motors import Motor
+from dodal.plans.wrapped import (
+    _make_list_scan_args,
+    _make_num_scan_args,
+    _make_step_scan_args,
+    _make_stepped_list,
+    count,
+    list_rscan,
+    list_scan,
+    num_rscan,
+    num_scan,
+    step_rscan,
+    step_scan,
+)
 
 
 @pytest.fixture
@@ -26,7 +40,7 @@ def documents_from_num(
 ) -> dict[str, list[Document]]:
     docs: dict[str, list[Document]] = {}
     run_engine(
-        count({det}, num=request.param),
+        count([det], num=request.param),
         lambda name, doc: docs.setdefault(name, []).append(doc),
     )
     return docs
@@ -50,16 +64,16 @@ def test_count_delay_validation(det: StandardDetector, run_engine: RunEngine):
     }
     for delay, reason in args.items():
         with pytest.raises((ValidationError, AssertionError), match=reason):
-            run_engine(count({det}, num=3, delay=delay))
+            run_engine(count([det], num=3, delay=delay))
         print(delay)
 
 
 def test_count_detectors_validation(run_engine: RunEngine):
-    args: dict[str, set[Readable]] = {
+    args: dict[str, Sequence[Readable | AsyncReadable]] = {
         # No device to read
-        "Set should have at least 1 item after validation, not 0": set(),
+        "1 validation error for count": set(),
         # Not Readable
-        "Input should be an instance of Readable": set("foo"),  # type: ignore
+        "Input should be an instance of Sequence": set("foo"),  # type: ignore
     }
     for reason, dets in args.items():
         with pytest.raises(ValidationError, match=reason):
@@ -74,7 +88,7 @@ def test_count_num_validation(det: StandardDetector, run_engine: RunEngine):
     }
     for num, reason in args.items():
         with pytest.raises(ValidationError, match=reason):
-            run_engine(count({det}, num=num))
+            run_engine(count([det], num=num))
 
 
 @pytest.mark.parametrize(
@@ -157,3 +171,634 @@ def test_plan_produces_expected_datums(
     docs = documents_from_num.get("stream_datum")
     data_keys = [det.name, f"{det.name}-sum"]
     assert docs and len(docs) == len(data_keys) * length
+
+
+@pytest.mark.parametrize(
+    "x_list, y_list, final_shape, final_length",
+    (
+        [[0.0, 1.1, 3], [2.2, 3.3], [3], 6],
+        [[0.0, 1.1, 2], [2.2, 3.3, 3], [2, 3], 8],
+    ),
+)
+def test_make_num_scan_args(
+    x_axis: Motor,
+    y_axis: Motor,
+    x_list: list[float | int],
+    y_list: list[float | int],
+    final_shape: list[int],
+    final_length: int,
+):
+    args, shape = _make_num_scan_args({x_axis: x_list, y_axis: y_list})
+    assert shape == final_shape
+    assert len(args) == final_length
+    assert args[0] == x_axis
+
+
+@pytest.mark.parametrize("x_args", ([0.0, 2.2, 5], [1.1, -1.1, 3]))
+def test_num_scan_with_one_axis(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+):
+    run_engine(num_scan(detectors=[det], params={x_axis: x_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2]], [[0, 1.1, 5], [2.2, 3.3]])
+)
+def test_num_scan_with_two_axes_and_concurrent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    run_engine(
+        num_scan(
+            detectors=[det],
+            params={x_axis: x_args, y_axis: y_args},
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
+)
+def test_num_scan_with_two_axes_and_independent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    run_engine(
+        num_scan(
+            detectors=[det],
+            params={x_axis: x_args, y_axis: y_args},
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
+)
+def test_num_scan_with_two_axes_and_independent_trajectories_when_snaking(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    run_engine(
+        num_scan(
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+        )
+    )
+
+
+def test_num_scan_fails_when_given_wrong_number_of_params(
+    run_engine: RunEngine, det: StandardDetector, x_axis: Motor, y_axis: Motor
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            num_scan(detectors=[det], params={x_axis: [0, 1.1, 2], y_axis: [1.1]})
+        )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args,", ([[-1, 1, 0], [2, 0]], [[-1, 1, 3.5], [-1, 1]])
+)
+def test_num_scan_fails_when_given_bad_info(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            num_scan(
+                detectors=[det],
+                params={x_axis: x_args, y_axis: y_args},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
+)
+def test_num_scan_fails_when_asked_to_snake_slow_axis(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            num_scan(
+                detectors=[det],
+                params={x_axis: x_args, y_axis: y_args},
+                snake_axes=[x_axis],
+            )
+        )
+
+
+@pytest.mark.parametrize("x_args", ([0.0, 2.2, 5], [1.1, -1.1, 3]))
+def test_num_rscan_with_one_axis(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+):
+    run_engine(num_rscan(detectors=[det], params={x_axis: x_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2]], [[0, 1.1, 5], [2.2, 3.3]])
+)
+def test_num_rscan_with_two_axes_and_concurrent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    run_engine(
+        num_rscan(
+            detectors=[det],
+            params={x_axis: x_args, y_axis: y_args},
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
+)
+def test_num_rscan_with_two_axes_and_independent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    run_engine(
+        num_rscan(
+            detectors=[det],
+            params={x_axis: x_args, y_axis: y_args},
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
+)
+def test_num_rscan_with_two_axes_and_independent_trajectories_when_snaking(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    run_engine(
+        num_rscan(
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+        )
+    )
+
+
+def test_num_rscan_fails_when_given_wrong_number_of_params(
+    run_engine: RunEngine, det: StandardDetector, x_axis: Motor, y_axis: Motor
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            num_rscan(detectors=[det], params={x_axis: [0, 1.1, 2], y_axis: [1.1]})
+        )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args,", ([[-1, 1, 0], [2, 0]], [[-1, 1, 3.5], [-1, 1]])
+)
+def test_num_rscan_fails_when_given_bad_info(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            num_rscan(
+                detectors=[det],
+                params={x_axis: x_args, y_axis: y_args},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[-1.1, 1.1, 5], [2.2, -2.2, 3]], [[0, 1.1, 5], [2.2, 3.3, 5]])
+)
+def test_num_rscan_fails_when_asked_to_snake_slow_axis(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[float | int],
+    y_axis: Motor,
+    y_args: list[float | int],
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            num_rscan(
+                detectors=[det],
+                params={x_axis: x_args, y_axis: y_args},
+                snake_axes=[x_axis],
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args, grid, final_shape, final_length",
+    ([[0, 1, 2], [3, 4, 5], False, [3], 4], [[0, 1, 2], [3, 4, 5, 6], True, [3, 4], 4]),
+)
+def test_make_list_scan_args(
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+    grid: bool,
+    final_shape: list,
+    final_length: int,
+):
+    args, shape = _make_list_scan_args(
+        params={x_axis: x_args, y_axis: y_args}, grid=grid
+    )
+    assert len(args) == final_length
+    assert shape == final_shape
+
+
+@pytest.mark.parametrize("x_list", ([0, 1, 2, 3], [1.1, 2.2, 3.3]))
+def test_list_scan(
+    run_engine: RunEngine, det: StandardDetector, x_axis: Motor, x_list: Any
+):
+    run_engine(list_scan(detectors=[det], params={x_axis: x_list}))
+
+
+@pytest.mark.parametrize(
+    "x_list, y_list",
+    (
+        [[3, 2, 1], [1, 2, 3]],
+        [[-1.1, -2.2, -3.3, -4.4, -5.5], [1.1, 2.2, 3.3, 4.4, 5.5]],
+    ),
+)
+def test_list_scan_with_two_axes_and_concurrent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_list: list,
+    y_axis: Motor,
+    y_list: list,
+):
+    run_engine(list_scan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+
+
+def test_list_scan_with_concurrent_trajectories_fails_with_differnt_list_lengths(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    y_axis: Motor,
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            list_scan(
+                detectors=[det],
+                params={x_axis: [1, 2, 3, 4, 5], y_axis: [1, 2, 3, 4]},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "x_list, y_list",
+    (
+        [[3, 2, 1], [1, 2, 3, 4]],
+        [[-1.1, -2.2, -3.3, -4.4, -5.5], [1.1, 2.2, 3.3, 4.4, 5.5]],
+    ),
+)
+def test_list_scan_with_two_axes_and_independent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_list: list,
+    y_axis: Motor,
+    y_list: list,
+):
+    run_engine(
+        list_scan(detectors=[det], params={x_axis: x_list, y_axis: y_list}, grid=True)
+    )
+
+
+@pytest.mark.parametrize("x_list", ([0, 1, 2, 3], [1.1, 2.2, 3.3]))
+def test_list_rscan(
+    run_engine: RunEngine, det: StandardDetector, x_axis: Motor, x_list: Any
+):
+    run_engine(list_rscan(detectors=[det], params={x_axis: x_list}))
+
+
+@pytest.mark.parametrize(
+    "x_list, y_list",
+    (
+        [[3, 2, 1], [1, 2, 3]],
+        [[-1.1, -2.2, -3.3, -4.4, -5.5], [1.1, 2.2, 3.3, 4.4, 5.5]],
+    ),
+)
+def test_list_rscan_with_two_axes_and_concurrent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_list: list,
+    y_axis: Motor,
+    y_list: list,
+):
+    run_engine(list_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+
+
+def test_list_rscan_with_concurrent_trajectories_fails_with_differnt_list_lengths(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    y_axis: Motor,
+):
+    with pytest.raises(ValueError):
+        run_engine(
+            list_rscan(
+                detectors=[det],
+                params={x_axis: [1, 2, 3, 4, 5], y_axis: [1, 2, 3, 4]},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "x_list, y_list",
+    (
+        [[3, 2, 1], [1, 2, 3, 4]],
+        [[-1.1, -2.2, -3.3, -4.4, -5.5], [1.1, 2.2, 3.3, 4.4, 5.5]],
+    ),
+)
+def test_list_rscan_with_two_axes_and_independent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_list: list,
+    y_axis: Motor,
+    y_list: list,
+):
+    run_engine(
+        list_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list}, grid=True)
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        [-1, 1, 0.1],
+        [-2, 2, 0.2],
+        [1, -1, -0.1],
+        [2, -2, -0.2],
+        [1, -1, 0.1],
+        [2, -2, 0.2],
+    ),
+)
+def test_make_stepped_list_when_given_three_params(params: list[Any]):
+    stepped_list, stepped_list_length = _make_stepped_list(params=params)
+    assert stepped_list_length == 21
+    assert stepped_list[0] / stepped_list[-1] == -1
+    assert stepped_list[10] == 0
+
+
+@pytest.mark.parametrize("params", ([-1, 0.1], [-2, 0.2], [1, -0.1], [2, -0.2]))
+def test_make_stepped_list_when_given_two_params(params: list[Any]):
+    stepped_list, stepped_list_length = _make_stepped_list(params=params, num=21)
+    assert stepped_list_length == 21
+    assert stepped_list[0] / stepped_list[-1] == -1
+    assert stepped_list[10] == 0
+
+
+def test_make_stepped_list_when_given_wrong_number_of_params():
+    with pytest.raises(ValueError):
+        _make_stepped_list(params=[1])
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args, final_shape, final_length",
+    (
+        [[0, 1, 0.25], [0, 0.1], [5], 4],
+        [[0, 1, 0.25], [0, 1, 0.2], [5, 6], 4],
+        [[0, -1, -0.25], [0, -0.1], [5], 4],
+        [[0, -1, -0.25], [0, -1, -0.2], [5, 6], 4],
+    ),
+)
+def test_make_step_scan_args(
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+    final_shape: list,
+    final_length: int,
+):
+    args, shape = _make_step_scan_args(params={x_axis: x_args, y_axis: y_args})
+    assert shape == final_shape
+    assert len(args) == final_length
+    assert args[0] == x_axis
+    assert args[2] == y_axis
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args, z_args",
+    (
+        [[0, 1], [0, 0.2], [0, 1, 0.5]],
+        [[0, 1, 0.25], [0, 1, 0.2, 1], [0, 1, 0.5]],
+        [[0, 1, 0.25], [0, 0.2], [0, 1, 0.5]],
+        [[0, 1, 0.25], [0, 1, 0.2], [0, 0.5]],
+    ),
+)
+def test_make_step_scan_args_fails_when_given_incorrect_number_of_parameters(
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+    z_axis: Motor,
+    z_args: list,
+):
+    with pytest.raises(ValueError):
+        _make_step_scan_args(params={x_axis: x_args, y_axis: y_args, z_axis: z_args})
+
+
+@pytest.mark.parametrize("x_args", ([0, 1, 0.1], [-1, 1, 0.1], [0, 10, 1]))
+def test_step_scan(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[Any],
+):
+    run_engine(step_scan(detectors=[det], params={x_axis: x_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args",
+    ([[0, 1, 0.25], [0, 0.1]], [[-1, 1, 0.25], [-1, 0.1]], [[0, 10, 2.5], [0, 1]]),
+)
+def test_step_scan_with_multiple_axes_and_concurrent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    run_engine(step_scan(detectors=[det], params={x_axis: x_args, y_axis: y_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args",
+    (
+        [[0, 1, 0.25], [0, 2, 0.5]],
+        [[-1, 1, 0.25], [1, -1, -0.5]],
+        [[0, 10, 2.5], [0, -10, -2.5]],
+    ),
+)
+def test_step_scan_with_multiple_axes_and_independent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    run_engine(step_scan(detectors=[det], params={x_axis: x_args, y_axis: y_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args",
+    (
+        [[0, 1, 0.25], [0, 2, 0.5]],
+        [[-1, 1, 0.25], [1, -1, -0.5]],
+    ),
+)
+def test_step_scan_with_multiple_axes_and_independent_trajectories_when_snaking(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    run_engine(
+        step_scan(
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[0, 1, 0.1], [0, 1, 0.1, 1]], [[0, 1, 0.1], [0]])
+)
+def test_step_scan_fails_when_given_incorrect_number_of_params(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    with pytest.raises(ValueError):
+        run_engine(step_scan(detectors=[det], params={x_axis: x_args, y_axis: y_args}))
+
+
+@pytest.mark.parametrize("x_args", ([0, 1, 0.1], [-1, 1, 0.1], [0, 10, 1]))
+def test_step_rscan(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list[Any],
+):
+    run_engine(step_rscan(detectors=[det], params={x_axis: x_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args",
+    ([[0, 1, 0.25], [0, 0.1]], [[-1, 1, 0.25], [-1, 0.1]], [[0, 10, 2.5], [0, 1]]),
+)
+def test_step_rscan_with_multiple_axes_and_concurrent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    run_engine(step_rscan(detectors=[det], params={x_axis: x_args, y_axis: y_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args",
+    (
+        [[0, 1, 0.25], [0, 2, 0.5]],
+        [[-1, 1, 0.25], [1, -1, -0.5]],
+        [[0, 10, 2.5], [0, -10, -2.5]],
+    ),
+)
+def test_step_rscan_with_multiple_axes_and_independent_trajectories(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    run_engine(step_rscan(detectors=[det], params={x_axis: x_args, y_axis: y_args}))
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args",
+    (
+        [[0, 1, 0.25], [0, 2, 0.5]],
+        [[-1, 1, 0.25], [1, -1, -0.5]],
+    ),
+)
+def test_step_rscan_with_multiple_axes_and_independent_trajectories_when_snaking(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    run_engine(
+        step_rscan(
+            detectors=[det], params={x_axis: x_args, y_axis: y_args}, snake_axes=True
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "x_args, y_args", ([[0, 1, 0.1], [0, 1, 0.1, 1]], [[0, 1, 0.1], [0]])
+)
+def test_step_rscan_fails_when_given_incorrect_number_of_params(
+    run_engine: RunEngine,
+    det: StandardDetector,
+    x_axis: Motor,
+    x_args: list,
+    y_axis: Motor,
+    y_args: list,
+):
+    with pytest.raises(ValueError):
+        run_engine(step_rscan(detectors=[det], params={x_axis: x_args, y_axis: y_args}))

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -565,7 +565,7 @@ def test_make_list_scan_args(
     final_length: int,
 ):
     args, shape = _make_list_scan_args(
-        params={x_axis: x_list, y_axis: y_list}, grid=grid
+        params=[(x_axis, x_list), (y_axis, y_list)], grid=grid
     )
     assert len(args) == final_length
     assert shape == final_shape
@@ -576,7 +576,7 @@ def test_make_list_scan_args_fails_when_lists_are_different_lengths(
     y_axis: Motor,
 ):
     with pytest.raises(ValueError):
-        _make_list_scan_args(params={x_axis: [0, 1, 2], y_axis: [0, 1, 2, 3]})
+        _make_list_scan_args(params=[(x_axis, [0, 1, 2]), (y_axis, [0, 1, 2, 3])])
 
 
 @pytest.mark.parametrize("x_list", ([0, 1, 2, 3], [1.1, 2.2, 3.3]))
@@ -590,7 +590,7 @@ def test_list_scan(
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
     num = int(len(x_list))
 
-    run_engine(list_scan(detectors=[det], params={x_axis: x_list}))
+    run_engine(list_scan(detectors=[det], params=[(x_axis, x_list)]))
 
     assert_emitted(
         docs,
@@ -622,7 +622,7 @@ def test_list_scan_with_two_axes(
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
     num = int(len(x_list))
 
-    run_engine(list_scan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+    run_engine(list_scan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)]))
 
     assert_emitted(
         docs,
@@ -645,7 +645,7 @@ def test_list_scan_fails_with_differnt_list_lengths(
         run_engine(
             list_scan(
                 detectors=[det],
-                params={x_axis: [1, 2, 3, 4, 5], y_axis: [1, 2, 3, 4]},
+                params=[(x_axis, [1, 2, 3, 4, 5]), (y_axis, [1, 2, 3, 4])],
             )
         )
 
@@ -669,7 +669,9 @@ def test_list_grid_scan(
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
     num = int(len(x_list) * len(y_list))
 
-    run_engine(list_grid_scan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+    run_engine(
+        list_grid_scan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)])
+    )
 
     assert_emitted(
         docs,
@@ -690,7 +692,7 @@ def test_list_rscan(
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
     num = int(len(x_list))
 
-    run_engine(list_rscan(detectors=[det], params={x_axis: x_list}))
+    run_engine(list_rscan(detectors=[det], params=[(x_axis, x_list)]))
 
     assert_emitted(
         docs,
@@ -722,7 +724,7 @@ def test_list_rscan_with_two_axes(
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
     num = int(len(x_list))
 
-    run_engine(list_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+    run_engine(list_rscan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)]))
 
     assert_emitted(
         docs,
@@ -745,7 +747,7 @@ def test_list_rscan_fails_with_differnt_list_lengths(
         run_engine(
             list_rscan(
                 detectors=[det],
-                params={x_axis: [1, 2, 3, 4, 5], y_axis: [1, 2, 3, 4]},
+                params=[(x_axis, [1, 2, 3, 4, 5]), (y_axis, [1, 2, 3, 4])],
             )
         )
 
@@ -770,7 +772,7 @@ def test_list_grid_rscan(
     num = int(len(x_list) * len(y_list))
 
     run_engine(
-        list_grid_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list})
+        list_grid_rscan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)])
     )
 
     assert_emitted(
@@ -845,7 +847,7 @@ def test_make_step_scan_args(
     final_length: int,
 ):
     args, shape = _make_step_scan_args(
-        params={x_axis: x_list, y_axis: y_list}, grid=grid
+        params=[(x_axis, x_list), (y_axis, y_list)], grid=grid
     )
     assert shape == final_shape
     assert len(args) == final_length
@@ -873,7 +875,7 @@ def test_make_step_scan_args_fails_when_given_incorrect_number_of_parameters(
 ):
     with pytest.raises(ValueError):
         _make_step_scan_args(
-            params={x_axis: x_list, y_axis: y_list, z_axis: z_list}, grid=grid
+            params=[(x_axis, x_list), (y_axis, y_list), (z_axis, z_list)], grid=grid
         )
 
 
@@ -890,7 +892,7 @@ def test_step_scan(
     docs = defaultdict(list)
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
-    run_engine(step_scan(detectors=[det], params={x_axis: x_list}))
+    run_engine(step_scan(detectors=[det], params=[(x_axis, x_list)]))
 
     assert_emitted(
         docs,
@@ -923,7 +925,7 @@ def test_step_scan_with_multiple_axes(
     docs = defaultdict(list)
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
-    run_engine(step_scan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+    run_engine(step_scan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)]))
 
     assert_emitted(
         docs,
@@ -956,7 +958,9 @@ def test_step_grid_scan(
     docs = defaultdict(list)
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
-    run_engine(step_grid_scan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+    run_engine(
+        step_grid_scan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)])
+    )
 
     assert_emitted(
         docs,
@@ -990,7 +994,9 @@ def test_step_grid_scan_when_not_snaking(
 
     run_engine(
         step_grid_scan(
-            detectors=[det], params={x_axis: x_list, y_axis: y_list}, snake_axes=False
+            detectors=[det],
+            params=[(x_axis, x_list), (y_axis, y_list)],
+            snake_axes=False,
         )
     )
 
@@ -1018,7 +1024,7 @@ def test_step_grid_scan_fails_when_given_incorrect_number_of_params(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            step_grid_scan(detectors=[det], params={x_axis: x_list, y_axis: y_list})
+            step_grid_scan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)])
         )
 
 
@@ -1035,7 +1041,7 @@ def test_step_rscan(
     docs = defaultdict(list)
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
-    run_engine(step_rscan(detectors=[det], params={x_axis: x_list}))
+    run_engine(step_rscan(detectors=[det], params=[(x_axis, x_list)]))
 
     assert_emitted(
         docs,
@@ -1068,7 +1074,7 @@ def test_step_rscan_with_multiple_axes(
     docs = defaultdict(list)
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
-    run_engine(step_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list}))
+    run_engine(step_rscan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)]))
 
     assert_emitted(
         docs,
@@ -1102,7 +1108,7 @@ def test_step_grid_rscan(
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
     run_engine(
-        step_grid_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list})
+        step_grid_rscan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)])
     )
 
     assert_emitted(
@@ -1137,7 +1143,9 @@ def test_step_grid_rscan_when_not_snaking(
 
     run_engine(
         step_grid_rscan(
-            detectors=[det], params={x_axis: x_list, y_axis: y_list}, snake_axes=False
+            detectors=[det],
+            params=[(x_axis, x_list), (y_axis, y_list)],
+            snake_axes=False,
         )
     )
 
@@ -1165,5 +1173,7 @@ def test_step_grid_rscan_fails_when_given_incorrect_number_of_params(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            step_grid_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list})
+            step_grid_rscan(
+                detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)]
+            )
         )

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -197,7 +197,7 @@ def test_make_num_scan_args(
     final_shape: list[int],
     final_length: int,
 ):
-    args, shape = _make_num_scan_args({x_axis: x_list, y_axis: y_list}, num=num)
+    args, shape = _make_num_scan_args([(x_axis, x_list), (y_axis, y_list)], num=num)
     assert shape == final_shape
     assert len(args) == final_length
     assert args[0] == x_axis
@@ -214,7 +214,7 @@ def test_num_scan_with_one_axis(
     docs = defaultdict(list)
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
-    run_engine(num_scan(detectors=[det], params={x_axis: x_list}, num=num))
+    run_engine(num_scan(detectors=[det], params=[(x_axis, x_list)], num=num))
 
     assert_emitted(
         docs,
@@ -245,7 +245,7 @@ def test_num_scan_with_two_axes(
     run_engine(
         num_scan(
             detectors=[det],
-            params={x_axis: x_list, y_axis: y_list},
+            params=[(x_axis, x_list), (y_axis, y_list)],
             num=num,
         )
     )
@@ -265,7 +265,7 @@ def test_num_scan_fails_when_given_wrong_number_of_params(
     run_engine: RunEngine, det: StandardDetector, x_axis: Motor, y_axis: Motor
 ):
     with pytest.raises(ValueError):
-        run_engine(num_scan(detectors=[det], params={x_axis: [-1, 1, 5]}, num=5))
+        run_engine(num_scan(detectors=[det], params=[(x_axis, [-1, 1, 5])], num=5))
 
 
 @pytest.mark.parametrize(
@@ -283,7 +283,7 @@ def test_num_scan_fails_when_given_bad_info(
         run_engine(
             num_scan(
                 detectors=[det],
-                params={x_axis: x_list, y_axis: y_list},
+                params=[(x_axis, x_list), (y_axis, y_list)],
             )
         )
 
@@ -306,7 +306,7 @@ def test_num_grid_scan(
     run_engine(
         num_grid_scan(
             detectors=[det],
-            params={x_axis: x_list, y_axis: y_list},
+            params=[(x_axis, x_list), (y_axis, y_list)],
         )
     )
 
@@ -338,7 +338,9 @@ def test_num_grid_scan_when_not_snaking(
 
     run_engine(
         num_grid_scan(
-            detectors=[det], params={x_axis: x_list, y_axis: y_list}, snake_axes=False
+            detectors=[det],
+            params=[(x_axis, x_list), (y_axis, y_list)],
+            snake_axes=False,
         )
     )
 
@@ -358,7 +360,9 @@ def test_num_grid_scan_fails_when_given_wrong_number_of_params(
 ):
     with pytest.raises(ValueError):
         run_engine(
-            num_grid_scan(detectors=[det], params={x_axis: [0, 1.1, 2], y_axis: [1.1]})
+            num_grid_scan(
+                detectors=[det], params=[(x_axis, [0, 1.1, 2]), (y_axis, [1.1])]
+            )
         )
 
 
@@ -377,7 +381,7 @@ def test_num_scan_fails_when_asked_to_snake_slow_axis(
         run_engine(
             num_grid_scan(
                 detectors=[det],
-                params={x_axis: x_list, y_axis: y_list},
+                params=[(x_axis, x_list), (y_axis, y_list)],
                 snake_axes=[x_axis],
             )
         )
@@ -394,7 +398,7 @@ def test_num_rscan(
     docs = defaultdict(list)
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
-    run_engine(num_rscan(detectors=[det], params={x_axis: x_list}, num=num))
+    run_engine(num_rscan(detectors=[det], params=[(x_axis, x_list)], num=num))
 
     assert_emitted(
         docs,
@@ -423,7 +427,7 @@ def test_num_rscan_with_two_axes(
     run_engine.subscribe(lambda name, doc: docs[name].append(doc))
 
     run_engine(
-        num_rscan(detectors=[det], params={x_axis: x_list, y_axis: y_list}, num=num)
+        num_rscan(detectors=[det], params=[(x_axis, x_list), (y_axis, y_list)], num=num)
     )
 
     assert_emitted(
@@ -453,7 +457,7 @@ def test_num_rscan_fails_when_given_bad_info(
         run_engine(
             num_rscan(
                 detectors=[det],
-                params={x_axis: x_list, y_axis: y_list},
+                params=[(x_axis, x_list), (y_axis, y_list)],
                 num=num,
             )
         )
@@ -477,7 +481,7 @@ def test_num_grid_rscan(
     run_engine(
         num_grid_rscan(
             detectors=[det],
-            params={x_axis: x_list, y_axis: y_list},
+            params=[(x_axis, x_list), (y_axis, y_list)],
         )
     )
 
@@ -509,7 +513,9 @@ def test_num_grid_rscan_when_not_snaking(
 
     run_engine(
         num_grid_rscan(
-            detectors=[det], params={x_axis: x_list, y_axis: y_list}, snake_axes=False
+            detectors=[det],
+            params=[(x_axis, x_list), (y_axis, y_list)],
+            snake_axes=False,
         )
     )
 
@@ -539,7 +545,7 @@ def test_num_grid_rscan_fails_when_asked_to_snake_slow_axis(
         run_engine(
             num_grid_rscan(
                 detectors=[det],
-                params={x_axis: x_list, y_axis: y_list},
+                params=[(x_axis, x_list), (y_axis, y_list)],
                 snake_axes=[x_axis],
             )
         )

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -269,7 +269,7 @@ def test_num_scan_fails_when_given_wrong_number_of_params(
 
 
 @pytest.mark.parametrize(
-    "x_list, y_list,", ([[-1, 1, 0], [2, 0]], [[-1, 1, 3.5], [-1, 1]])
+    "x_list, y_list, num", ([[-1, 1], [2, 0], 0], [[-1, 1], [-1, 1], 3.5])
 )
 def test_num_scan_fails_when_given_bad_info(
     run_engine: RunEngine,
@@ -278,12 +278,14 @@ def test_num_scan_fails_when_given_bad_info(
     x_list: list[float | int],
     y_axis: Motor,
     y_list: list[float | int],
+    num: int,
 ):
     with pytest.raises(ValueError):
         run_engine(
             num_scan(
                 detectors=[det],
                 params=[(x_axis, x_list), (y_axis, y_list)],
+                num=num,
             )
         )
 

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -827,6 +827,14 @@ def test_make_stepped_list_step(start: float, stop: float, step: float):
     assert stepped_list[10] == 0
 
 
+def test_make_stepped_list_step_with_large_step():
+    stepped_list = _make_stepped_list_step(0, 1, 5)
+    stepped_list_length = len(stepped_list)
+    assert stepped_list_length == 2
+    assert stepped_list[0] == 0
+    assert stepped_list[-1] == 1
+
+
 @pytest.mark.parametrize("start, step", ([-1, 0.1], [-2, 0.2], [1, -0.1], [2, -0.2]))
 def test_make_stepped_list_num(start: float, step: float):
     stepped_list = _make_stepped_list_num(start, step, num=21)

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -555,7 +555,7 @@ def test_num_grid_rscan_fails_when_asked_to_snake_slow_axis(
 
 @pytest.mark.parametrize(
     "x_list, y_list, grid, final_shape, final_length",
-    ([[0, 1, 2], [3, 4, 5], None, [3], 4], [[0, 1, 2], [3, 4, 5, 6], True, [3, 4], 4]),
+    ([[0, 1, 2], [3, 4, 5], False, [3], 4], [[0, 1, 2], [3, 4, 5, 6], True, [3, 4], 4]),
 )
 def test_make_list_scan_args(
     x_axis: Motor,
@@ -578,7 +578,9 @@ def test_make_list_scan_args_fails_when_lists_are_different_lengths(
     y_axis: Motor,
 ):
     with pytest.raises(ValueError):
-        _make_list_scan_args(params=[(x_axis, [0, 1, 2]), (y_axis, [0, 1, 2, 3])])
+        _make_list_scan_args(
+            params=[(x_axis, [0, 1, 2]), (y_axis, [0, 1, 2, 3])], grid=False
+        )
 
 
 @pytest.mark.parametrize("x_list", ([0, 1, 2, 3], [1.1, 2.2, 3.3]))

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -271,7 +271,8 @@ def test_num_scan_fails_when_given_wrong_number_of_params(
 
 
 @pytest.mark.parametrize(
-    "x_list, y_list, num", ([[-1, 1], [2, 0], 0], [[-1, 1], [-1, 1], 3.5])
+    "x_list, y_list, num",
+    ([[-1, 1], [2, 0], 0], [[-1, 1], [-1, 1], 3.5], [[-1, 1], [-1, 1], -2]),
 )
 def test_num_scan_fails_when_given_bad_info(
     run_engine: RunEngine,

--- a/tests/plans/test_wrapped.py
+++ b/tests/plans/test_wrapped.py
@@ -25,7 +25,9 @@ from dodal.plans.wrapped import (
     _make_list_scan_args,
     _make_num_scan_args,
     _make_step_scan_args,
-    _make_stepped_list,
+    _make_stepped_list_num,
+    _make_stepped_list_step,
+    _round_list_elements,
     count,
     list_grid_rscan,
     list_grid_scan,
@@ -791,7 +793,23 @@ def test_list_grid_rscan(
 
 
 @pytest.mark.parametrize(
-    "params",
+    "stepped_list, params, rounded_element",
+    (
+        [[0.1234, 1.1234, 2.1234], [0.123, 2.123, 1], 0.123],
+        [[0.1234, 1.1234, 2.1234], [0.12, 2.12, 1], 0.12],
+        [[0.1234, 1.1234, 2.1234], [0.1, 2.1, 1], 0.1],
+        [[0.1234, 1.1234, 2.1234], [0, 2, 1], 0],
+    ),
+)
+def test_round_list_elements(
+    stepped_list: list[float], params: list[float], rounded_element: float
+):
+    rounded_list = _round_list_elements(stepped_list, params)
+    assert rounded_list[0] == rounded_element
+
+
+@pytest.mark.parametrize(
+    "start, stop, step",
     (
         [-1, 1, 0.1],
         [-2, 2, 0.2],
@@ -801,52 +819,43 @@ def test_list_grid_rscan(
         [2, -2, 0.2],
     ),
 )
-def test_make_stepped_list_when_given_three_params(params: list):
-    stepped_list, stepped_list_length = _make_stepped_list(params=params)
+def test_make_stepped_list_step(start: float, stop: float, step: float):
+    stepped_list = _make_stepped_list_step(start, stop, step)
+    stepped_list_length = len(stepped_list)
     assert stepped_list_length == 21
     assert stepped_list[0] / stepped_list[-1] == -1
     assert stepped_list[10] == 0
 
 
-@pytest.mark.parametrize("params", ([-1, 0.1], [-2, 0.2], [1, -0.1], [2, -0.2]))
-def test_make_stepped_list_when_given_two_params(params: list):
-    stepped_list, stepped_list_length = _make_stepped_list(params=params, num=21)
+@pytest.mark.parametrize("start, step", ([-1, 0.1], [-2, 0.2], [1, -0.1], [2, -0.2]))
+def test_make_stepped_list_num(start: float, step: float):
+    stepped_list = _make_stepped_list_num(start, step, num=21)
+    stepped_list_length = len(stepped_list)
     assert stepped_list_length == 21
     assert stepped_list[0] / stepped_list[-1] == -1
     assert stepped_list[10] == 0
-
-
-def test_make_stepped_list_when_given_wrong_number_of_params():
-    with pytest.raises(ValueError):
-        _make_stepped_list(params=[1])
-
-
-def test_make_stepped_list_when_given_step_larger_than_range():
-    stepped_list, stepped_list_length = _make_stepped_list(params=[1, 2, 3])
-    assert stepped_list_length == 2
-    assert stepped_list == [1, 2]
 
 
 def test_make_stepped_list_fails_when_given_equal_start_and_stop_values():
     with pytest.raises(ValueError):
-        _make_stepped_list(params=[1.1, 1.1, 0.25])
+        _make_stepped_list_step(start=1.1, stop=1.1, step=0.25)
 
 
 @pytest.mark.parametrize(
     "x_list, y_list, grid, final_shape, final_length",
     (
-        [[0, 1, 0.25], [0, 0.1], None, [5], 4],
+        [[0, 1, 0.25], [0, 0.1], False, [5], 4],
         [[0, 1, 0.25], [0, 1, 0.2], True, [5, 6], 4],
-        [[0, -1, -0.25], [0, -0.1], None, [5], 4],
+        [[0, -1, -0.25], [0, -0.1], False, [5], 4],
         [[0, -1, -0.25], [0, -1, -0.2], True, [5, 6], 4],
     ),
 )
 def test_make_step_scan_args(
     x_axis: Motor,
-    x_list: list,
+    x_list: list[float],
     y_axis: Motor,
-    y_list: list,
-    grid: bool | None,
+    y_list: list[float],
+    grid: bool,
     final_shape: list,
     final_length: int,
 ):
@@ -862,8 +871,8 @@ def test_make_step_scan_args(
 @pytest.mark.parametrize(
     "x_list, y_list, z_list, grid",
     (
-        [[0, 1], [0, 0.2], [0, 0.5], None],
-        [[0, 1, 0.25], [0, 0.2], [0, 1, 0.2, 0.5], None],
+        [[0, 1], [0, 0.2], [0, 0.5], False],
+        [[0, 1, 0.25], [0, 0.2], [0, 1, 0.2, 0.5], False],
         [[0, 1, 0.25], [0, 0.2], [0, 1, 0.5], True],
         [[0, 1, 0.25], [0, 1, 0.2], [0, 0.5], True],
     ),
@@ -875,7 +884,7 @@ def test_make_step_scan_args_fails_when_given_incorrect_number_of_parameters(
     y_list: list,
     z_axis: Motor,
     z_list: list,
-    grid: bool | None,
+    grid: bool,
 ):
     with pytest.raises(ValueError):
         _make_step_scan_args(


### PR DESCRIPTION
Closes #1498, and as an alternative to [#1702](https://github.com/DiamondLightSource/dodal/pull/1702). Scan syntax is more similar to both GDA and bluesky.

Wraps bluesky plans (`scan`, `rel_scan`, `grid_scan`, `rel_grid_scan`) and plan stubs (`rd`, `stop`) for use in blueapi. Intended as a replacement for gda-style start stop step scans until spec_scan is stable and supports start stop step rather than start stop num. Start stop step scans are achieved through generating a list for use with `list_scan`, `rel_list_scan`, ...

Concurrent trajectory scans (`scan`, etc.) and independent trajectory scans (`grid_scan`, etc.) are both accessed through the same plan and differentiated by number of parameters given for each movable - similar to current GDA-style scans. 

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes