### PR TITLE
Conversion for zoom and microns per pixel

### DIFF
--- a/src/dodal/devices/oav/oav_parameters.py
+++ b/src/dodal/devices/oav/oav_parameters.py
@@ -178,6 +178,7 @@ class OAVConfigBeamCentre(OAVConfigBase[ZoomParamsCrosshair]):
         config = {}
         um_xy = self._read_zoom_params()
         bc_xy = self._read_display_config()
+        um_xy = {str(float(k)): v for k, v in um_xy.items()}
         for zoom_key in list(bc_xy.keys()):
             config[zoom_key] = ZoomParamsCrosshair(
                 microns_per_pixel=um_xy[zoom_key], crosshair=bc_xy[zoom_key]


### PR DESCRIPTION
In oav_parameters.py, there was an error when OAVConfigBeamCenter would run get_parameters() whenever the user clicked on the Move on Click button.
The um_xy and bc_xy had different types for their keys.
um_xy was giving integer strings while bc_xy was giving float strings.

So a change was made to convert um_xy to float strings which allowed the code to work as the keys now matched.

The issue might be related to the move to the daq config server?