### PR TITLE
Add cam and webcam devices

### DIFF
--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -240,7 +240,7 @@ def gonio_interlock() -> GonioInterlock:
 
 
 @devices.factory()
-def webcam(path_provider: PathProvider) -> ContAcqAreaDetector:
+def webcam_1(path_provider: PathProvider) -> ContAcqAreaDetector:
     return ContAcqAreaDetector(
         f"{PREFIX.beamline_prefix}-DI-WEB-01:",
         path_provider=path_provider,
@@ -264,7 +264,7 @@ def webcam_2(path_provider: PathProvider) -> ContAcqAreaDetector:
 
 
 @devices.factory()
-def cam(path_provider: PathProvider) -> ContAcqAreaDetector:
+def cam_1(path_provider: PathProvider) -> ContAcqAreaDetector:
     return ContAcqAreaDetector(
         f"{PREFIX.beamline_prefix}-DI-CAM-01:",
         path_provider=path_provider,

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -212,7 +212,7 @@ def puck_detect() -> PuckDetect:
     return PuckDetect("https://i15-1-cam3-processing.diamond.ac.uk/result")
 
 
-@devices.factory(skip=True)
+@devices.factory()
 def attenuator() -> Attenuator:
     return Attenuator(f"{PREFIX.beamline_prefix}-OP-ATTN-02:")
 

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -2,7 +2,7 @@ from functools import cache
 from pathlib import Path
 
 from ophyd_async.core import PathProvider
-from ophyd_async.epics.adcore import ADJPEGWriter, ContAcqAreaDetector
+from ophyd_async.epics.adcore import ADWriterType, ContAcqDetector
 from ophyd_async.epics.motor import Motor
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
@@ -212,7 +212,7 @@ def puck_detect() -> PuckDetect:
     return PuckDetect("https://i15-1-cam3-processing.diamond.ac.uk/result")
 
 
-@devices.factory()
+@devices.factory(skip=True)
 def attenuator() -> Attenuator:
     return Attenuator(f"{PREFIX.beamline_prefix}-OP-ATTN-02:")
 
@@ -240,60 +240,60 @@ def gonio_interlock() -> GonioInterlock:
 
 
 @devices.factory()
-def webcam_1(path_provider: PathProvider) -> ContAcqAreaDetector:
-    return ContAcqAreaDetector(
+def webcam_1(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
         f"{PREFIX.beamline_prefix}-DI-WEB-01:",
         path_provider=path_provider,
-        drv_suffix=CAM_SUFFIX,
+        driver_suffix=CAM_SUFFIX,
         cb_suffix="CIRC:",
-        writer_cls=ADJPEGWriter,
-        fileio_suffix="JPEG:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
     )
 
 
 @devices.factory()
-def webcam_2(path_provider: PathProvider) -> ContAcqAreaDetector:
-    return ContAcqAreaDetector(
+def webcam_2(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
         f"{PREFIX.beamline_prefix}-DI-WEB-02:",
         path_provider=path_provider,
-        drv_suffix=CAM_SUFFIX,
+        driver_suffix=CAM_SUFFIX,
         cb_suffix="CIRC:",
-        writer_cls=ADJPEGWriter,
-        fileio_suffix="JPEG:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
     )
 
 
 @devices.factory()
-def cam_1(path_provider: PathProvider) -> ContAcqAreaDetector:
-    return ContAcqAreaDetector(
+def cam_1(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
         f"{PREFIX.beamline_prefix}-DI-CAM-01:",
         path_provider=path_provider,
-        drv_suffix=CAM_SUFFIX,
+        driver_suffix=CAM_SUFFIX,
         cb_suffix="CIRC:",
-        writer_cls=ADJPEGWriter,
-        fileio_suffix="JPEG:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
     )
 
 
 @devices.factory()
-def cam_2(path_provider: PathProvider) -> ContAcqAreaDetector:
-    return ContAcqAreaDetector(
+def cam_2(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
         f"{PREFIX.beamline_prefix}-DI-CAM-02:",
         path_provider=path_provider,
-        drv_suffix=CAM_SUFFIX,
+        driver_suffix=CAM_SUFFIX,
         cb_suffix="CIRC:",
-        writer_cls=ADJPEGWriter,
-        fileio_suffix="JPEG:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
     )
 
 
 @devices.factory()
-def cam_3(path_provider: PathProvider) -> ContAcqAreaDetector:
-    return ContAcqAreaDetector(
+def cam_3(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
         f"{PREFIX.beamline_prefix}-DI-CAM-03:",
         path_provider=path_provider,
-        drv_suffix=CAM_SUFFIX,
+        driver_suffix=CAM_SUFFIX,
         cb_suffix="CIRC:",
-        writer_cls=ADJPEGWriter,
-        fileio_suffix="JPEG:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
     )

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -1,6 +1,13 @@
+from functools import cache
+from pathlib import Path
+
+from ophyd_async.core import PathProvider
+from ophyd_async.epics.adcore import ADJPEGWriter, ContAcqAreaDetector
 from ophyd_async.epics.motor import Motor
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
+from dodal.common.beamlines.device_helpers import CAM_SUFFIX
+from dodal.common.visit import StaticVisitPathProvider
 from dodal.device_manager import DeviceManager
 from dodal.devices.beamlines.i15.laue import LaueMonochrometer
 from dodal.devices.beamlines.i15.motors import NumberedTripleAxisStage
@@ -32,6 +39,15 @@ Define device factory functions below this point.
 A device factory function is any function that has a return type which conforms
 to one or more Bluesky Protocols.
 """
+
+
+@devices.fixture
+@cache
+def path_provider() -> PathProvider:
+    return StaticVisitPathProvider(
+        BL,
+        Path("/dls/i15-1/data/2026/cm44163-2/"),
+    )
 
 
 @devices.factory()
@@ -220,4 +236,64 @@ def hutch_shutter() -> InterlockedHutchShutter:
 def gonio_interlock() -> GonioInterlock:
     return GonioInterlock(
         bl_prefix=PREFIX.beamline_prefix, interlock_suffix="-VA-OMRON-01:INT3:ILK"
+    )
+
+
+@devices.factory()
+def webcam(path_provider: PathProvider) -> ContAcqAreaDetector:
+    return ContAcqAreaDetector(
+        f"{PREFIX.beamline_prefix}-DI-WEB-01:",
+        path_provider=path_provider,
+        drv_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_cls=ADJPEGWriter,
+        fileio_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def webcam_2(path_provider: PathProvider) -> ContAcqAreaDetector:
+    return ContAcqAreaDetector(
+        f"{PREFIX.beamline_prefix}-DI-WEB-02:",
+        path_provider=path_provider,
+        drv_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_cls=ADJPEGWriter,
+        fileio_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def cam(path_provider: PathProvider) -> ContAcqAreaDetector:
+    return ContAcqAreaDetector(
+        f"{PREFIX.beamline_prefix}-DI-CAM-01:",
+        path_provider=path_provider,
+        drv_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_cls=ADJPEGWriter,
+        fileio_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def cam_2(path_provider: PathProvider) -> ContAcqAreaDetector:
+    return ContAcqAreaDetector(
+        f"{PREFIX.beamline_prefix}-DI-CAM-02:",
+        path_provider=path_provider,
+        drv_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_cls=ADJPEGWriter,
+        fileio_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def cam_3(path_provider: PathProvider) -> ContAcqAreaDetector:
+    return ContAcqAreaDetector(
+        f"{PREFIX.beamline_prefix}-DI-CAM-03:",
+        path_provider=path_provider,
+        drv_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_cls=ADJPEGWriter,
+        fileio_suffix="JPEG:",
     )

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -3,12 +3,13 @@ from pathlib import Path
 
 from daq_config_server import ConfigClient
 from ophyd_async.core import PathProvider, StaticPathProvider, UUIDFilenameProvider
-from ophyd_async.epics.adcore import NDPluginBaseIO
+from ophyd_async.epics.adcore import ADWriterType, ContAcqDetector, NDPluginBaseIO
 from ophyd_async.epics.motor import Motor
 from ophyd_async.fastcs.eiger import EigerDetector
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.beamline_utils import set_config_client
+from dodal.common.beamlines.device_helpers import CAM_SUFFIX
 from dodal.device_manager import DeviceManager
 from dodal.devices.beamlines.i15.laue import LaueMonochrometer
 from dodal.devices.beamlines.i15.motors import NumberedTripleAxisStage
@@ -294,4 +295,64 @@ def zebra() -> Zebra:
     return Zebra(
         prefix=f"{PREFIX.beamline_prefix}-EA-ZEBRA-01:",
         mapping=ZebraMapping(),
+    )
+
+
+@devices.factory()
+def webcam_1(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
+        f"{PREFIX.beamline_prefix}-DI-WEB-01:",
+        path_provider=path_provider,
+        driver_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def webcam_2(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
+        f"{PREFIX.beamline_prefix}-DI-WEB-02:",
+        path_provider=path_provider,
+        driver_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def cam_1(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
+        f"{PREFIX.beamline_prefix}-DI-CAM-01:",
+        path_provider=path_provider,
+        driver_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def cam_2(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
+        f"{PREFIX.beamline_prefix}-DI-CAM-02:",
+        path_provider=path_provider,
+        driver_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
+    )
+
+
+@devices.factory()
+def cam_3(path_provider: PathProvider) -> ContAcqDetector:
+    return ContAcqDetector(
+        f"{PREFIX.beamline_prefix}-DI-CAM-03:",
+        path_provider=path_provider,
+        driver_suffix=CAM_SUFFIX,
+        cb_suffix="CIRC:",
+        writer_type=ADWriterType.JPEG,
+        writer_suffix="JPEG:",
     )


### PR DESCRIPTION
Adds camera devices to i15-1 for https://github.com/DiamondLightSource/crystallography-bluesky/issues/20
The webcams won't connect due to an issue in ophyd-async, fixed in https://github.com/bluesky/ophyd-async/pull/1225. For this reason I've based this branch on the `update_dodal_ophyd_async_v0.17a` branch
### Instructions to reviewer on how to test:
1. Do dodal connect i15_1
2. Confirm the cams connect

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
