### PR TITLE
Don't instantiate config client inside oav params

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -111,7 +111,6 @@ def daq_configuration_path() -> str:
 
 @devices.factory()
 def aperture_scatterguard(config_client: ConfigClient) -> ApertureScatterguard:
-    print(BEAMLINE_PARAMETERS_PATH)
     params = config_client.get_file_contents(BEAMLINE_PARAMETERS_PATH, dict)
     return ApertureScatterguard(
         aperture_prefix=f"{PREFIX.beamline_prefix}-MO-MAPT-01:",

--- a/src/dodal/devices/oav/oav_parameters.py
+++ b/src/dodal/devices/oav/oav_parameters.py
@@ -30,15 +30,15 @@ class OAVParameters:
 
     def __init__(
         self,
+        config_client: ConfigClient,
         context="loopCentring",
         oav_config_json=OAV_CONFIG_JSON,
     ):
         self.oav_config_json: str = oav_config_json
         self.context = context
-        config_server = ConfigClient(url="https://daq-config.diamond.ac.uk")
 
         self.global_params, self.context_dicts = self.load_json(
-            config_server, self.oav_config_json
+            config_client, self.oav_config_json
         )
         self.active_params: ChainMap = ChainMap(
             self.context_dicts[self.context], self.global_params
@@ -47,12 +47,12 @@ class OAVParameters:
 
     @staticmethod
     def load_json(
-        config_server: ConfigClient, filename: str
+        config_client: ConfigClient, filename: str
     ) -> tuple[dict[str, Any], dict[str, dict]]:
         """Loads the specified file from the config server, and returns a dict with all the
         individual top-level k-v pairs, and one with all the subdicts.
         """
-        raw_params: dict[str, Any] = config_server.get_file_contents(filename, dict)
+        raw_params: dict[str, Any] = config_client.get_file_contents(filename, dict)
         global_params = {
             k: raw_params.pop(k)
             for k, v in list(raw_params.items())

--- a/tests/devices/oav/test_oav_parameters.py
+++ b/tests/devices/oav/test_oav_parameters.py
@@ -19,10 +19,7 @@ from tests.devices.oav.test_data import (
 
 @pytest.fixture
 def mock_parameters():
-    return OAVParameters(
-        "loopCentring",
-        TEST_OAV_CENTRING_JSON,
-    )
+    return OAVParameters(ConfigClient(""), "loopCentring", TEST_OAV_CENTRING_JSON)
 
 
 @pytest.fixture

--- a/tests/plans/device_setup_plans/test_setup_pin_tip.py
+++ b/tests/plans/device_setup_plans/test_setup_pin_tip.py
@@ -1,5 +1,6 @@
 import pytest
 from bluesky import RunEngine
+from daq_config_server import ConfigClient
 from ophyd_async.core import init_devices
 
 from dodal.devices.oav.oav_parameters import OAVParameters
@@ -20,7 +21,7 @@ def pin_tip_detection() -> PinTipDetection:
 
 @pytest.fixture
 def params() -> OAVParameters:
-    return OAVParameters("pinTipCentring", TEST_OAV_CENTRING_JSON)
+    return OAVParameters(ConfigClient(""), "pinTipCentring", TEST_OAV_CENTRING_JSON)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
