### PR TITLE
Add a derived signal so that plans can read the interlock state

### DIFF
--- a/src/dodal/devices/hutch_shutter.py
+++ b/src/dodal/devices/hutch_shutter.py
@@ -8,7 +8,9 @@ from ophyd_async.core import (
     EnumTypes,
     SignalR,
     StandardReadable,
+    StandardReadableFormat,
     StrictEnum,
+    derived_signal_r,
     wait_for_value,
 )
 from ophyd_async.epics.core import epics_signal_r, epics_signal_w
@@ -63,12 +65,19 @@ class BaseHutchInterlock(ABC, StandardReadable):
         name: str = "",
     ) -> None:
         pv_address = f"{bl_prefix}{interlock_infix}{interlock_suffix}"
+
         with self.add_children_as_readables():
             self.status = epics_signal_r(signal_type, pv_address)
+
+        with self.add_children_as_readables(StandardReadableFormat.HINTED_SIGNAL):
+            self.is_safe = derived_signal_r(
+                self._safe_to_operate,
+                status=self.status,
+            )
         super().__init__(name)
 
     @abstractmethod
-    async def shutter_safe_to_operate(self) -> bool:
+    def _safe_to_operate(self, status: float | EnumTypes) -> bool:
         """Abstract method to define if interlock allows shutter to operate."""
 
 
@@ -90,16 +99,13 @@ class HutchInterlock(BaseHutchInterlock):
             name=name,
         )
 
-    # TODO replace with read
-    # See https://github.com/DiamondLightSource/dodal/issues/651
-    async def shutter_safe_to_operate(self) -> bool:
+    def _safe_to_operate(self, status: float | EnumTypes) -> bool:
         """If the status value is 0, hutch has been searched and locked and it is safe \
         to operate the shutter.
         If the status value is not 0 (usually set to 7), the hutch is open and the \
         shutter should not be in use.
         """
-        interlock_state = await self.status.get_value()
-        return isclose(float(interlock_state), HUTCH_SAFE_FOR_OPERATIONS, abs_tol=5e-2)
+        return isclose(float(status), HUTCH_SAFE_FOR_OPERATIONS, abs_tol=5e-2)
 
 
 class PLCShutterInterlock(BaseHutchInterlock):
@@ -120,9 +126,7 @@ class PLCShutterInterlock(BaseHutchInterlock):
             name=name,
         )
 
-    # TODO replace with read
-    # See https://github.com/DiamondLightSource/dodal/issues/651
-    async def shutter_safe_to_operate(self) -> bool:
+    def _safe_to_operate(self, status: float | EnumTypes) -> bool:
         """If the status value is OK or Run Ilk OK, shutter is open or safe to operate.
 
         If the status value is "OK", valve or shutter is open and interlocks are OK to
@@ -131,10 +135,7 @@ class PLCShutterInterlock(BaseHutchInterlock):
         failed and the shutter cannot be operated. Disarmed status applies only to fast
         shutters.
         """
-        interlock_state = await self.status.get_value()
-        return (interlock_state == InterlockState.OK) | (
-            interlock_state == InterlockState.RUN_ILKS_OK
-        )
+        return (status == InterlockState.OK) | (status == InterlockState.RUN_ILKS_OK)
 
 
 class BaseHutchShutter(ABC, StandardReadable, Movable[ShutterDemand]):
@@ -249,7 +250,7 @@ class InterlockedHutchShutter(BaseHutchShutter):
         Raises:
              ShutterNotSafeToOperateError - whereby an unhappy interlock will veto any attempt to open the shutter.
         """
-        interlock_state = await self.interlock.shutter_safe_to_operate()
+        interlock_state = await self.interlock.is_safe.get_value()
         if not interlock_state:
             raise ShutterNotSafeToOperateError(
                 "The hutch has not been locked, not operating shutter."

--- a/tests/devices/test_hutch_shutter.py
+++ b/tests/devices/test_hutch_shutter.py
@@ -103,6 +103,7 @@ async def test_interlock_is_readable(interlock: HutchInterlock):
     await assert_reading(
         interlock,
         {
+            f"{interlock.name}-is_safe": partial_reading(True),
             f"{interlock.name}-status": partial_reading(0.0),
         },
     )
@@ -112,6 +113,7 @@ async def test_plc_interlock_is_readable(plc_interlock: PLCShutterInterlock):
     await assert_reading(
         plc_interlock,
         {
+            f"{interlock.name}-is_safe": partial_reading(False),
             f"{plc_interlock.name}-status": partial_reading(InterlockState.FAILED),
         },
     )
@@ -131,7 +133,7 @@ async def test_hutch_interlock_safe_to_operate_logic(
     expected_state: bool,
 ):
     set_mock_value(interlock.status, readback)
-    assert await interlock.shutter_safe_to_operate() is expected_state
+    assert await interlock.is_safe.get_value() is expected_state
 
 
 @pytest.mark.parametrize(
@@ -149,7 +151,7 @@ async def test_plc_shutter_interlock_safe_to_operate_logic(
     expected_state: bool,
 ):
     set_mock_value(plc_interlock.status, readback)
-    assert await plc_interlock.shutter_safe_to_operate() is expected_state
+    assert await plc_interlock.is_safe.get_value() is expected_state
 
 
 async def test_shutter_readable(fake_shutter_without_interlock: HutchShutter):
@@ -182,7 +184,7 @@ async def test_interlocked_shutter_raises_error_on_open_if_hutch_not_locked(
     interlock: HutchInterlock,
 ):
     set_mock_value(interlock.status, 1)  # hutch is unlocked
-    assert await interlock.shutter_safe_to_operate() is False
+    assert await interlock.is_safe.get_value() is False
 
     with pytest.raises(ShutterNotSafeToOperateError):
         await fake_interlocked_shutter.set(ShutterDemand.OPEN)
@@ -193,7 +195,7 @@ async def test_interlocked_shutter_does_not_error_on_close_even_if_hutch_not_loc
     interlock: HutchInterlock,
 ):
     set_mock_value(interlock.status, 1)  # hutch is unlocked
-    assert await interlock.shutter_safe_to_operate() is False
+    assert await interlock.is_safe.get_value() is False
 
     await fake_interlocked_shutter.set(ShutterDemand.CLOSE)
 

--- a/tests/devices/test_hutch_shutter.py
+++ b/tests/devices/test_hutch_shutter.py
@@ -171,6 +171,7 @@ async def test_interlocked_shutter_readable(
 ):
     result = {
         f"{fake_interlocked_shutter.name}-status": partial_reading(ShutterState.FAULT),
+        f"{fake_interlocked_shutter.interlock.name}-is_safe": partial_reading(True),
     }
     result[f"{fake_interlocked_shutter.interlock.name}-status"] = partial_reading(0.0)
     await assert_reading(


### PR DESCRIPTION
Fixes #651

### Instructions to reviewer on how to test:
1. Confirm tests still pass
2. Confirm a plan can now read the interlock status directly

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
