### PR TITLE
Configure the config server via an environment variable

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -1,4 +1,5 @@
 from functools import cache
+from os import getenv
 
 from daq_config_server import ConfigClient
 from ophyd_async.core import PathProvider, Reference
@@ -72,7 +73,7 @@ BEAMLINE_PARAMETERS_PATH = (
     "/dls_sw/i03/software/daq_configuration/domain/beamlineParameters"
 )
 DAQ_CONFIGURATION_PATH = "/dls_sw/i03/software/daq_configuration"
-I03_CONFIG_SERVER_ENDPOINT = "https://i03-daq-config.diamond.ac.uk"
+DEFAULT_CONFIG_SERVER_ENDPOINT = "https://i03-daq-config.diamond.ac.uk"
 
 BL = get_beamline_name("i03")
 set_log_beamline(BL)
@@ -99,7 +100,8 @@ def path_provider() -> PathProvider:
 @devices.fixture
 @cache
 def config_client() -> ConfigClient:
-    client = ConfigClient(I03_CONFIG_SERVER_ENDPOINT)
+    config_server_url = getenv("CONFIG_SERVER_URL", DEFAULT_CONFIG_SERVER_ENDPOINT)
+    client = ConfigClient(config_server_url)
     set_config_client(client)
     return client
 


### PR DESCRIPTION
Required in order to fix the mx-bluesky system tests, since the config server needs to be configurable in order to point against the system test daq-config-server.

See also mx-bluesky PR 
* DiamondLightSource/mx-bluesky#1698

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
