### PR TITLE
Add timeout option for dodal connect (default 5 seconds)

### DIFF
--- a/src/dodal/cli.py
+++ b/src/dodal/cli.py
@@ -80,7 +80,16 @@ def describe(beamline: str, device_manager: str) -> None:
     default=False,
 )
 @click.option("-n", "--name", "device_manager", default="devices")
-def connect(beamline: str, all: bool, sim_backend: bool, device_manager: str) -> None:
+@click.option(
+    "-t",
+    "--timeout",
+    is_flag=False,
+    help="Specify the timeout when connect devices. Default is 5 seconds.",
+    default=5.0,
+)
+def connect(
+    beamline: str, all: bool, sim_backend: bool, device_manager: str, timeout: float
+) -> None:
     """Initialises a beamline module, connects to all devices, reports
     any connection issues.
     """
@@ -109,6 +118,7 @@ def connect(beamline: str, all: bool, sim_backend: bool, device_manager: str) ->
     ):
         devices, instance_exceptions, connect_exceptions = manager.build_and_connect(
             mock=sim_backend,
+            timeout=timeout,
         )
     else:
         print(f"No device manager named '{device_manager}' found in {mod}")

--- a/src/dodal/cli.py
+++ b/src/dodal/cli.py
@@ -84,7 +84,7 @@ def describe(beamline: str, device_manager: str) -> None:
     "-t",
     "--timeout",
     is_flag=False,
-    help="Specify the timeout when connect devices. Default is 5 seconds.",
+    help="Specify the timeout when connecting devices. Default is 5 seconds.",
     default=5.0,
 )
 def connect(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,7 +213,9 @@ def test_missing_device_manager(connect, make, imp, runner: CliRunner):
         (True, 3.0),
         (False, 3.0),
     ],
-    ids=lambda x: f"{x}" if isinstance(x, float) else ("sim" if x else "live"),
+    ids=lambda x: (
+        f"{x} second timeout" if isinstance(x, float) else ("sim" if x else "live")
+    ),
 )
 def test_device_manager_init(runner: CliRunner, mock: bool, timeout: float):
     with patch("dodal.cli.importlib") as mock_import:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,7 +206,7 @@ def test_missing_device_manager(connect, make, imp, runner: CliRunner):
 
 @patch.dict(os.environ, clear=True)
 @pytest.mark.parametrize(
-    "mock, timeout",
+    "sim, timeout",
     [
         (True, 5.0),  # default
         (False, 5.0),  # default
@@ -224,11 +224,9 @@ def test_device_manager_init(runner: CliRunner, mock: bool, timeout: float):
         mock_import.reset_mock()
 
         args = ["connect", "-n", "devices", "i22"]
-
         if mock:
             args.append("-s")
 
-        # only pass -t if not default (optional, but realistic)
         if timeout != 5.0:
             args += ["-t", str(timeout)]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,7 +206,7 @@ def test_missing_device_manager(connect, make, imp, runner: CliRunner):
 
 @patch.dict(os.environ, clear=True)
 @pytest.mark.parametrize(
-    "sim, timeout",
+    "mock, timeout",
     [
         (True, 5.0),  # default
         (False, 5.0),  # default

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,17 +205,39 @@ def test_missing_device_manager(connect, make, imp, runner: CliRunner):
 
 
 @patch.dict(os.environ, clear=True)
-@pytest.mark.parametrize("mock", [True, False], ids=["live", "sim"].__getitem__)
-def test_device_manager_init(runner: CliRunner, mock: bool):
+@pytest.mark.parametrize(
+    "mock, timeout",
+    [
+        (True, 5.0),  # default
+        (False, 5.0),  # default
+        (True, 3.0),
+        (False, 3.0),
+    ],
+    ids=lambda x: f"{x}" if isinstance(x, float) else ("sim" if x else "live"),
+)
+def test_device_manager_init(runner: CliRunner, mock: bool, timeout: float):
     with patch("dodal.cli.importlib") as mock_import:
         dm = mock_import.import_module("dodal.beamlines.i22")
         dm.devices = Mock(spec=DeviceManager)
         mock_import.reset_mock()
-        runner.invoke(
-            main, ["connect", "-n", "devices", "i22"] + (["-s"] if mock else [])
-        )
+
+        args = ["connect", "-n", "devices", "i22"]
+
+        if mock:
+            args.append("-s")
+
+        # only pass -t if not default (optional, but realistic)
+        if timeout != 5.0:
+            args += ["-t", str(timeout)]
+
+        runner.invoke(main, args)
+
         mock_import.import_module.assert_called_once_with("dodal.beamlines.i22")
-        dm.devices.build_and_connect.assert_called_once_with(mock=mock)
+
+        dm.devices.build_and_connect.assert_called_once_with(
+            mock=mock,
+            timeout=timeout,
+        )
 
 
 def _mock_connect(


### PR DESCRIPTION
Added a timeout option for dodal connect and also adjusted the default from 10 seconds to 5 seconds to make it faster.

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
