### PR TITLE
Convert p45 beamline to use DeviceManager

### DIFF
--- a/src/dodal/beamlines/p45.py
+++ b/src/dodal/beamlines/p45.py
@@ -1,16 +1,13 @@
 from pathlib import Path
 
+from ophyd_async.core import PathProvider
 from ophyd_async.epics.adaravis import AravisDetector
 from ophyd_async.fastcs.panda import HDFPanda
 
-from dodal.common.beamlines.beamline_utils import (
-    device_factory,
-    get_path_provider,
-    set_path_provider,
-)
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import DET_SUFFIX, HDF5_SUFFIX
 from dodal.common.visit import StaticVisitPathProvider
+from dodal.device_manager import DeviceManager
 from dodal.devices.beamlines.p45 import TomoStageWithStretchAndSkew
 from dodal.devices.motors import XYStage
 from dodal.log import set_beamline as set_log_beamline
@@ -21,41 +18,44 @@ PREFIX = BeamlinePrefix(BL)
 set_log_beamline(BL)
 set_utils_beamline(BL)
 
-set_path_provider(
-    StaticVisitPathProvider(
+devices = DeviceManager()
+
+
+@devices.fixture
+def path_provider() -> PathProvider:
+    return StaticVisitPathProvider(
         BL,
         Path("/data/2024/cm37283-2/"),  # latest commissioning visit
     )
-)
 
 
-@device_factory()
+@devices.factory
 def sample() -> TomoStageWithStretchAndSkew:
     return TomoStageWithStretchAndSkew(f"{PREFIX.beamline_prefix}-MO-STAGE-01:")
 
 
-@device_factory()
+@devices.factory
 def choppers() -> XYStage:
     return XYStage(f"{PREFIX.beamline_prefix}-MO-CHOP-01:")
 
 
 # Disconnected
-@device_factory(skip=True)
-def det() -> AravisDetector:
+@devices.factory(skip=True)
+def det(path_provider: PathProvider) -> AravisDetector:
     return AravisDetector(
         f"{PREFIX.beamline_prefix}-EA-MAP-01:",
-        path_provider=get_path_provider(),
+        path_provider=path_provider,
         drv_suffix=DET_SUFFIX,
         fileio_suffix=HDF5_SUFFIX,
     )
 
 
 # Disconnected
-@device_factory(skip=True)
-def diff() -> AravisDetector:
+@devices.factory(skip=True)
+def diff(path_provider: PathProvider) -> AravisDetector:
     return AravisDetector(
         f"{PREFIX.beamline_prefix}-EA-DIFF-01:",
-        path_provider=get_path_provider(),
+        path_provider=path_provider,
         drv_suffix=DET_SUFFIX,
         fileio_suffix=HDF5_SUFFIX,
     )
@@ -63,17 +63,17 @@ def diff() -> AravisDetector:
 
 # Must document what PandAs are physically connected to
 # See: https://github.com/bluesky/ophyd-async/issues/284
-@device_factory(skip=True)
-def panda1() -> HDFPanda:
+@devices.factory(skip=True)
+def panda1(path_provider: PathProvider) -> HDFPanda:
     return HDFPanda(
         f"{PREFIX.beamline_prefix}-MO-PANDA-01:",
-        path_provider=get_path_provider(),
+        path_provider=path_provider,
     )
 
 
-@device_factory(skip=True)
-def panda2() -> HDFPanda:
+@devices.factory(skip=True)
+def panda2(path_provider: PathProvider) -> HDFPanda:
     return HDFPanda(
         f"{PREFIX.beamline_prefix}-MO-PANDA-02:",
-        path_provider=get_path_provider(),
+        path_provider=path_provider,
     )


### PR DESCRIPTION
Partially fixes [ACQP-495](https://jira.diamond.ac.uk/browse/ACQP-495)

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
