### PR TITLE
Fixes #1787 Add I19 filter wheel selections

### DIFF
--- a/src/dodal/beamlines/i19_optics.py
+++ b/src/dodal/beamlines/i19_optics.py
@@ -25,7 +25,17 @@ devices = DeviceManager()
 
 @devices.factory()
 def access_control() -> HutchAccessControl:
-    """Device to check which hutch is the active hutch on i19."""
+    """Device factory for access control device.
+
+    I19 features two experimental hutches, EH-1 and EH-2,
+    longitudinally positioned downstream from the common optics hutch:
+    Only one active EH can control the optics.
+    This device checks which EH is the active hutch.
+
+    Uses:
+        I19 beamline prefix extended with an infix specific to the access control.
+        Name of the access device in i19-blueapi.
+    """
     return HutchAccessControl(
         f"{PREFIX.beamline_prefix}-OP-STAT-01:", ACCESS_DEVICE_NAME
     )
@@ -33,43 +43,84 @@ def access_control() -> HutchAccessControl:
 
 @devices.factory()
 def attenuator_x_motor() -> Motor:
-    """Attenuator x motor - drives the resin wedge horizontally orthogonal to the x-ray beam.
-    :return: Device for the attenuator system resin wedge horizontal motion.
+    """Device factory for the I19 attenuator x-axis motor.
+
+    The x-axis linear motor drives an absorber wedge horizontally orthogonal to the x-ray beam.
+
+    Uses:
+        Prefix for the I19 beamline extended with an infix specific to the attenuator x-axis motor.
+        Name of the attenuator system x-axis motor device.
+
+    Returns:
+        Device for the x-axis attenuation system motor.
     """
-    return Motor(f"{PREFIX.beamline_prefix}-OP-ATTN-04:X", "ATTENUATOR_X")
+    return Motor(f"{PREFIX.beamline_prefix}-OP-ATTN-04:X", "attenuator_x")
 
 
 @devices.factory()
 def attenuator_y_motor() -> Motor:
-    """Attenuator y motor - drives the aluminium / aluminum wedge vertically orthogonal to the x-ray beam.
-    :return: Device for the attenuator system aluminium wedge vertical motion.
+    """Device factory for the I19 attenuator y-axis motor.
+
+    The y-axis linear motor drives an absorber wedge vertically orthogonal to the x-ray beam.
+
+    Uses:
+        Prefix for the I19 beamline extended with an infix specific to the attenuator y-axis motor.
+        Name of the attenuator system y-axis motor device.
+
+    Returns:
+        Device for the y-axis attenuation system motor.
     """
-    return Motor(f"{PREFIX.beamline_prefix}-OP-ATTN-05:Y", "ATTENUATOR_Y")
+    return Motor(f"{PREFIX.beamline_prefix}-OP-ATTN-05:Y", "attenuator_y")
 
 
 @devices.factory()
 def filter_wheel() -> FilterWheel:
-    """Filter wheel motor - rotates indexed wheel position to filters into/out of x-ray beam.
-    :return: Device for the indexed filter wheel rotation.
+    """Device factory for the I19 EH-1 filter wheel indexing motor.
+
+    Filter wheel motor rotates indexed wheel to bring specific attenuating filter into/out of x-ray beam.
+
+    Uses:
+        Beamline prefix for I19 extended with infix specific to the filter motor.
+        A further infix specific to filter wheel usage.
+        Name of the first filter wheel.
+
+    Returns:
+        First indexed filter wheel slot selecting rotation device.
     """
     return FilterWheel(
-        f"{PREFIX.beamline_prefix}-MO-FILT-01:FILTER",
-        I19FilterOneSelections,
-        "FILTER_W",
+        prefix=f"{PREFIX.beamline_prefix}-MO-FILT-01:",
+        filter_infix="FILTER",
+        filter_selections=I19FilterOneSelections,
+        name="filter_w_1",
     )
 
 
 @devices.factory()
 def hfm() -> FocusingMirrorWithPiezo:
-    """Get the i19 hfm device, instantiate it if it hasn't already been.
-    If this is called when already instantiated, it will return the existing object.
+    """Device factory for the I19 Horizontal Focus Mirror (HFM) Piezo Device.
+
+    Lazy instantiation:  Instantiates a device object if none have been,
+    else it will return the pre-existing instance.
+
+    Uses:
+        I19 beamline prefix extended with an infix specific to the HFM.
+
+    Returns:
+         Focusing mirror piezo device for the HFM.
     """
     return FocusingMirrorWithPiezo(f"{PREFIX.beamline_prefix}-OP-HFM-01:")
 
 
