### PR TITLE
Add i15-1 hexapod motors for crystallography-bluesky#9

### DIFF
--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -14,7 +14,7 @@ from dodal.devices.hutch_shutter import (
     InterlockedHutchShutter,
     PLCShutterInterlock,
 )
-from dodal.devices.motors import XYPhiStage, XYStage, YZStage
+from dodal.devices.motors import XYPhiStage, XYStage, XYZStage, YZStage
 from dodal.devices.slits import Slits
 from dodal.devices.synchrotron import Synchrotron
 from dodal.log import set_beamline as set_log_beamline
@@ -83,6 +83,23 @@ def env_x() -> Motor:
 @devices.factory()
 def f2y() -> Motor:
     return Motor(f"{PREFIX.beamline_prefix}-OP-ATTN-02:Y")
+
+
+@devices.factory()
+def h() -> XYZStage:
+    return XYZStage(
+        f"{PREFIX.beamline_prefix}-MO-HEX-01:",
+    )
+
+
+@devices.factory()
+def hr() -> XYZStage:
+    return XYZStage(
+        f"{PREFIX.beamline_prefix}-MO-HEX-01:",
+        x_infix="RX",
+        y_infix="RY",
+        z_infix="RZ",
+    )
 
 
 @devices.factory()

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -93,7 +93,7 @@ def hexapod() -> XYZStage:
 
 
 @devices.factory()
-def hexapod_rot() -> XYZStage:
+def hexapod_rotation() -> XYZStage:
     return XYZStage(
         f"{PREFIX.beamline_prefix}-MO-HEX-01:",
         x_infix="RX",

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -86,14 +86,14 @@ def f2y() -> Motor:
 
 
 @devices.factory()
-def h() -> XYZStage:
+def hexapod() -> XYZStage:
     return XYZStage(
         f"{PREFIX.beamline_prefix}-MO-HEX-01:",
     )
 
 
 @devices.factory()
-def hr() -> XYZStage:
+def hexapod_rot() -> XYZStage:
     return XYZStage(
         f"{PREFIX.beamline_prefix}-MO-HEX-01:",
         x_infix="RX",


### PR DESCRIPTION
Fixes [crystallography-bluesky#9](https://github.com/DiamondLightSource/crystallography-bluesky/issues/9)

### Instructions to reviewer on how to test:
1. Wait for missing i15-1 motors to be restored
2. Confirm `dodal connect i15-1` runs.
3. Confirm which axes are X, Y and Z.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`

TODO: Confirm X, Y & Z axes are beamline standard