### PR TITLE
move CONFIG_SERVER_URL environment variable name to a constant

### DIFF
--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -7,6 +7,7 @@ from ophyd_async.fastcs.eiger import EigerDetector as FastEiger
 from ophyd_async.fastcs.panda import HDFPanda
 from yarl import URL
 
+from dodal.common.beamlines.beamline_parameters import CONFIG_SERVER_URL_ENV_VAR
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.beamline_utils import set_config_client, set_path_provider
 from dodal.common.beamlines.commissioning_mode import set_commissioning_signal
@@ -100,7 +101,9 @@ def path_provider() -> PathProvider:
 @devices.fixture
 @cache
 def config_client() -> ConfigClient:
-    config_server_url = getenv("CONFIG_SERVER_URL", DEFAULT_CONFIG_SERVER_ENDPOINT)
+    config_server_url = getenv(
+        CONFIG_SERVER_URL_ENV_VAR, DEFAULT_CONFIG_SERVER_ENDPOINT
+    )
     client = ConfigClient(config_server_url)
     set_config_client(client)
     return client

--- a/src/dodal/common/beamlines/beamline_parameters.py
+++ b/src/dodal/common/beamlines/beamline_parameters.py
@@ -8,6 +8,9 @@ BEAMLINE_PARAMETER_PATHS = {
 }
 
 
+CONFIG_SERVER_URL_ENV_VAR = "CONFIG_SERVER_URL"
+
+
 def get_beamline_parameters(beamline: str) -> dict[str, Any]:
     """Loads the beamline parameters for a specified beamline from the config server.
 


### PR DESCRIPTION
moves `CONFIG_SERVER_URL` into a constant as suggested in 
* https://github.com/DiamondLightSource/mx-bluesky/pull/1698

### Instructions to reviewer on how to test:
1. Tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
