### PR TITLE
Instantiate serial stages on i19-2

### DIFF
--- a/src/dodal/beamlines/i19_2.py
+++ b/src/dodal/beamlines/i19_2.py
@@ -25,6 +25,7 @@ from dodal.devices.beamlines.i19.backlight import BacklightPosition
 from dodal.devices.beamlines.i19.beamstop import BeamStop
 from dodal.devices.beamlines.i19.diffractometer import FourCircleDiffractometer
 from dodal.devices.beamlines.i19.pin_col_stages import PinholeCollimatorControl
+from dodal.devices.motors import XYZPhiStage
 from dodal.devices.synchrotron import Synchrotron
 from dodal.devices.zebra.zebra import Zebra
 from dodal.devices.zebra.zebra_constants_mapping import (
@@ -105,6 +106,11 @@ def panda(path_provider: PathProvider) -> HDFPanda:
 @devices.factory()
 def pinhole_and_collimator() -> PinholeCollimatorControl:
     return PinholeCollimatorControl(prefix=PREFIX.beamline_prefix)
+
+
+@devices.factory()
+def serial_stages() -> XYZPhiStage:
+    return XYZPhiStage(prefix=f"{PREFIX.beamline_prefix}-MO-SRL-01:")
 
 
 @devices.factory()

--- a/src/dodal/devices/motors.py
+++ b/src/dodal/devices/motors.py
@@ -20,6 +20,7 @@ _Y = "Y"
 _Z = "Z"
 
 _OMEGA = "OMEGA"
+_PHI = "PHI"
 _POLAR = "POLAR"
 _AZIMUTH = "AZIMUTH"
 _TILT = "TILT"
@@ -81,6 +82,23 @@ class XYZStage(XYStage):
         with self.add_children_as_readables():
             self.z = Motor(prefix + z_infix)
         super().__init__(prefix, name, x_infix, y_infix)
+
+
+class XYZPhiStage(XYZStage):
+    """Four-axis stage with a standard xyz stage and one axis of rotation: phi."""
+
+    def __init__(
+        self,
+        prefix: str,
+        name: str = "",
+        x_infix: str = _X,
+        y_infix: str = _Y,
+        z_infix: str = _Z,
+        phi_infix: str = _PHI,
+    ) -> None:
+        with self.add_children_as_readables():
+            self.phi = Motor(prefix + phi_infix)
+        super().__init__(prefix, name, x_infix, y_infix, z_infix)
 
 
 class XYZThetaStage(XYZStage):
@@ -205,7 +223,7 @@ class XYPhiStage(XYStage):
         prefix: str,
         x_infix: str = _X,
         y_infix: str = _Y,
-        phi_infix: str = "PHI",
+        phi_infix: str = _PHI,
         name: str = "",
     ) -> None:
         with self.add_children_as_readables():
@@ -302,7 +320,7 @@ class SixAxisGonio(XYZOmegaStage):
         y_infix: str = _Y,
         z_infix: str = _Z,
         kappa_infix: str = "KAPPA",
-        phi_infix: str = "PHI",
+        phi_infix: str = _PHI,
         omega_infix: str = _OMEGA,
     ):
         with self.add_children_as_readables():
@@ -328,7 +346,7 @@ class SixAxisGonioKappaPhi(XYZStage):
         y_infix: str = _Y,
         z_infix: str = _Z,
         kappa_infix: str = "KAPPA",
-        phi_infix: str = "PHI",
+        phi_infix: str = _PHI,
     ):
         with self.add_children_as_readables():
             self.kappa = Motor(prefix + kappa_infix)

--- a/tests/devices/test_motors.py
+++ b/tests/devices/test_motors.py
@@ -12,9 +12,17 @@ from dodal.devices.motors import (
     XYZAzimuthStage,
     XYZAzimuthTiltPolarStage,
     XYZAzimuthTiltStage,
+    XYZPhiStage,
     XYZPitchYawRollStage,
     XYZThetaStage,
 )
+
+
+@pytest.fixture
+async def xyzp_stage() -> XYZPhiStage:
+    async with init_devices(mock=True):
+        xyzp_stage = XYZPhiStage("")
+    return xyzp_stage
 
 
 @pytest.fixture
@@ -118,6 +126,35 @@ async def test_setting_xyztheta_position_table(xyzt_stage: XYZThetaStage):
             "xyzt_stage-y": partial_reading(4.56),
             "xyzt_stage-z": partial_reading(7.89),
             "xyzt_stage-theta": partial_reading(10.11),
+        },
+    )
+
+
+async def test_setting_xyzphi_position_table(xyzp_stage: XYZPhiStage):
+    """Test setting x,y,z,phi positions on the Table using the ophyd_async mock tools."""
+    await assert_reading(
+        xyzp_stage,
+        {
+            "xyzp_stage-x": partial_reading(0.0),
+            "xyzp_stage-y": partial_reading(0.0),
+            "xyzp_stage-z": partial_reading(0.0),
+            "xyzp_stage-phi": partial_reading(0.0),
+        },
+    )
+
+    # Call set to update the position
+    set_mock_value(xyzp_stage.x.user_readback, 1.23)
+    set_mock_value(xyzp_stage.y.user_readback, 4.56)
+    set_mock_value(xyzp_stage.z.user_readback, 7.89)
+    set_mock_value(xyzp_stage.phi.user_readback, 10.11)
+
+    await assert_reading(
+        xyzp_stage,
+        {
+            "xyzp_stage-x": partial_reading(1.23),
+            "xyzp_stage-y": partial_reading(4.56),
+            "xyzp_stage-z": partial_reading(7.89),
+            "xyzp_stage-phi": partial_reading(10.11),
         },
     )
 


### PR DESCRIPTION
Fixes #2010 

### Instructions to reviewer on how to test:
1. Run dodal connect i19-2
2. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
