### PR TITLE
Fix #1935 - corrections of discrepancies / inconsistencies in motors

### DIFF
--- a/src/dodal/devices/motors.py
+++ b/src/dodal/devices/motors.py
@@ -19,8 +19,8 @@ _TILT = "TILT"
 
 class Stage(StandardReadable, ABC):
     """For these devices, the following co-ordinates are typical but not enforced:
-    - z is horizontal & parallel to the direction of synchrotron electrons.
-         ( Usually the x-rays have the same direction: But z is defined by the electrons )
+    - z is tangential to the electrons (as they orbit inside the synchrotron);
+          the x-rays are generated in that tangential direction: But z is defined by the electrons.
     - y is vertical and antiparallel to the force of gravity
     - x is the cross product of y with z
 


### PR DESCRIPTION
* dodal devices motors script hereby has corrections applied to: YXStage class now lists relevant motor axes as Y and X

* motor stage with 3 linear axes and 3 rotations is hereby labelled as a six-axis ( rather than five ) stage

* inconsistencies in the layout of axes constants are thrashed out (previously linear motors were all in a line, rotation axes isolated perhaps it was a poetic metaphor ? )

* Grammar corrected when spelling out motors as a set of motors rather than as one or more letters and a letter labelled motor
* Replaces cross product symbol ( which was not rendering on github - nor in simple text editor )
   with the phrase "cross product of y with z" ( in the description of the x axis direction definition )

Fixes #1935 

### Instructions to reviewer on how to test:
1. Check corrections made to motors script
2. Confirm no new discrepancies added to documentation etc
3. Confirm CI doesn't fall over due to any spurious typos

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
