### PR TITLE
Skip devices expected to be off

### DIFF
--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -65,7 +65,7 @@ def bs2() -> XYStage:
     return XYStage(f"{PREFIX.beamline_prefix}-MO-SMAR-02:")
 
 
-@devices.factory()
+@devices.factory(skip=True)
 def clean() -> XYStage:
     return XYStage(f"{PREFIX.beamline_prefix}-MO-ABSB-01:CLEAN:")
 
@@ -117,7 +117,7 @@ def sam() -> XYPhiStage:
     return XYPhiStage(f"{PREFIX.beamline_prefix}-MO-TABLE-01:SAMPLE:", phi_infix="PHI2")
 
 
-@devices.factory()
+@devices.factory(skip=True)
 def slits_1() -> Slits:
     return Slits(
         prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-01:",
@@ -177,7 +177,7 @@ def trans() -> XYPhiStage:
     return XYPhiStage(prefix=f"{PREFIX.beamline_prefix}-MO-TABLE-01:TRANS:")
 
 
-@devices.factory()
+@devices.factory(skip=True)
 def xtal() -> LaueMonochrometer:
     return LaueMonochrometer(prefix=f"{PREFIX.beamline_prefix}-OP-LAUE-01:")
 

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -65,7 +65,7 @@ def bs2() -> XYStage:
     return XYStage(f"{PREFIX.beamline_prefix}-MO-SMAR-02:")
 
 
-@devices.factory(skip=True)
+@devices.factory(skip=True)  # Currently turned off due to work on the beamline
 def clean() -> XYStage:
     return XYStage(f"{PREFIX.beamline_prefix}-MO-ABSB-01:CLEAN:")
 
@@ -117,7 +117,7 @@ def sam() -> XYPhiStage:
     return XYPhiStage(f"{PREFIX.beamline_prefix}-MO-TABLE-01:SAMPLE:", phi_infix="PHI2")
 
 
-@devices.factory(skip=True)
+@devices.factory(skip=True)  # Currently turned off due to work on the beamline
 def slits_1() -> Slits:
     return Slits(
         prefix=f"{PREFIX.beamline_prefix}-AL-SLITS-01:",
@@ -177,7 +177,7 @@ def trans() -> XYPhiStage:
     return XYPhiStage(prefix=f"{PREFIX.beamline_prefix}-MO-TABLE-01:TRANS:")
 
 
-@devices.factory(skip=True)
+@devices.factory(skip=True)  # Currently turned off due to work on the beamline
 def xtal() -> LaueMonochrometer:
     return LaueMonochrometer(prefix=f"{PREFIX.beamline_prefix}-OP-LAUE-01:")
 


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/crystallography-bluesky/issues/30
Skips devices that we expect to be off. Attenuator is not off but is currently broken.

### Instructions to reviewer on how to test:
1. Do `dodal connect i15_1`
2. Confirm all devices connect other than attenuator
3. checkout main, do another `dodal connect i15_1`
4. Confirm the devices skipped in this PR don't connect (`clean`, `slits_1`, `xtal`)

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
