### PR TITLE
Add docstrings to beamsize devices

### DIFF
--- a/src/dodal/devices/i03/beamsize.py
+++ b/src/dodal/devices/i03/beamsize.py
@@ -8,8 +8,9 @@ from dodal.devices.i03.constants import BeamsizeConstants
 class Beamsize(BeamsizeBase):
     """
     Device that calculates the size of the beam by taking the minimum of the beam dimensions
-    and the aperture scatterguard diameter (misnamed radius in the device https://github.com/DiamondLightSource/dodal/issues/1710). 
+    and the aperture scatterguard diameter (misnamed radius in the device https://github.com/DiamondLightSource/dodal/issues/1710).
     """
+
     def __init__(self, aperture_scatterguard: ApertureScatterguard, name=""):
         super().__init__(name=name)
         self._aperture_scatterguard_ref = Reference(aperture_scatterguard)

--- a/src/dodal/devices/i04/beamsize.py
+++ b/src/dodal/devices/i04/beamsize.py
@@ -7,10 +7,11 @@ from dodal.devices.i04.transfocator import Transfocator
 
 class Beamsize(BeamsizeBase):
     """
-    Device that calculates the size of the beam by taking the minimum of the transfocator 
+    Device that calculates the size of the beam by taking the minimum of the transfocator
     size and the aperture scatterguard diameter (misnamed radius in the device
     https://github.com/DiamondLightSource/dodal/issues/1710).
     """
+
     def __init__(
         self,
         transfocator: Transfocator,


### PR DESCRIPTION
Fixes #1835

### Instructions to reviewer on how to test:
1. Check docstring makes sense

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
