### PR TITLE
Add Psu pv override so VGScienta connect works

### DIFF
--- a/src/dodal/devices/electron_analyser/base/base_driver_io.py
+++ b/src/dodal/devices/electron_analyser/base/base_driver_io.py
@@ -58,7 +58,7 @@ class AbstractAnalyserDriverIO(
         pass_energy_type (type[TPassEnergy]): Can be enum or float, depending on
             electron analyser model. If enum, it determines the available pass
             energies for this device.
-        psu_infix (str, optional): The psu infix to connect to EPICS. Defaults to PSU_MODE.
+        psu_suffix (str, optional): The psu infix to connect to EPICS. Defaults to PSU_MODE.
         name (str, optional): Name of the device.
     """
 
@@ -69,7 +69,7 @@ class AbstractAnalyserDriverIO(
         lens_mode_type: type[TLensMode],
         psu_mode_type: type[TPsuMode],
         pass_energy_type: type[TPassEnergy],
-        psu_infix: str = _PSU,
+        psu_suffix: str = _PSU,
         name: str = "",
     ) -> None:
         self.acquisition_mode_type = acquisition_mode_type
@@ -110,7 +110,7 @@ class AbstractAnalyserDriverIO(
             )
             # This is used by each electron analyser, however it depends on the electron
             # analyser type to know if is moved with region settings.
-            self.psu_mode = epics_signal_rw(psu_mode_type, prefix + psu_infix)
+            self.psu_mode = epics_signal_rw(psu_mode_type, prefix + psu_suffix)
 
         # This is defined in the parent class, add it as readable configuration.
         self.add_readables([self.acquire_time], StandardReadableFormat.CONFIG_SIGNAL)

--- a/src/dodal/devices/electron_analyser/specs/specs_driver_io.py
+++ b/src/dodal/devices/electron_analyser/specs/specs_driver_io.py
@@ -35,7 +35,7 @@ class SpecsAnalyserDriverIO(
         prefix: str,
         lens_mode_type: type[TLensMode],
         psu_mode_type: type[TPsuMode],
-        psu_infix: str = _PSU,
+        psu_suffix: str = _PSU,
         name: str = "",
     ) -> None:
         with self.add_children_as_readables(StandardReadableFormat.CONFIG_SIGNAL):
@@ -57,7 +57,7 @@ class SpecsAnalyserDriverIO(
             lens_mode_type=lens_mode_type,
             psu_mode_type=psu_mode_type,
             pass_energy_type=float,
-            psu_infix=psu_infix,
+            psu_suffix=psu_suffix,
             name=name,
         )
 

--- a/src/dodal/devices/electron_analyser/vgscienta/vgscienta_driver_io.py
+++ b/src/dodal/devices/electron_analyser/vgscienta/vgscienta_driver_io.py
@@ -40,7 +40,7 @@ class VGScientaAnalyserDriverIO(
         lens_mode_type: type[TLensMode],
         psu_mode_type: type[TPsuMode],
         pass_energy_type: type[TPassEnergyEnum],
-        psu_infix: str = "ELEMENT_SET",
+        psu_suffix: str = "ELEMENT_SET",
         name: str = "",
     ) -> None:
         with self.add_children_as_readables(StandardReadableFormat.CONFIG_SIGNAL):
@@ -61,7 +61,7 @@ class VGScientaAnalyserDriverIO(
             lens_mode_type=lens_mode_type,
             psu_mode_type=psu_mode_type,
             pass_energy_type=pass_energy_type,
-            psu_infix=psu_infix,
+            psu_suffix=psu_suffix,
             name=name,
         )
 


### PR DESCRIPTION
Add Psu pv override so connect works, waiting on https://jira.diamond.ac.uk/browse/I09-651 so it standardised. 

### Instructions to reviewer on how to test:
1. Check dodal connect for i09 (timesout due to image expected)

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
