### PR TITLE
Add docstrings for all devices in motors.py

### DIFF
--- a/src/dodal/devices/motors.py
+++ b/src/dodal/devices/motors.py
@@ -31,12 +31,13 @@ class Stage(StandardReadable, ABC):
 
 
 class XThetaStage(Stage):
+    """
+    Two-axis stage with an x and a theta motor.
+    """
+
     def __init__(
         self, prefix: str, name: str = "", x_infix: str = _X, theta_infix: str = "A"
     ):
-        """
-        Two-axis stage with an x and a theta motor.
-        """
         with self.add_children_as_readables():
             self.x = Motor(prefix + x_infix)
             self.theta = Motor(prefix + theta_infix)
@@ -44,12 +45,13 @@ class XThetaStage(Stage):
 
 
 class XYStage(Stage):
+    """
+    A standard two-axis stage with an x and a y motor.
+    """
+
     def __init__(
         self, prefix: str, name: str = "", x_infix: str = _X, y_infix: str = _Y
     ):
-        """
-        A standard two-axis stage with an x and a y motor.
-        """
         with self.add_children_as_readables():
             self.x = Motor(prefix + x_infix)
             self.y = Motor(prefix + y_infix)
@@ -57,6 +59,10 @@ class XYStage(Stage):
 
 
 class XYZStage(XYStage):
+    """
+    A standard three-axis stage with an x, a y, and a z motor.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -65,15 +71,16 @@ class XYZStage(XYStage):
         y_infix: str = _Y,
         z_infix: str = _Z,
     ):
-        """
-        A standard three-axis stage with an x, a y, and a z motor.
-        """
         with self.add_children_as_readables():
             self.z = Motor(prefix + z_infix)
         super().__init__(prefix, name, x_infix, y_infix)
 
 
 class XYZThetaStage(XYZStage):
+    """
+    Four-axis stage with a standard xyz stage and one axis of rotation: theta.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -83,15 +90,16 @@ class XYZThetaStage(XYZStage):
         z_infix: str = _Z,
         theta_infix: str = "THETA",
     ) -> None:
-        """
-        Four-axis stage with a standard xyz stage and one axis of rotation: theta.
-        """
         with self.add_children_as_readables():
             self.theta = Motor(prefix + theta_infix)
         super().__init__(prefix, name, x_infix, y_infix, z_infix)
 
 
 class XYZOmegaStage(XYZStage):
+    """
+    Four-axis stage with a standard xyz stage and one axis of rotation: omega.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -101,15 +109,16 @@ class XYZOmegaStage(XYZStage):
         z_infix: str = _Z,
         omega_infix: str = _OMEGA,
     ) -> None:
-        """
-        Four-axis stage with a standard xyz stage and one axis of rotation: omega.
-        """
         with self.add_children_as_readables():
             self.omega = Motor(prefix + omega_infix)
         super().__init__(prefix, name, x_infix, y_infix, z_infix)
 
 
 class XYPhiStage(XYStage):
+    """
+    Three-axis stage with a standard xy stage and one axis of rotation: phi.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -118,15 +127,16 @@ class XYPhiStage(XYStage):
         phi_infix: str = "PHI",
         name: str = "",
     ) -> None:
-        """
-        Three-axis stage with a standard xy stage and one axis of rotation: phi.
-        """
         with self.add_children_as_readables():
             self.phi = Motor(prefix + phi_infix)
         super().__init__(prefix, name, x_infix, y_infix)
 
 
 class XYPitchStage(XYStage):
+    """
+    Three-axis stage with a standard xy stage and one axis of rotation: pitch.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -135,15 +145,16 @@ class XYPitchStage(XYStage):
         pitch_infix: str = "PITCH",
         name: str = "",
     ) -> None:
-        """
-        Three-axis stage with a standard xy stage and one axis of rotation: pitch.
-        """
         with self.add_children_as_readables():
             self.pitch = Motor(prefix + pitch_infix)
         super().__init__(prefix, name, x_infix, y_infix)
 
 
 class XYRollStage(XYStage):
+    """
+    Three-axis stage with a standard xy stage and one axis of rotation: roll.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -152,15 +163,16 @@ class XYRollStage(XYStage):
         roll_infix: str = "ROLL",
         name: str = "",
     ) -> None:
