### PR TITLE
B21: Update vici valve names

### DIFF
--- a/src/dodal/devices/beamlines/b21/vici_valves.py
+++ b/src/dodal/devices/beamlines/b21/vici_valves.py
@@ -3,21 +3,21 @@ from ophyd_async.epics.core import epics_signal_rw, epics_signal_rw_rbv
 
 
 class Valve1Positions(StrictEnum):
-    POS_1 = "Pos 1"
-    POS_2 = "Pos 2"
-    POS_3 = "Pos 3"
-    POS_4 = "Pos 4"
-    POS_5 = "Pos 5"
-    POS_6 = "Pos 6"
+    POS_1 = "Sep300"
+    POS_2 = "KW402.5"
+    POS_3 = "S200"
+    POS_4 = "Sup6"
+    POS_5 = "Guest1"
+    POS_6 = "Bypass1"
 
 
 class Valve2Positions(StrictEnum):
-    POS_1 = "Pos 1"
-    POS_2 = "Pos 2"
-    POS_3 = "Pos 3"
-    POS_4 = "Pos 4"
-    POS_5 = "Pos 5"
-    POS_6 = "Pos 6"
+    POS_1 = "KW403"
+    POS_2 = "KW402.5"
+    POS_3 = "S200"
+    POS_4 = "Sep500"
+    POS_5 = "Guest2"
+    POS_6 = "Bypass2"
 
 
 class ViciValves(StandardReadable):


### PR DESCRIPTION
Fixes vici valve names that were entered as placeholders. The correct names can be found by doing
`caget -d31 BL21B-EA-GIR-01:VALVE1:POSN`
`caget -d31 BL21B-EA-GIR-01:VALVE2:POSN`

### Instructions to reviewer on how to test:
1. Test the names match what they should be

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
