### PR TITLE
i15-1: add goniometer interlock 

### DIFF
--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -7,6 +7,7 @@ from dodal.devices.beamlines.i15.motors import NumberedTripleAxisStage
 from dodal.devices.beamlines.i15.multilayer_mirror import MultiLayerMirror
 from dodal.devices.beamlines.i15.rail import Rail
 from dodal.devices.beamlines.i15_1.attenuator import Attenuator
+from dodal.devices.beamlines.i15_1.gonio_interlock import GonioInterlock
 from dodal.devices.beamlines.i15_1.puck_detector import PuckDetect
 from dodal.devices.beamlines.i15_1.robot import Robot
 from dodal.devices.hutch_shutter import (
@@ -212,4 +213,11 @@ def hutch_shutter() -> InterlockedHutchShutter:
         interlock=PLCShutterInterlock(
             bl_prefix=PREFIX.beamline_prefix, interlock_suffix="-PS-SHTR-01:ILKSTA"
         ),
+    )
+
+
+@devices.factory()
+def gonio_interlock() -> GonioInterlock:
+    return GonioInterlock(
+        bl_prefix=PREFIX.beamline_prefix, interlock_suffix="-VA-OMRON-01:INT3:ILK"
     )

--- a/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
+++ b/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
@@ -24,6 +24,10 @@ class GonioInterlock(BaseHutchInterlock):
         )
 
     async def shutter_safe_to_operate(self) -> bool:
-        """Description."""
+        """Check device is safe to operate.
+
+        If the status value is not 65535 (healhty), the interlock has been tripped and
+        the device cannot be operated.
+        """
         interlock_state = await self.status.get_value()
         return isclose(float(interlock_state), GONIO_SAFE_FOR_OPERATIONS, abs_tol=5e-2)

--- a/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
+++ b/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
@@ -1,5 +1,7 @@
 from math import isclose
 
+from ophyd_async.core import EnumTypes
+
 from dodal.devices.hutch_shutter import BaseHutchInterlock
 
 GONIO_SAFE_FOR_OPERATIONS = 65535  # All 16 bits are true
@@ -23,11 +25,10 @@ class GonioInterlock(BaseHutchInterlock):
             name=name,
         )
 
-    async def shutter_safe_to_operate(self) -> bool:
+    def _safe_to_operate(self, status: float | EnumTypes) -> bool:
         """Check device is safe to operate.
 
         If the status value is not 65535 (healhty), the interlock has been tripped and
         the device cannot be operated.
         """
-        interlock_state = await self.status.get_value()
-        return isclose(float(interlock_state), GONIO_SAFE_FOR_OPERATIONS, abs_tol=5e-2)
+        return isclose(float(status), GONIO_SAFE_FOR_OPERATIONS, abs_tol=5e-2)

--- a/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
+++ b/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
@@ -1,0 +1,31 @@
+from math import isclose
+
+from dodal.devices.hutch_shutter import BaseHutchInterlock
+
+# TODO: Make this the right number
+GONIO_SAFE_FOR_OPERATIONS = 65535
+# GONIO_SAFE_FOR_OPERATIONS = 65439
+
+
+class GonioInterlock(BaseHutchInterlock):
+    """Device to check if the air is on for the goniometer air bearing."""
+
+    def __init__(
+        self,
+        bl_prefix: str,
+        shtr_infix: str = "",
+        interlock_suffix: str = "",
+        name: str = "",
+    ) -> None:
+        super().__init__(
+            signal_type=int,
+            bl_prefix=bl_prefix,
+            interlock_infix=shtr_infix,
+            interlock_suffix=interlock_suffix,
+            name=name,
+        )
+
+    async def shutter_safe_to_operate(self) -> bool:
+        """Description."""
+        interlock_state = await self.status.get_value()
+        return isclose(float(interlock_state), GONIO_SAFE_FOR_OPERATIONS, abs_tol=5e-2)