-@devices.factory()
 def shutter() -> InterlockedHutchShutter:
-    """Real experiment shutter device for I19."""
+    """Device factory for the I19 optics hutch shutter device.
+
+    Uses:
+        I19 beamline prefix extended with an infix specific to the optics hutch shutter.
+        HutchInterlock device (itself using I19 beamline prefix)
+
+    Returns:
+        I19 optics hutch shutter device.
+    """
     return InterlockedHutchShutter(
         PREFIX.beamline_prefix, HutchInterlock(PREFIX.beamline_prefix)
     )
@@ -77,7 +128,15 @@ def shutter() -> InterlockedHutchShutter:
 
 @devices.factory()
 def vfm() -> FocusingMirrorWithPiezo:
-    """Get the i19 vfm device, instantiate it if it hasn't already been.
-    If this is called when already instantiated, it will return the existing object.
+    """Device factory for the I19 Vertical Focus Mirror (VFM) Piezo Device.
+
+    Lazy instantiation:  Instantiates a device object if none have been,
+    else it will return the pre-existing instance.
+
+    Uses:
+        I19 beamline prefix with VFM infix.
+
+    Returns:
+         Focusing mirror piezo device for the VFM.
     """
     return FocusingMirrorWithPiezo(f"{PREFIX.beamline_prefix}-OP-VFM-01:")

--- a/src/dodal/devices/attenuator/filter.py
+++ b/src/dodal/devices/attenuator/filter.py
@@ -1,5 +1,5 @@
 from ophyd_async.core import StandardReadable, StrictEnum, SubsetEnum
-from ophyd_async.epics.core import epics_signal_rw, epics_signal_rw_rbv
+from ophyd_async.epics.core import epics_signal_rw
 
 
 class FilterMotor(StandardReadable):
@@ -18,12 +18,15 @@ class FilterWheel(StandardReadable):
     def __init__(
         self,
         prefix: str,
+        filter_infix: str,
         filter_selections: type[StrictEnum | SubsetEnum],
         name: str = "",
     ):
+        filter_prefix: str = f"{prefix}{filter_infix}"
         with self.add_children_as_readables():
-            self.user_setpoint = epics_signal_rw_rbv(filter_selections, prefix)
-            self.done_move = epics_signal_rw(
-                int, f"{prefix}DMOV"
-            )  # 1 for yes, 0 for no
+            self.user_setpoint = epics_signal_rw(
+                datatype=filter_selections,
+                read_pv=filter_prefix,
+                write_pv=filter_prefix,
+            )
         super().__init__(name=name)

--- a/src/dodal/devices/attenuator/filter_selections.py
+++ b/src/dodal/devices/attenuator/filter_selections.py
@@ -73,12 +73,12 @@ class I02_1FilterFourSelections(SubsetEnum):  # noqa: N801
 
 
 class I19FilterOneSelections(StrictEnum):
-    AIR1 = "Empty"
-    AL = "Al"
-    AIR3 = "Empty"
-    AU = "Au"
-    AIR5 = "Empty"
-    FE = "Fe"
+    AIR1 = "1 - "
+    AL = "2 - Al"
+    AIR3 = "3 - "
+    AU = "4 - Au"
+    AIR5 = "5 - "
+    FE = "6 - Fe"
 
 
 class I24FilterOneSelections(SubsetEnum):


### PR DESCRIPTION
* Add filter wheel with all six indexed positions

Fixes #1787

### Instructions to reviewer on how to test:
1. Browse over additions to I19 optics configuration for filter wheel and attenuator linear motors x and y
2. Confirm CI tests pass
3. Remind me if I need any test coverage - where the tests should live for this type of change

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
