### PR TITLE
Fix broken tests due to deprecation

### DIFF
--- a/tests/devices/oav/test_snapshots.py
+++ b/tests/devices/oav/test_snapshots.py
@@ -118,7 +118,9 @@ def assert_images_identical(left: Image.Image, right: Image.Image):
     assert all(
         left_px == right_px
         for left_px, right_px in zip(
-            iter(left.getdata()), iter(right.getdata()), strict=True
+            iter(left.get_flattened_data()),
+            iter(right.get_flattened_data()),
+            strict=True,
         )
     )
 


### PR DESCRIPTION
Fixes the following issues:

```
=========================== short test summary info ============================
FAILED tests/devices/oav/test_snapshots.py::test_snapshot_correctly_triggered_and_saved - DeprecationWarning: Image.Image.getdata is deprecated and will be removed in Pillow 14 (2027-10-15). Use get_flattened_data instead.
FAILED tests/devices/oav/test_snapshots.py::test_directory_created_when_snapshot_triggered - DeprecationWarning: Image.Image.getdata is deprecated and will be removed in Pillow 14 (2027-10-15). Use get_flattened_data instead.
```

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
