### PR TITLE
set_cam_pvs to check for EigerDetector.nexpi exist

### DIFF
--- a/src/dodal/plans/configure_arm_trigger_and_disarm_detector.py
+++ b/src/dodal/plans/configure_arm_trigger_and_disarm_detector.py
@@ -76,7 +76,9 @@ def set_cam_pvs(
     yield from bps.abs_set(
         eiger.drv.detector.frame_time, detector_params.exposure_time_s, group=group
     )
-    yield from bps.abs_set(eiger.drv.detector.nexpi, 1, group=group)
+    if hasattr(eiger.drv.detector, "nexpi"):
+        if eiger.drv.detector.nexpi:
+            yield from bps.abs_set(eiger.drv.detector.nexpi, 1, group=group)
 
     if wait:
         yield from bps.wait(group)


### PR DESCRIPTION
Fixes #1796 

I'm not certain if this is the definitive fix, but I've added a check for the EigerDetector nexpi parameter before attempting to set it. The latest ophyd_async has made nexpi optional.

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
