### PR TITLE
Make the I19-optics shutter a device again

### DIFF
--- a/src/dodal/beamlines/i19_optics.py
+++ b/src/dodal/beamlines/i19_optics.py
@@ -111,6 +111,7 @@ def hfm() -> FocusingMirrorWithPiezo:
     return FocusingMirrorWithPiezo(f"{PREFIX.beamline_prefix}-OP-HFM-01:")
 
 
+@devices.factory()
 def shutter() -> InterlockedHutchShutter:
     """Device factory for the I19 optics hutch shutter device.
 


### PR DESCRIPTION
Re-add the `@device.factory()` that disappeared from the shutter device in i19_optics in #1954 

Fixes #ISSUE

### Instructions to reviewer on how to test:
1. Run dodal connect i19_optics and verify there is a shutter in the device list

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
