### PR TITLE
Add beamstop motors for I22

### DIFF
--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -19,7 +19,7 @@ from dodal.devices.i22.dcm import DCM
 from dodal.devices.i22.fswitch import FSwitch
 from dodal.devices.i22.nxsas import NXSasMetadataHolder, NXSasOAV, NXSasPilatus
 from dodal.devices.linkam3 import Linkam3
-from dodal.devices.motors import XYPitchStage
+from dodal.devices.motors import XYPitchStage, XYRollStage, XYStage
 from dodal.devices.slits import Slits
 from dodal.devices.synchrotron import Synchrotron
 from dodal.devices.tetramm import TetrammDetector
@@ -274,3 +274,18 @@ def ppump() -> WatsonMarlow323Pump:
 @device_factory()
 def base() -> XYPitchStage:
     return XYPitchStage(f"{PREFIX.beamline_prefix}-MO-STABL-01:")
+
+
+@device_factory()
+def bs1() -> XYStage:
+    return XYStage(f"{PREFIX.beamline_prefix}-MO-SAXSP-01:BS1:")
+
+
+@device_factory()
+def bs2() -> XYStage:
+    return XYStage(f"{PREFIX.beamline_prefix}-MO-SAXSP-01:BS2:")
+
+
+@device_factory()
+def bs3() -> XYRollStage:
+    return XYRollStage(f"{PREFIX.beamline_prefix}-MO-SAXSP-01:BS3:")

--- a/src/dodal/devices/motors.py
+++ b/src/dodal/devices/motors.py
@@ -122,6 +122,20 @@ class XYPitchStage(XYStage):
         super().__init__(prefix, name, x_infix, y_infix)
 
 
+class XYRollStage(XYStage):
+    def __init__(
+        self,
+        prefix: str,
+        x_infix: str = _X,
+        y_infix: str = _Y,
+        roll_infix: str = "ROLL",
+        name: str = "",
+    ) -> None:
+        with self.add_children_as_readables():
+            self.roll = Motor(prefix + roll_infix)
+        super().__init__(prefix, name, x_infix, y_infix)
+
+
 class XYZPitchYawStage(XYZStage):
     def __init__(
         self,


### PR DESCRIPTION
Needed for #1711, which requires control of beamstop positions.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
