### PR TITLE
Handle timeout error when turning off spinner for robot unload

### DIFF
--- a/src/dodal/devices/beamlines/i15_1/robot.py
+++ b/src/dodal/devices/beamlines/i15_1/robot.py
@@ -24,6 +24,8 @@ from ophyd_async.epics.core import (
     epics_signal_x,
 )
 
+from dodal.log import LOGGER
+
 
 @dataclass
 class SampleLocation:
@@ -202,8 +204,9 @@ class Robot(StandardReadable, Movable[SampleLocation]):
         # https://jira.diamond.ac.uk/browse/I15_1-1540
         try:
             await self._trigger_program_and_wait_for_complete(self.spinner_off)
-        except TimeoutError:
-            # Spinner is already off.
+        except TimeoutError as e:
+            # Assume spinner is already off.
+            LOGGER.warning(f"Assuming spinner is off, ignoring TimeoutError: {e}")
             pass
 
         await self._load_program_and_wait_for_loaded(

--- a/src/dodal/devices/beamlines/i15_1/robot.py
+++ b/src/dodal/devices/beamlines/i15_1/robot.py
@@ -198,7 +198,13 @@ class Robot(StandardReadable, Movable[SampleLocation]):
             self.spinner_load_program, ProgramNames.SPINNER
         )
 
-        await self._trigger_program_and_wait_for_complete(self.spinner_off)
+        # Can remove try except once we have feedback on whether the spinner is running or not.
+        # https://jira.diamond.ac.uk/browse/I15_1-1540
+        try:
+            await self._trigger_program_and_wait_for_complete(self.spinner_off)
+        except TimeoutError:
+            # Spinner is already off.
+            pass
 
         await self._load_program_and_wait_for_loaded(
             self.beam_load_program, ProgramNames.BEAM

--- a/tests/devices/beamlines/i15_1/test_robot.py
+++ b/tests/devices/beamlines/i15_1/test_robot.py
@@ -189,6 +189,8 @@ async def test_given_wrong_spinner_program_gets_loaded_robot_times_out(robot: Ro
     get_mock_put(robot.spinner_off).assert_not_called()
 
 
+# Can unskip this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
+@pytest.mark.skip(reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34")
 async def test_given_spinner_stop_program_doesnt_start_then_robot_times_out(
     robot: Robot,
 ):
@@ -201,6 +203,8 @@ async def test_given_spinner_stop_program_doesnt_start_then_robot_times_out(
         await robot.set(SAMPLE_LOCATION_EMPTY)
 
 
+# Can unskip this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
+@pytest.mark.skip(reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34")
 async def test_given_spinner_stop_program_doesnt_stop_then_robot_times_out(
     robot: Robot,
 ):
@@ -237,3 +241,15 @@ async def test_after_robot_unload_new_0_0_is_put_in_index_pvs(robot: Robot):
 
     assert await robot.current_sample.puck.get_value() == 0
     assert await robot.current_sample.position.get_value() == 0
+
+
+
+async def test_given_spinner_not_running_then_unload_does_not_raise_an_error(
+    robot: Robot,
+):
+    def do_nothing(*_, **__):
+        pass
+
+    callback_on_mock_put(robot.spinner_off, do_nothing)
+
+    await robot._unload()

--- a/tests/devices/beamlines/i15_1/test_robot.py
+++ b/tests/devices/beamlines/i15_1/test_robot.py
@@ -247,6 +247,7 @@ async def test_after_robot_unload_new_0_0_is_put_in_index_pvs(robot: Robot):
     assert await robot.current_sample.position.get_value() == 0
 
 
+# Can remove this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
 async def test_given_spinner_not_running_then_unload_does_not_raise_an_error(
     robot: Robot,
 ):

--- a/tests/devices/beamlines/i15_1/test_robot.py
+++ b/tests/devices/beamlines/i15_1/test_robot.py
@@ -190,7 +190,9 @@ async def test_given_wrong_spinner_program_gets_loaded_robot_times_out(robot: Ro
 
 
 # Can unskip this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
-@pytest.mark.skip(reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34")
+@pytest.mark.skip(
+    reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34"
+)
 async def test_given_spinner_stop_program_doesnt_start_then_robot_times_out(
     robot: Robot,
 ):
@@ -204,7 +206,9 @@ async def test_given_spinner_stop_program_doesnt_start_then_robot_times_out(
 
 
 # Can unskip this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
-@pytest.mark.skip(reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34")
+@pytest.mark.skip(
+    reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34"
+)
 async def test_given_spinner_stop_program_doesnt_stop_then_robot_times_out(
     robot: Robot,
 ):
@@ -241,7 +245,6 @@ async def test_after_robot_unload_new_0_0_is_put_in_index_pvs(robot: Robot):
 
     assert await robot.current_sample.puck.get_value() == 0
     assert await robot.current_sample.position.get_value() == 0
-
 
 
 async def test_given_spinner_not_running_then_unload_does_not_raise_an_error(


### PR DESCRIPTION
Fixes (https://github.com/DiamondLightSource/crystallography-bluesky/issues/34)

### Instructions to reviewer on how to test:
1. Check tests still pass (have skipped 2 tests)
2. Confirm spinner still turns off when it is in fact on

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