--- a/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
+++ b/src/dodal/devices/beamlines/i15_1/gonio_interlock.py
@@ -2,13 +2,11 @@ from math import isclose
 
 from dodal.devices.hutch_shutter import BaseHutchInterlock
 
-# TODO: Make this the right number
-GONIO_SAFE_FOR_OPERATIONS = 65535
-# GONIO_SAFE_FOR_OPERATIONS = 65439
+GONIO_SAFE_FOR_OPERATIONS = 65535  # All 16 bits are true
 
 
 class GonioInterlock(BaseHutchInterlock):
-    """Device to check if the air is on for the goniometer air bearing."""
+    """Device to check the state of the goniometer interlock."""
 
     def __init__(
         self,

--- a/tests/devices/beamlines/i15_1/test_gonio_interlock.py
+++ b/tests/devices/beamlines/i15_1/test_gonio_interlock.py
@@ -1,0 +1,33 @@
+import pytest
+from ophyd_async.core import init_devices, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading
+
+from dodal.devices.beamlines.i15_1.gonio_interlock import GonioInterlock
+
+
+@pytest.fixture
+async def interlock() -> GonioInterlock:
+    async with init_devices(mock=True):
+        interlock = GonioInterlock(bl_prefix="TEST")
+    return interlock
+
+
+async def test_interlock_is_readable(interlock: GonioInterlock):
+    await assert_reading(interlock, {f"{interlock.name}-status": partial_reading(0.0)})
+
+
+# TODO: fix these numbers to be real
+@pytest.mark.parametrize(
+    "readback, expected_state",
+    [
+        (65435, True),
+        (65440, False),
+    ],
+)
+async def test_interlock_safe_to_operate_logic(
+    interlock: GonioInterlock,
+    readback: float,
+    expected_state: bool,
+):
+    set_mock_value(interlock.status, readback)
+    assert await interlock.shutter_safe_to_operate() is expected_state

--- a/tests/devices/beamlines/i15_1/test_gonio_interlock.py
+++ b/tests/devices/beamlines/i15_1/test_gonio_interlock.py
@@ -16,7 +16,6 @@ async def test_interlock_is_readable(interlock: GonioInterlock):
     await assert_reading(interlock, {f"{interlock.name}-status": partial_reading(0.0)})
 
 
-# TODO: fix these numbers to be real
 @pytest.mark.parametrize(
     "readback, expected_state",
     [

--- a/tests/devices/beamlines/i15_1/test_gonio_interlock.py
+++ b/tests/devices/beamlines/i15_1/test_gonio_interlock.py
@@ -13,7 +13,14 @@ async def interlock() -> GonioInterlock:
 
 
 async def test_interlock_is_readable(interlock: GonioInterlock):
-    await assert_reading(interlock, {f"{interlock.name}-status": partial_reading(0.0)})
+    set_mock_value(interlock.status, 65535)
+    await assert_reading(
+        interlock,
+        {
+            f"{interlock.name}-is_safe": partial_reading(True),
+            f"{interlock.name}-status": partial_reading(65535),
+        },
+    )
 
 
 @pytest.mark.parametrize(
@@ -29,4 +36,4 @@ async def test_interlock_safe_to_operate_logic(
     expected_state: bool,
 ):
     set_mock_value(interlock.status, readback)
-    assert await interlock.shutter_safe_to_operate() is expected_state
+    assert await interlock.is_safe.get_value() is expected_state

--- a/tests/devices/beamlines/i15_1/test_gonio_interlock.py
+++ b/tests/devices/beamlines/i15_1/test_gonio_interlock.py
@@ -20,7 +20,7 @@ async def test_interlock_is_readable(interlock: GonioInterlock):
 @pytest.mark.parametrize(
     "readback, expected_state",
     [
-        (65435, True),
+        (65535, True),
         (65440, False),
     ],
 )


### PR DESCRIPTION
Fixes crystallography_bluesky [#26](https://github.com/DiamondLightSource/crystallography-bluesky/issues/26)

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
