### PR TITLE
Add fastcs eiger to i15-1

### DIFF
--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -1,4 +1,9 @@
+from functools import cache
+from pathlib import Path
+
+from ophyd_async.core import PathProvider, StaticPathProvider, UUIDFilenameProvider
 from ophyd_async.epics.motor import Motor
+from ophyd_async.fastcs.eiger import EigerDetector
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.device_manager import DeviceManager
@@ -32,6 +37,14 @@ Define device factory functions below this point.
 A device factory function is any function that has a return type which conforms
 to one or more Bluesky Protocols.
 """
+
+
+@devices.fixture
+@cache
+def path_provider() -> PathProvider:
+    return StaticPathProvider(
+        UUIDFilenameProvider(), Path("/dls/i15-1/data/2026/cm44163-2")
+    )
 
 
 @devices.factory()
@@ -220,4 +233,11 @@ def hutch_shutter() -> InterlockedHutchShutter:
 def gonio_interlock() -> GonioInterlock:
     return GonioInterlock(
         bl_prefix=PREFIX.beamline_prefix, interlock_suffix="-VA-OMRON-01:INT3:ILK"
+    )
+
+
+@devices.factory()
+def fastcs_eiger(path_provider: PathProvider) -> EigerDetector:
+    return EigerDetector(
+        prefix=f"{PREFIX.beamline_prefix}-EA-EIGER-01:", path_provider=path_provider
     )


### PR DESCRIPTION
Adds the fastcs eiger to i15-1. Needs the new ophyd async version so based on top of https://github.com/DiamondLightSource/dodal/pull/1979

### Instructions to reviewer on how to test:
1. Do `dodal connect i15-1`
2. Confirm `fastcs_eiger` connects

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