-        """
-        Three-axis stage with a standard xy stage and one axis of rotation: roll.
-        """
         with self.add_children_as_readables():
             self.roll = Motor(prefix + roll_infix)
         super().__init__(prefix, name, x_infix, y_infix)
 
 
 class XYZPitchYawStage(XYZStage):
+    """
+    Five-axis stage with a standard xyz stage and two axes of rotation: pitch and yaw.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -171,9 +183,6 @@ class XYZPitchYawStage(XYZStage):
         pitch_infix="PITCH",
         yaw_infix="YAW",
     ):
-        """
-        Five-axis stage with a standard xyz stage and two axes of rotation: pitch and yaw.
-        """
         with self.add_children_as_readables():
             self.pitch = Motor(prefix + pitch_infix)
             self.yaw = Motor(prefix + yaw_infix)
@@ -181,6 +190,11 @@ class XYZPitchYawStage(XYZStage):
 
 
 class XYZPitchYawRollStage(XYZStage):
+    """
+    Five-axis stage with a standard xyz stage and three axes of rotation: pitch, yaw,
+    and roll.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -192,10 +206,6 @@ class XYZPitchYawRollStage(XYZStage):
         yaw_infix: str = "YAW",
         roll_infix: str = "ROLL",
     ):
-        """
-        Five-axis stage with a standard xyz stage and three axes of rotation: pitch, yaw,
-        and roll.
-        """
         with self.add_children_as_readables():
             self.pitch = Motor(prefix + pitch_infix)
             self.yaw = Motor(prefix + yaw_infix)
@@ -204,6 +214,11 @@ class XYZPitchYawRollStage(XYZStage):
 
 
 class SixAxisGonio(XYZOmegaStage):
+    """
+    Six-axis goniometer with a standard xyz stage and three axes of rotation:
+    kappa, phi and omega.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -215,9 +230,6 @@ class SixAxisGonio(XYZOmegaStage):
         phi_infix: str = "PHI",
         omega_infix: str = _OMEGA,
     ):
-        """Six-axis goniometer with a standard xyz stage and three axes of rotation:
-        kappa, phi and omega.
-        """
         with self.add_children_as_readables():
             self.kappa = Motor(prefix + kappa_infix)
             self.phi = Motor(prefix + phi_infix)
@@ -229,6 +241,11 @@ class SixAxisGonio(XYZOmegaStage):
 
 
 class SixAxisGonioKappaPhi(XYZStage):
+    """
+    Six-axis goniometer with a standard xyz stage and two axes of rotation:
+    kappa and phi.
+    """
+
     def __init__(
         self,
         prefix: str,
@@ -239,9 +256,6 @@ class SixAxisGonioKappaPhi(XYZStage):
         kappa_infix: str = "KAPPA",
         phi_infix: str = "PHI",
     ):
-        """Six-axis goniometer with a standard xyz stage and two axes of rotation:
-        kappa and phi.
-        """
         with self.add_children_as_readables():
             self.kappa = Motor(prefix + kappa_infix)
             self.phi = Motor(prefix + phi_infix)
@@ -249,12 +263,13 @@ class SixAxisGonioKappaPhi(XYZStage):
 
 
 class YZStage(Stage):
+    """
+    Two-axis stage with an x and a z motor.
+    """
+
     def __init__(
         self, prefix: str, name: str = "", y_infix: str = _Y, z_infix: str = _Z
     ) -> None:
-        """
-        Two-axis stage with an x and a z motor.
-        """
         with self.add_children_as_readables():
             self.y = Motor(prefix + y_infix)
             self.z = Motor(prefix + z_infix)


### PR DESCRIPTION
Closes #1823

Adds a docstring to devices in `motors.py` which do not yet have a docstring. Docstrings should be consistent and informative.