### PR TITLE
Make DeviceManager iterable

### DIFF
--- a/src/dodal/device_manager.py
+++ b/src/dodal/device_manager.py
@@ -5,6 +5,7 @@ from collections import UserDict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from functools import cached_property, wraps
 from inspect import Parameter
+from itertools import chain
 from types import NoneType
 from typing import (
     Annotated,
@@ -602,3 +603,6 @@ class DeviceManager:
 
     def __repr__(self) -> str:
         return f"<DeviceManager: {len(self)} devices>"
+
+    def __iter__(self):
+        return chain(self._factories.items(), self._v1_factories.items())


### PR DESCRIPTION
Allows the list of device factories to be inspected without having to
build devices or access internals

    devices = DeviceManager()

    # ... all the device factory definitions

    for name, factory in devices:
        print(name)
        print(factory.__doc__)
