### PR TITLE
Add i21 shutter with lateral motor

### DIFF
--- a/src/dodal/beamlines/i21.py
+++ b/src/dodal/beamlines/i21.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from daq_config_server import ConfigClient
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.enums import OpenClosed
 from dodal.device_manager import DeviceManager
 from dodal.devices.beamlines.i21 import (
+    FastShutterWithLateralMotor,
     Grating,
     I21SampleManipulatorStage,
     ToolPointMotion,
@@ -24,9 +26,7 @@ from dodal.devices.insertion_device.energy_motor_lookup import (
 from dodal.devices.insertion_device.lookup_table_models import LookupTableColumnConfig
 from dodal.devices.pgm import PlaneGratingMonochromator
 from dodal.devices.synchrotron import Synchrotron
-from dodal.devices.temperture_controller import (
-    Lakeshore336,
-)
+from dodal.devices.temperture_controller import Lakeshore336
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import BeamlinePrefix, get_beamline_name
 
@@ -48,6 +48,17 @@ devices = DeviceManager()
 @devices.factory()
 def synchrotron() -> Synchrotron:
     return Synchrotron()
+
+
+@devices.factory
+def fs1() -> FastShutterWithLateralMotor[OpenClosed]:
+    return FastShutterWithLateralMotor[OpenClosed](
+        prefix=PREFIX.beamline_prefix,
+        shutter_suffix="-OP-SHTR-01:CON",
+        lateral_suffix="-MO-SHTR-01:LAT",
+        open_state=OpenClosed.OPEN,
+        close_state=OpenClosed.CLOSED,
+    )
 
 
 @devices.factory()

--- a/src/dodal/common/enums.py
+++ b/src/dodal/common/enums.py
@@ -1,5 +1,11 @@
 from ophyd_async.core import StrictEnum
 
+
+class OpenClosed(StrictEnum):
+    OPEN = "Open"
+    CLOSED = "Closed"
+
+
 # Any capitalised enums needs to be removed and replaced with ones from ophyd-async.core
 # https://github.com/DiamondLightSource/dodal/issues/1416
 

--- a/src/dodal/devices/beamlines/i21/__init__.py
+++ b/src/dodal/devices/beamlines/i21/__init__.py
@@ -1,4 +1,5 @@
 from .enums import Grating
+from .fast_shutter import FastShutterWithLateralMotor
 from .i21_motors import I21SampleManipulatorStage
 from .toolpoint_motion import (
     ToolPointMotion,
@@ -8,6 +9,7 @@ from .toolpoint_motion import (
 
 __all__ = [
     "Grating",
+    "FastShutterWithLateralMotor",
     "I21SampleManipulatorStage",
     "ToolPointMotion",
     "UVWTiltAzimuthMotorPositions",

--- a/src/dodal/devices/beamlines/i21/fast_shutter.py
+++ b/src/dodal/devices/beamlines/i21/fast_shutter.py
@@ -1,0 +1,20 @@
+from typing import Generic
+
+from ophyd_async.epics.motor import Motor
+
+from dodal.devices.fast_shutter import EnumTypesT, FastShutter
+
+
+class FastShutterWithLateralMotor(FastShutter[EnumTypesT], Generic[EnumTypesT]):
+    def __init__(
+        self,
+        prefix: str,
+        open_state: EnumTypesT,
+        close_state: EnumTypesT,
+        shutter_suffix: str = "CON",
+        lateral_suffix: str = "LAT",
+        name: str = "",
+    ):
+        with self.add_children_as_readables():
+            self.x = Motor(prefix + lateral_suffix)
+        super().__init__(prefix + shutter_suffix, open_state, close_state, name)

--- a/src/dodal/devices/beamlines/i21/fast_shutter.py
+++ b/src/dodal/devices/beamlines/i21/fast_shutter.py
@@ -6,6 +6,20 @@ from dodal.devices.fast_shutter import EnumTypesT, FastShutter
 
 
 class FastShutterWithLateralMotor(FastShutter[EnumTypesT], Generic[EnumTypesT]):
+    """Implementation of fast shutter that connects to an epics pv. This pv is an enum
+    that controls the open and close state of the shutter.
+
+    Args:
+        pv (str): The pv to connect to the shutter device.
+        open_state (EnumTypesT): The enum value that corresponds with opening the
+            shutter.
+        close_state (EnumTypesT): The enum value that corresponds with closing the
+            shutter.
+        shutter_suffix (str, optional): Shutter suffix state. Defaults to CON.
+        lateral_suffix (str, optional): Lateral mottor suffix. Defaults to LAT.
+        name (str, optional): The name of the shutter.
+    """
+
     def __init__(
         self,
         prefix: str,

--- a/src/dodal/devices/beamlines/i21/fast_shutter.py
+++ b/src/dodal/devices/beamlines/i21/fast_shutter.py
@@ -16,7 +16,7 @@ class FastShutterWithLateralMotor(FastShutter[EnumTypesT], Generic[EnumTypesT]):
         close_state (EnumTypesT): The enum value that corresponds with closing the
             shutter.
         shutter_suffix (str, optional): Shutter suffix state. Defaults to CON.
-        lateral_suffix (str, optional): Lateral mottor suffix. Defaults to LAT.
+        lateral_suffix (str, optional): Lateral motor suffix. Defaults to LAT.
         name (str, optional): The name of the shutter.
     """
 

--- a/src/dodal/devices/beamlines/i21/fast_shutter.py
+++ b/src/dodal/devices/beamlines/i21/fast_shutter.py
@@ -6,8 +6,8 @@ from dodal.devices.fast_shutter import EnumTypesT, FastShutter
 
 
 class FastShutterWithLateralMotor(FastShutter[EnumTypesT], Generic[EnumTypesT]):
-    """Implementation of fast shutter that connects to an epics pv. This pv is an enum
-    that controls the open and close state of the shutter.
+    """Implementation of fast shutter that connects to an epics enum pv. This controls
+    the open and close state of the shutter. This also has the lateral motor x.
 
     Args:
         pv (str): The pv to connect to the shutter device.

--- a/src/dodal/devices/detector/detector_motion.py
+++ b/src/dodal/devices/detector/detector_motion.py
@@ -1,13 +1,8 @@
-from ophyd_async.core import StrictEnum
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 from ophyd_async.epics.motor import Motor
 
+from dodal.common.enums import OpenClosed
 from dodal.devices.motors import XYZStage
-
-
-class ShutterState(StrictEnum):
-    CLOSED = "Closed"
-    OPEN = "Open"
 
 
 class DetectorMotion(XYZStage):
@@ -16,9 +11,7 @@ class DetectorMotion(XYZStage):
         self.downstream_x = Motor(f"{device_prefix}DOWNSTREAMX")
         self.yaw = Motor(f"{device_prefix}YAW")
 
-        self.shutter = epics_signal_rw(
-            ShutterState, f"{device_prefix}SET_SHUTTER_STATE"
-        )
+        self.shutter = epics_signal_rw(OpenClosed, f"{device_prefix}SET_SHUTTER_STATE")
         self.shutter_closed_lim = epics_signal_r(
             float, f"{device_prefix}CLOSE_LIMIT"
         )  # on limit = 1, off = 0

--- a/src/dodal/devices/insertion_device/__init__.py
+++ b/src/dodal/devices/insertion_device/__init__.py
@@ -27,7 +27,7 @@ from .energy_motor_lookup import (
     ConfigServerEnergyMotorLookup,
     EnergyMotorLookup,
 )
-from .enum import Pol, UndulatorGateStatus
+from .enum import Pol
 from .lookup_table_models import (
     EnergyCoverage,
     LookupTable,
@@ -60,7 +60,6 @@ __all__ = [
     "Pol",
     "DEFAULT_MOTOR_MIN_TIMEOUT",
     "EnabledDisabledUpper",
-    "UndulatorGateStatus",
     "Apple2LockedPhasesVal",
     "EnergyMotorLookup",
     "ConfigServerEnergyMotorLookup",

--- a/src/dodal/devices/insertion_device/apple2_undulator.py
+++ b/src/dodal/devices/insertion_device/apple2_undulator.py
@@ -23,8 +23,7 @@ from ophyd_async.core import (
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 from ophyd_async.epics.motor import Motor
 
-from dodal.common.enums import EnabledDisabledUpper
-from dodal.devices.insertion_device.enum import UndulatorGateStatus
+from dodal.common.enums import EnabledDisabledUpper, OpenClosed
 from dodal.log import LOGGER
 
 T = TypeVar("T")
@@ -71,7 +70,7 @@ class UndulatorBase(abc.ABC, Device, Generic[T]):
 
     def __init__(self, name: str = ""):
         # Gate keeper open when move is requested, closed when move is completed
-        self.gate: SignalR[UndulatorGateStatus]
+        self.gate: SignalR[OpenClosed]
         self.status: SignalR[EnabledDisabledUpper]
         super().__init__(name=name)
 
@@ -86,7 +85,7 @@ class UndulatorBase(abc.ABC, Device, Generic[T]):
     async def raise_if_cannot_move(self) -> None:
         if await self.status.get_value() is EnabledDisabledUpper.DISABLED:
             raise RuntimeError(f"{self.name} is DISABLED and cannot move.")
-        if await self.gate.get_value() is UndulatorGateStatus.OPEN:
+        if await self.gate.get_value() is OpenClosed.OPEN:
             raise RuntimeError(f"{self.name} is already in motion.")
 
 
@@ -97,7 +96,7 @@ class SafeUndulatorMover(StandardReadable, UndulatorBase, Generic[T]):
 
     def __init__(self, set_move: SignalW, prefix: str, name: str = ""):
         # Gate keeper open when move is requested, closed when move is completed
-        self.gate = epics_signal_r(UndulatorGateStatus, prefix + "BLGATE")
+        self.gate = epics_signal_r(OpenClosed, prefix + "BLGATE")
         self.status = epics_signal_r(EnabledDisabledUpper, prefix + "IDBLENA")
         self.set_move = set_move
         super().__init__(name)
@@ -110,7 +109,7 @@ class SafeUndulatorMover(StandardReadable, UndulatorBase, Generic[T]):
         timeout = await self.get_timeout()
         LOGGER.info(f"Moving {self.name} to {value} with timeout = {timeout}")
         await self.set_move.set(value=1, timeout=timeout)
-        await wait_for_value(self.gate, UndulatorGateStatus.CLOSE, timeout=timeout)
+        await wait_for_value(self.gate, OpenClosed.CLOSED, timeout=timeout)
 
 
 class UnstoppableMotor(Motor):
@@ -129,7 +128,7 @@ class GapSafeMotorNoStop(UnstoppableMotor, UndulatorBase[float]):
 
     def __init__(self, set_move: SignalW[int], prefix: str, name: str = ""):
         # Gate keeper open when move is requested, closed when move is completed
-        self.gate = epics_signal_r(UndulatorGateStatus, prefix + "BLGATE")
+        self.gate = epics_signal_r(OpenClosed, prefix + "BLGATE")
         self.status = epics_signal_r(EnabledDisabledUpper, prefix + "IDBLENA")
         self.set_move = set_move
         super().__init__(prefix=prefix + "BLGAPMTR", name=name)
@@ -153,7 +152,7 @@ class GapSafeMotorNoStop(UnstoppableMotor, UndulatorBase[float]):
 
         await self.set_move.set(value=1, timeout=timeout)
         move_status = AsyncStatus(
-            wait_for_value(self.gate, UndulatorGateStatus.CLOSE, timeout=timeout)
+            wait_for_value(self.gate, OpenClosed.CLOSED, timeout=timeout)
         )
 
         async for current_position in observe_value(
@@ -402,6 +401,4 @@ class Apple2(StandardReadable, Movable[Apple2Val], Generic[PhaseAxesType]):
             self.phase().set_move.set(value=1, timeout=timeout),
         )
 
-        await wait_for_value(
-            self.gap().gate, UndulatorGateStatus.CLOSE, timeout=timeout
-        )
+        await wait_for_value(self.gap().gate, OpenClosed.CLOSED, timeout=timeout)

--- a/src/dodal/devices/insertion_device/enum.py
+++ b/src/dodal/devices/insertion_device/enum.py
@@ -10,8 +10,3 @@ class Pol(StrictEnum):
     LA = "la"
     LH3 = "lh3"
     LV3 = "lv3"
-
-
-class UndulatorGateStatus(StrictEnum):
-    OPEN = "Open"
-    CLOSE = "Closed"

--- a/src/dodal/testing/fixtures/devices/apple2.py
+++ b/src/dodal/testing/fixtures/devices/apple2.py
@@ -7,10 +7,10 @@ from ophyd_async.core import (
     set_mock_value,
 )
 
+from dodal.common.enums import OpenClosed
 from dodal.devices.insertion_device import (
     EnabledDisabledUpper,
     UndulatorGap,
-    UndulatorGateStatus,
     UndulatorJawPhase,
     UndulatorPhaseAxes,
 )
@@ -40,7 +40,7 @@ async def mock_id_gap(prefix: str = "BLXX-EA-DET-007:") -> UndulatorGap:
     async with init_devices(mock=True):
         mock_id_gap = UndulatorGap(prefix, "mock_id_gap")
     assert mock_id_gap.name == "mock_id_gap"
-    set_mock_value(mock_id_gap.gate, UndulatorGateStatus.CLOSE)
+    set_mock_value(mock_id_gap.gate, OpenClosed.CLOSED)
     set_mock_value(mock_id_gap.velocity, 1)
     set_mock_value(mock_id_gap.user_readback, 1)
     set_mock_value(mock_id_gap.user_setpoint, "1")
@@ -59,7 +59,7 @@ async def mock_phase_axes(prefix: str = "BLXX-EA-DET-007:") -> UndulatorPhaseAxe
             btm_inner="RPQ4",
         )
     assert mock_phase_axes.name == "mock_phase_axes"
-    set_mock_value(mock_phase_axes.gate, UndulatorGateStatus.CLOSE)
+    set_mock_value(mock_phase_axes.gate, OpenClosed.CLOSED)
     set_mock_value(mock_phase_axes.top_outer.velocity, 2)
     set_mock_value(mock_phase_axes.top_inner.velocity, 2)
     set_mock_value(mock_phase_axes.btm_outer.velocity, 2)
@@ -74,7 +74,7 @@ async def mock_jaw_phase(prefix: str = "BLXX-EA-DET-007:") -> UndulatorJawPhase:
         mock_jaw_phase = UndulatorJawPhase(
             prefix=prefix, move_pv="RPQ1", jaw_phase="JAW"
         )
-    set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.CLOSE)
+    set_mock_value(mock_jaw_phase.gate, OpenClosed.CLOSED)
     set_mock_value(mock_jaw_phase.jaw_phase.velocity, 2)
     set_mock_value(mock_jaw_phase.jaw_phase.user_readback, 0)
     set_mock_value(mock_jaw_phase.jaw_phase.user_setpoint_readback, 0)
@@ -93,7 +93,7 @@ async def mock_locked_phase_axes(
             btm_inner="RPQ4",
         )
     assert mock_phase_axes.name == "mock_phase_axes"
-    set_mock_value(mock_phase_axes.gate, UndulatorGateStatus.CLOSE)
+    set_mock_value(mock_phase_axes.gate, OpenClosed.CLOSED)
     set_mock_value(mock_phase_axes.top_outer.velocity, 2)
     set_mock_value(mock_phase_axes.btm_inner.velocity, 2)
     set_mock_value(mock_phase_axes.top_outer.user_readback, 2)

--- a/tests/devices/beamlines/i10/test_i10_apple2.py
+++ b/tests/devices/beamlines/i10/test_i10_apple2.py
@@ -16,6 +16,7 @@ from ophyd_async.core import (
 )
 from ophyd_async.testing import assert_emitted
 
+from dodal.common.enums import OpenClosed
 from dodal.devices.beamlines.i10.i10_apple2 import (
     DEFAULT_JAW_PHASE_POLY_PARAMS,
     I10Apple2,
@@ -31,7 +32,6 @@ from dodal.devices.insertion_device import (
     InsertionDevicePolarisation,
     Pol,
     UndulatorGap,
-    UndulatorGateStatus,
     UndulatorJawPhase,
     UndulatorPhaseAxes,
 )
@@ -253,7 +253,7 @@ async def test_fail_i10_apple2_controller_set_id_not_ready(
     set_mock_value(
         mock_id_controller.apple2().gap().status, EnabledDisabledUpper.ENABLED
     )
-    set_mock_value(mock_id_controller.apple2().gap().gate, UndulatorGateStatus.OPEN)
+    set_mock_value(mock_id_controller.apple2().gap().gate, OpenClosed.OPEN)
     with pytest.raises(RuntimeError) as e:
         await mock_id_controller.energy.set(600)
     assert (
@@ -629,11 +629,11 @@ async def test_linear_arbitrary_run_engine_scan(
     assert_emitted(run_engine_documents, start=1, descriptor=1, event=num_point, stop=1)
     set_mock_value(
         mock_id_controller.apple2().gap().gate,
-        UndulatorGateStatus.CLOSE,
+        OpenClosed.CLOSED,
     )
     set_mock_value(
         mock_id_controller.apple2().phase().gate,
-        UndulatorGateStatus.CLOSE,
+        OpenClosed.CLOSED,
     )
     jaw_phase = get_mock_put(
         mock_id_controller.apple2().jaw_phase().jaw_phase.user_setpoint

--- a/tests/devices/beamlines/i21/test_fast_shutter.py
+++ b/tests/devices/beamlines/i21/test_fast_shutter.py
@@ -1,0 +1,27 @@
+import pytest
+from ophyd_async.core import init_devices
+from ophyd_async.testing import assert_reading, partial_reading
+
+from dodal.common.enums import OpenClosed
+from dodal.devices.beamlines.i21 import FastShutterWithLateralMotor
+
+
+@pytest.fixture
+def fs_with_lateral_motor() -> FastShutterWithLateralMotor:
+    with init_devices(mock=True):
+        fs_with_lateral_motor = FastShutterWithLateralMotor[OpenClosed](
+            "TESt", open_state=OpenClosed.OPEN, close_state=OpenClosed.CLOSED
+        )
+    return fs_with_lateral_motor
+
+
+async def test_fs_with_lateral_motor_read(
+    fs_with_lateral_motor: FastShutterWithLateralMotor,
+) -> None:
+    await assert_reading(
+        fs_with_lateral_motor,
+        {
+            "fs_with_lateral_motor-shutter_state": partial_reading(OpenClosed.OPEN),
+            "fs_with_lateral_motor-x": partial_reading(0),
+        },
+    )

--- a/tests/devices/insertion_device/test_apple2_controller.py
+++ b/tests/devices/insertion_device/test_apple2_controller.py
@@ -6,6 +6,7 @@ from ophyd_async.core import (
     set_mock_value,
 )
 
+from dodal.common.enums import OpenClosed
 from dodal.devices.insertion_device import (
     Apple2,
     Apple2Controller,
@@ -14,7 +15,6 @@ from dodal.devices.insertion_device import (
     EnabledDisabledUpper,
     EnergyMotorConvertor,
     Pol,
-    UndulatorGateStatus,
     UndulatorLockedPhaseAxes,
 )
 
@@ -34,7 +34,7 @@ async def mock_locked_phase_axes(
             btm_inner="RPQ4",
         )
     assert mock_phase_axes.name == "mock_phase_axes"
-    set_mock_value(mock_phase_axes.gate, UndulatorGateStatus.CLOSE)
+    set_mock_value(mock_phase_axes.gate, OpenClosed.CLOSED)
     set_mock_value(mock_phase_axes.top_outer.velocity, 2)
     set_mock_value(mock_phase_axes.btm_inner.velocity, 2)
     set_mock_value(mock_phase_axes.top_outer.user_readback, 2)

--- a/tests/devices/insertion_device/test_apple2_undulator.py
+++ b/tests/devices/insertion_device/test_apple2_undulator.py
@@ -19,6 +19,7 @@ from ophyd_async.testing import (
     partial_reading,
 )
 
+from dodal.common.enums import OpenClosed
 from dodal.devices.insertion_device import (
     DEFAULT_MOTOR_MIN_TIMEOUT,
     Apple2,
@@ -30,7 +31,6 @@ from dodal.devices.insertion_device import (
     EnergyMotorConvertor,
     Pol,
     UndulatorGap,
-    UndulatorGateStatus,
     UndulatorJawPhase,
     UndulatorLockedPhaseAxes,
     UndulatorPhaseAxes,
@@ -60,14 +60,14 @@ async def test_in_motion_error(
     mock_phase_axes: UndulatorPhaseAxes,
     mock_jaw_phase: UndulatorJawPhase,
 ):
-    set_mock_value(mock_id_gap.gate, UndulatorGateStatus.OPEN)
+    set_mock_value(mock_id_gap.gate, OpenClosed.OPEN)
     with pytest.raises(RuntimeError):
         await mock_id_gap.set(2)
-    set_mock_value(mock_phase_axes.gate, UndulatorGateStatus.OPEN)
+    set_mock_value(mock_phase_axes.gate, OpenClosed.OPEN)
     set_value = Apple2PhasesVal(3, 2, 5, 7)
     with pytest.raises(RuntimeError):
         await mock_phase_axes.set(set_value)
-    set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.OPEN)
+    set_mock_value(mock_jaw_phase.gate, OpenClosed.OPEN)
     with pytest.raises(RuntimeError):
         await mock_jaw_phase.set(2)
 
@@ -99,7 +99,7 @@ async def test_given_gate_never_closes_then_setting_gaps_times_out(
 ):
     callback_on_mock_put(
         mock_id_gap.user_setpoint,
-        lambda *_, **__: set_mock_value(mock_id_gap.gate, UndulatorGateStatus.OPEN),
+        lambda *_, **__: set_mock_value(mock_id_gap.gate, OpenClosed.OPEN),
     )
     mock_id_gap.get_timeout = AsyncMock(return_value=0.002)
 
@@ -120,7 +120,7 @@ async def test_gap_success_scan(
 ):
     callback_on_mock_put(
         mock_id_gap.user_setpoint,
-        lambda *_, **__: set_mock_value(mock_id_gap.gate, UndulatorGateStatus.OPEN),
+        lambda *_, **__: set_mock_value(mock_id_gap.gate, OpenClosed.OPEN),
     )
     output = range(0, 11, 1)
 
@@ -131,7 +131,7 @@ async def test_gap_success_scan(
 
     def set_complete_move():
         set_mock_value(mock_id_gap.user_readback, next(pos))
-        set_mock_value(mock_id_gap.gate, UndulatorGateStatus.CLOSE)
+        set_mock_value(mock_id_gap.gate, OpenClosed.CLOSED)
 
     callback_on_mock_put(mock_id_gap.set_move, lambda *_, **__: set_complete_move())
 
@@ -148,7 +148,7 @@ async def test_given_gate_never_closes_then_setting_phases_times_out(
 
     callback_on_mock_put(
         mock_phase_axes.top_outer.user_setpoint,
-        lambda *_, **__: set_mock_value(mock_phase_axes.gate, UndulatorGateStatus.OPEN),
+        lambda *_, **__: set_mock_value(mock_phase_axes.gate, OpenClosed.OPEN),
     )
     mock_phase_axes.get_timeout = AsyncMock(return_value=0.002)
     with pytest.raises(TimeoutError):
@@ -259,7 +259,7 @@ async def test_phase_success_set(
     set_value = Apple2PhasesVal(top_inner=3, top_outer=2, btm_inner=5, btm_outer=7)
     callback_on_mock_put(
         mock_phase_axes.top_inner.user_setpoint,
-        lambda *_, **__: set_mock_value(mock_phase_axes.gate, UndulatorGateStatus.OPEN),
+        lambda *_, **__: set_mock_value(mock_phase_axes.gate, OpenClosed.OPEN),
     )
 
     def set_complete_move():
@@ -279,7 +279,7 @@ async def test_phase_success_set(
             mock_phase_axes.btm_outer.user_readback,
             7,
         )
-        set_mock_value(mock_phase_axes.gate, UndulatorGateStatus.CLOSE)
+        set_mock_value(mock_phase_axes.gate, OpenClosed.CLOSED)
 
     callback_on_mock_put(mock_phase_axes.set_move, lambda *_, **__: set_complete_move())
     run_engine(bps.abs_set(mock_phase_axes, set_value, wait=True))
@@ -313,7 +313,7 @@ async def test_given_gate_never_closes_then_setting_jaw_phases_times_out(
 ):
     callback_on_mock_put(
         mock_jaw_phase.jaw_phase.user_setpoint,
-        lambda *_, **__: set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.OPEN),
+        lambda *_, **__: set_mock_value(mock_jaw_phase.gate, OpenClosed.OPEN),
     )
     mock_jaw_phase.get_timeout = AsyncMock(return_value=0.002)
     with pytest.raises(TimeoutError):
@@ -358,7 +358,7 @@ async def test_jaw_phase_success_scan(
 ):
     callback_on_mock_put(
         mock_jaw_phase.jaw_phase.user_setpoint,
-        lambda *_, **__: set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.OPEN),
+        lambda *_, **__: set_mock_value(mock_jaw_phase.gate, OpenClosed.OPEN),
     )
     output = range(0, 11, 1)
 
@@ -369,7 +369,7 @@ async def test_jaw_phase_success_scan(
 
     def set_complete_move():
         set_mock_value(mock_jaw_phase.jaw_phase.user_readback, next(pos))
-        set_mock_value(mock_jaw_phase.gate, UndulatorGateStatus.CLOSE)
+        set_mock_value(mock_jaw_phase.gate, OpenClosed.CLOSED)
 
     callback_on_mock_put(mock_jaw_phase.set_move, lambda *_, **__: set_complete_move())
 

--- a/tests/devices/insertion_device/test_energy.py
+++ b/tests/devices/insertion_device/test_energy.py
@@ -14,13 +14,13 @@ from ophyd_async.core import (
     wait_for_value,
 )
 
+from dodal.common.enums import OpenClosed
 from dodal.devices.insertion_device import (
     MAXIMUM_MOVE_TIME,
     BeamEnergy,
     InsertionDeviceEnergy,
     Pol,
     UndulatorGap,
-    UndulatorGateStatus,
 )
 from dodal.devices.pgm import PlaneGratingMonochromator
 
@@ -84,7 +84,7 @@ async def test_insertion_device_energy_prepare_success(
     set_mock_value(mock_id_controller.apple2().gap().min_velocity, 1)
     set_mock_value(mock_id_controller.apple2().gap().low_limit_travel, 0)
     set_mock_value(mock_id_controller.apple2().gap().high_limit_travel, 200)
-    set_mock_value(mock_id_controller.apple2().gap().gate, UndulatorGateStatus.CLOSE)
+    set_mock_value(mock_id_controller.apple2().gap().gate, OpenClosed.CLOSED)
     set_mock_value(
         mock_id_controller.apple2().gap().acceleration_time, acceleration_time
     )
@@ -173,7 +173,7 @@ async def test_beam_energy_kickoff_set_correct_delay(
     set_mock_value(mock_pgm.energy.low_limit_travel, 0)
     set_mock_value(mock_pgm.energy.high_limit_travel, 1000)
     set_mock_value(mock_pgm.energy.acceleration_time, pgm_acc_time)
-    set_mock_value(mock_id_gap.gate, UndulatorGateStatus.CLOSE)
+    set_mock_value(mock_id_gap.gate, OpenClosed.CLOSED)
     mock_id_gap.kickoff = AsyncMock()
     mock_pgm.energy.kickoff = AsyncMock()
     await mock_beam_energy.prepare(fly_info)


### PR DESCRIPTION
Added fastshutter to i21. Extended base to add the additional motor that i21 requires. Updated existing classes to reuse the same enum `OpenClosed`

### Instructions to reviewer on how to test:
1. Check dodal connect
2. Check tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
