### PR TITLE
Get UndulatorDCM config from config server

### DIFF
--- a/src/dodal/devices/i03/undulator_dcm.py
+++ b/src/dodal/devices/i03/undulator_dcm.py
@@ -1,6 +1,8 @@
 import asyncio
 
 from bluesky.protocols import Movable
+from daq_config_server.client import ConfigServer
+from daq_config_server.converters.models import GenericLookupTable
 from ophyd_async.core import AsyncStatus, Reference, StandardReadable
 
 from dodal.common.beamlines.beamline_parameters import get_beamline_parameters
@@ -39,12 +41,16 @@ class UndulatorDCM(StandardReadable, Movable[float]):
         self.undulator_ref = Reference(undulator)
         self.dcm_ref = Reference(dcm)
 
+        config_server = ConfigServer(url="https://daq-config.diamond.ac.uk")
+
         # These attributes are just used by hyperion for lookup purposes
-        self.pitch_energy_table_path = (
-            daq_configuration_path + "/lookup/BeamLineEnergy_DCM_Pitch_converter.txt"
+        self.pitch_energy_table = config_server.get_file_contents(
+            daq_configuration_path + "/lookup/BeamLineEnergy_DCM_Pitch_converter.txt",
+            GenericLookupTable,
         )
-        self.roll_energy_table_path = (
-            daq_configuration_path + "/lookup/BeamLineEnergy_DCM_Roll_converter.txt"
+        self.roll_energy_table = config_server.get_file_contents(
+            daq_configuration_path + "/lookup/BeamLineEnergy_DCM_Roll_converter.txt",
+            GenericLookupTable,
         )
         # I03 configures the DCM Perp as a side effect of applying this fixed value to the DCM Offset after an energy change
         # Nb this parameter is misleadingly named to confuse you


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-bluesky/issues/1494

Reads config files through the config server when UndulatorDcm device is initialised. Anything downstream can then access the config directly without reading the file system.

### Instructions to reviewer on how to test:
1. Check tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
