### PR TITLE
Add test to ensure all functions in beamline modules are devices or fixtures

### DIFF
--- a/tests/common/beamlines/test_device_instantiation.py
+++ b/tests/common/beamlines/test_device_instantiation.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any
 
 import pytest
@@ -63,3 +64,37 @@ def test_devices_are_identical(module_and_devices_for_beamline):
     assert len(non_identical_names) == 0, (
         f"{non_identical_number_of_devices}/{total_number_of_devices} devices were not identical: {non_identical_names}"
     )
+
+
+@pytest.mark.parametrize(
+    "module_and_devices_for_beamline",
+    set(all_beamline_modules()),
+    indirect=True,
+)
+def test_all_functions_in_beamline_modules_are_devices_or_fixtures(
+    module_and_devices_for_beamline,
+):
+    module, _, _ = module_and_devices_for_beamline
+    devices: DeviceManager | None = getattr(module, "devices", None)
+
+    def func_is_device(func) -> bool:
+        return hasattr(func, "_devices_decorator")
+
+    def func_is_fixture(func) -> bool:
+        if not devices:
+            return False
+        return (
+            func.__name__ in devices._fixtures
+            and devices._fixtures[func.__name__] is func
+        )
+
+    functions_in_module = [
+        (name, func)
+        for name, func in inspect.getmembers(module, inspect.isfunction)
+        if func.__module__ == module.__name__
+    ]
+
+    for name, func in functions_in_module:
+        assert func_is_device(func) or func_is_fixture(func), (
+            f"Function '{name}' in module '{module.__file__}' is not a device or a fixture!"
+        )


### PR DESCRIPTION
Fixes #1981

### Instructions to reviewer on how to test:
1. Delete fixture or device decorator in a beamline module.
2. Confirm test for that beamline fails.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
