### PR TITLE
Include pmac trigger logic as visr device

### DIFF
--- a/src/dodal/beamlines/b01_1.py
+++ b/src/dodal/beamlines/b01_1.py
@@ -144,6 +144,6 @@ def pmac_trigger_logic(pmac: PmacIO) -> PmacTrajectoryTriggerLogic:
     """The trigger logic for the Power PMAC.
 
     Returns:
-        PmacTrajectoryTriggerLogic.
+        PmacTrajectoryTriggerLogic: Flyable device for Power PMAC flyscanning.
     """
     return PmacTrajectoryTriggerLogic(pmac)


### PR DESCRIPTION


### Instructions to reviewer on how to test:
1. Updates the visr detectors suffices
2. Includes Pmac Trigger Logic as a device for Visr. 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
