### PR TITLE
i15-1: Add separate ability to start/stop spinner

### DIFF
--- a/src/dodal/devices/beamlines/i15_1/robot.py
+++ b/src/dodal/devices/beamlines/i15_1/robot.py
@@ -13,6 +13,7 @@ from ophyd_async.core import (
     StrictEnum,
     callback_on_mock_put,
     default_mock_class,
+    derived_signal_rw,
     set_and_wait_for_value,
     set_mock_value,
     wait_for_value,
@@ -47,6 +48,11 @@ class ProgramRunning(StrictEnum):
     PROGRAM_RUNNING = "Program Running"
 
 
+class SpinnerState(StrictEnum):
+    ON = "Spinner On"
+    OFF = "Spinner Off"
+
+
 class CurrentSample(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         with self.add_children_as_readables():
@@ -68,7 +74,7 @@ class MockRobot(DeviceMock["Robot"]):
         )
 
         callback_on_mock_put(
-            device.spinner_load_program,
+            device._spinner_load_program,  # noqa: SLF001
             partial(set_program, ProgramNames.SPINNER.value),
         )
 
@@ -88,8 +94,8 @@ class MockRobot(DeviceMock["Robot"]):
         callback_on_mock_put(device.beam_place, program_running)
         callback_on_mock_put(device.beam_pick, program_running)
 
-        callback_on_mock_put(device.spinner_off, program_running)
-        callback_on_mock_put(device.spinner_on, program_running)
+        callback_on_mock_put(device._spinner_off, program_running)  # noqa: SLF001
+        callback_on_mock_put(device._spinner_on, program_running)  # noqa: SLF001
 
 
 @default_mock_class(MockRobot)
@@ -128,6 +134,15 @@ class Robot(StandardReadable, Movable[SampleLocation]):
             Sequence[str], f"{robot_prefix}CNTL_ERR_MSG"
         )
 
+        self._spinner_rbv = epics_signal_r(SpinnerState, f"{robot_prefix}SPINNER_STATE")
+        self._spinner_off = epics_signal_x(f"{robot_prefix}MOTOR:ACTION0.PROC")
+        self._spinner_on = epics_signal_x(f"{robot_prefix}MOTOR:ACTION1.PROC")
+        self._spinner_load_program = epics_signal_x(f"{robot_prefix}MOTOR:LOAD.PROC")
+
+        self.spinner = derived_signal_rw(
+            self._get_spinner_state, self._set_spinner_state, rbv=self._spinner_rbv
+        )
+
         self.puck_pick = epics_signal_x(f"{robot_prefix}PUCK:ACTION0.PROC")
         self.puck_place = epics_signal_x(f"{robot_prefix}PUCK:ACTION1.PROC")
         self.puck_load_program = epics_signal_x(f"{robot_prefix}PUCK:LOAD.PROC")
@@ -135,10 +150,6 @@ class Robot(StandardReadable, Movable[SampleLocation]):
         self.beam_pick = epics_signal_x(f"{robot_prefix}BEAM:ACTION0.PROC")
         self.beam_place = epics_signal_x(f"{robot_prefix}BEAM:ACTION1.PROC")
         self.beam_load_program = epics_signal_x(f"{robot_prefix}BEAM:LOAD.PROC")
-
-        self.spinner_off = epics_signal_x(f"{robot_prefix}MOTOR:ACTION0.PROC")
-        self.spinner_on = epics_signal_x(f"{robot_prefix}MOTOR:ACTION1.PROC")
-        self.spinner_load_program = epics_signal_x(f"{robot_prefix}MOTOR:LOAD.PROC")
 
         self.servo_off = epics_signal_x(f"{robot_prefix}SOFF.PROC")
         self.servo_on = epics_signal_x(f"{robot_prefix}SON.PROC")
@@ -173,6 +184,8 @@ class Robot(StandardReadable, Movable[SampleLocation]):
         )
 
     async def _load(self, location: SampleLocation):
+        await self._set_spinner_state(SpinnerState.OFF)
+
         await self._load_program_and_wait_for_loaded(
             self.puck_load_program, ProgramNames.PUCK
         )
@@ -196,18 +209,7 @@ class Robot(StandardReadable, Movable[SampleLocation]):
         )
 
     async def _unload(self):
-        await self._load_program_and_wait_for_loaded(
-            self.spinner_load_program, ProgramNames.SPINNER
-        )
-
-        # Can remove try except once we have feedback on whether the spinner is running or not.
-        # https://jira.diamond.ac.uk/browse/I15_1-1540
-        try:
-            await self._trigger_program_and_wait_for_complete(self.spinner_off)
-        except TimeoutError as e:
-            # Assume spinner is already off.
-            LOGGER.warning(f"Assuming spinner is off, ignoring TimeoutError: {e}")
-            pass
+        await self._set_spinner_state(SpinnerState.OFF)
 
         await self._load_program_and_wait_for_loaded(
             self.beam_load_program, ProgramNames.BEAM
@@ -233,6 +235,26 @@ class Robot(StandardReadable, Movable[SampleLocation]):
             self.current_sample.puck.set(0),
             self.current_sample.position.set(0),
         )
+
+    async def _set_spinner_state(self, new_state: SpinnerState) -> None:
+        current_spinner_state = await self._spinner_rbv.get_value()
+        if new_state == current_spinner_state:
+            LOGGER.info(f"Spinner is already {new_state}, doing nothing")
+            return
+
+        await self._load_program_and_wait_for_loaded(
+            self._spinner_load_program, ProgramNames.SPINNER
+        )
+
+        signal_to_set = (
+            self._spinner_off if new_state == SpinnerState.OFF else self._spinner_on
+        )
+
+        await self._trigger_program_and_wait_for_complete(signal_to_set)
+
+    def _get_spinner_state(self, rbv: SpinnerState) -> SpinnerState:
+        # This function is needed so that the derived signal picks up the type hints
+        return rbv
 
     @AsyncStatus.wrap
     async def set(self, value: SampleLocation):

