### PR TITLE
Update comments to explain connection issues

### DIFF
--- a/src/dodal/beamlines/b07.py
+++ b/src/dodal/beamlines/b07.py
@@ -30,8 +30,8 @@ def energy_source(pgm: PlaneGratingMonochromator) -> EnergySource:
     return EnergySource(pgm.energy.user_readback)
 
 
-# Connect will work again after this work completed
-# https://jira.diamond.ac.uk/browse/B07-1104
+# CAM:IMAGE will fail to connect outside the beamline network,
+# see https://github.com/DiamondLightSource/dodal/issues/1852
 @devices.factory()
 def analyser(energy_source: EnergySource) -> SpecsDetector[LensMode, PsuMode]:
     return SpecsDetector[LensMode, PsuMode](

--- a/src/dodal/beamlines/b07_1.py
+++ b/src/dodal/beamlines/b07_1.py
@@ -40,6 +40,8 @@ def energy_source(pgm: PlaneGratingMonochromator) -> EnergySource:
     return EnergySource(pgm.energy.user_readback)
 
 
+# CAM:IMAGE will fail to connect outside the beamline network,
+# see https://github.com/DiamondLightSource/dodal/issues/1852
 @devices.factory()
 def analyser(energy_source: EnergySource) -> SpecsDetector[LensMode, PsuMode]:
     return SpecsDetector[LensMode, PsuMode](

--- a/src/dodal/beamlines/i09.py
+++ b/src/dodal/beamlines/i09.py
@@ -75,9 +75,9 @@ def dual_fast_shutter(
     return DualFastShutter[InOut](fsi1, fsj1, source_selector.selected_source)
 
 
-# Connect will work again after this work completed
-# https://jira.diamond.ac.uk/browse/I09-651
-@devices.factory(skip=True)
+# CAM:IMAGE will fail to connect outside the beamline network,
+# see https://github.com/DiamondLightSource/dodal/issues/1852
+@devices.factory()
 def ew4000(
     dual_fast_shutter: DualFastShutter,
     dual_energy_source: DualEnergySource,

--- a/src/dodal/beamlines/i09_1.py
+++ b/src/dodal/beamlines/i09_1.py
@@ -29,9 +29,9 @@ def energy_source(dcm: DoubleCrystalMonochromatorWithDSpacing) -> EnergySource:
     return EnergySource(dcm.energy_in_eV)
 
 
-# Connect will work again after this work completed
-# https://jira.diamond.ac.uk/browse/I09-651
-@devices.factory(skip=True)
+# CAM:IMAGE will fail to connect outside the beamline network,
+# see https://github.com/DiamondLightSource/dodal/issues/1852
+@devices.factory()
 def analyser(energy_source: EnergySource) -> SpecsDetector[LensMode, PsuMode]:
     return SpecsDetector[LensMode, PsuMode](
         prefix=f"{PREFIX.beamline_prefix}-EA-DET-02:CAM:",

--- a/src/dodal/beamlines/p60.py
+++ b/src/dodal/beamlines/p60.py
@@ -13,6 +13,11 @@ from dodal.devices.selectable_source import SourceSelector
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import BeamlinePrefix, get_beamline_name
 
+"""
+NOTE: Due to p60 not having a CA gateway, PVs are not available remotely and you need to
+be on the beamline network to access them so a remote `dodal connect p60` will fail.
+"""
+
 devices = DeviceManager()
 
 BL = get_beamline_name("p60")


### PR DESCRIPTION
Fixes #1852

* Added comments about why `CAM:IMAGE` does not work
* Also removed skips where only this was failing (we can add back in if you want though)
* Also removed comments where we reference other PVs as not existing when they actually do
* For p60 I added the comment about gateways at the top of the file and didn't bother for `CAM:IMAGE` as it's true for all PVs in the file

### Instructions to reviewer on how to test:
1. Confirm comments are correct

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