--- a/tests/devices/beamlines/i15_1/test_robot.py
+++ b/tests/devices/beamlines/i15_1/test_robot.py
@@ -14,6 +14,7 @@ from dodal.devices.beamlines.i15_1.robot import (
     ProgramRunning,
     Robot,
     SampleLocation,
+    SpinnerState,
 )
 
 
@@ -169,56 +170,63 @@ async def test_when_unloaded_then_spinner_stops_before_beam_program_loaded(
     parent_mock = get_mock(robot)
 
     expected_calls = [
-        call.spinner_load_program.put(ANY),
-        call.spinner_off.put(ANY),
+        call._spinner_load_program.put(ANY),
+        call._spinner_off.put(ANY),
         call.beam_load_program.put(ANY),
     ]
 
     parent_mock.assert_has_calls(expected_calls, any_order=False)
 
 
-async def test_given_wrong_spinner_program_gets_loaded_robot_times_out(robot: Robot):
+async def test_given_wrong_spinner_program_gets_loaded_then_times_out(robot: Robot):
     def change_to_wrong_program(*_, **__):
         set_mock_value(robot.program_name, "BAD PROGRAM")
 
-    callback_on_mock_put(robot.spinner_load_program, change_to_wrong_program)
+    callback_on_mock_put(robot._spinner_load_program, change_to_wrong_program)
 
     with pytest.raises(TimeoutError):
-        await robot.set(SAMPLE_LOCATION_EMPTY)
+        await robot.spinner.set(SpinnerState.OFF)
 
-    get_mock_put(robot.spinner_off).assert_not_called()
+    get_mock_put(robot._spinner_off).assert_not_called()
 
 
-# Can unskip this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
-@pytest.mark.skip(
-    reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34"
-)
-async def test_given_spinner_stop_program_doesnt_start_then_robot_times_out(
+async def test_given_spinner_stop_program_doesnt_start_then_times_out(
     robot: Robot,
 ):
     def do_nothing(*_, **__):
         pass
 
-    callback_on_mock_put(robot.spinner_off, do_nothing)
+    callback_on_mock_put(robot._spinner_off, do_nothing)
 
     with pytest.raises(TimeoutError):
-        await robot.set(SAMPLE_LOCATION_EMPTY)
+        await robot.spinner.set(SpinnerState.OFF)
 
 
-# Can unskip this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
-@pytest.mark.skip(
-    reason="Temporarily handling this timeout error, see https://github.com/DiamondLightSource/crystallography-bluesky/issues/34"
-)
-async def test_given_spinner_stop_program_doesnt_stop_then_robot_times_out(
+async def test_given_spinner_stop_program_doesnt_stop_then_times_out(
     robot: Robot,
 ):
     def infinite_program(*_, **__):
         set_mock_value(robot.program_running, ProgramRunning.PROGRAM_RUNNING)
 
-    callback_on_mock_put(robot.spinner_off, infinite_program)
+    callback_on_mock_put(robot._spinner_off, infinite_program)
 
     with pytest.raises(TimeoutError):
-        await robot.set(SAMPLE_LOCATION_EMPTY)
+        await robot.spinner.set(SpinnerState.OFF)
+
+
+@pytest.mark.parametrize(
+    "initial_state",
+    (SpinnerState.ON, SpinnerState.OFF),
+)
+async def test_given_spinner_is_already_in_state_then_dont_change_it(
+    robot: Robot,
+    initial_state: SpinnerState,
+):
+    set_mock_value(robot._spinner_rbv, initial_state)
+
+    await robot.spinner.set(initial_state)
+
+    get_mock_put(robot._spinner_load_program).assert_not_called()
 
 
 async def test_when_robot_unloaded_beam_picked_then_puck_placed(robot: Robot) -> None:
@@ -245,15 +253,3 @@ async def test_after_robot_unload_new_0_0_is_put_in_index_pvs(robot: Robot):
 
     assert await robot.current_sample.puck.get_value() == 0
     assert await robot.current_sample.position.get_value() == 0
-
-
-# Can remove this test once https://github.com/DiamondLightSource/crystallography-bluesky/issues/16 done
-async def test_given_spinner_not_running_then_unload_does_not_raise_an_error(
-    robot: Robot,
-):
-    def do_nothing(*_, **__):
-        pass
-
-    callback_on_mock_put(robot.spinner_off, do_nothing)
-
-    await robot._unload()

--- a/tests/devices/beamlines/i15_1/test_robot.py
+++ b/tests/devices/beamlines/i15_1/test_robot.py
@@ -159,6 +159,14 @@ async def test_given_loaded_from_a_position_then_unload_moves_to_position(
     assert await robot.pos_sel.get_value() == 2
 
 
+async def test_given_spinner_started_then_can_read_spinner_state(
+    robot: Robot,
+):
+    await robot.spinner.set(SpinnerState.ON)
+
+    assert await robot.spinner.get_value() == SpinnerState.ON
+
+
 async def test_when_unloaded_then_spinner_stops_before_beam_program_loaded(
     robot: Robot,
 ) -> None:


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/crystallography-bluesky/issues/16

### Instructions to reviewer on how to test:
1. Confirm tests still pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
