### PR TITLE
Change oav parameters direction attribute to enum from int

### DIFF
--- a/src/dodal/devices/oav/oav_parameters.py
+++ b/src/dodal/devices/oav/oav_parameters.py
@@ -7,6 +7,8 @@ from xml.etree.ElementTree import Element
 from daq_config_server import ConfigClient
 from daq_config_server.models import DisplayConfig
 
+from dodal.devices.oav.pin_image_recognition import ScanDirections
+
 # GDA currently assumes this aspect ratio for the OAV window size.
 # For some beamline this doesn't affect anything as the actual OAV aspect ratio
 # matches. Others need to take it into account to rescale the values stored in
@@ -99,7 +101,9 @@ class OAVParameters:
         self.open_ksize: int = update("open_ksize", int, default=0)
         self.close_ksize: int = update("close_ksize", int, default=5)
         self.min_callback_time: float = update("min_callback_time", float, default=0.08)
-        self.direction: int = update("direction", int)
+        self.direction: ScanDirections = [*ScanDirections][
+            self.active_params["direction"]
+        ]
         self.max_tip_distance: float = update("max_tip_distance", float, default=300)
 
     def get_max_tip_distance_in_pixels(self, microns_per_pixel: float) -> float:


### PR DESCRIPTION
Changes `OAVParameters` so that `direction` attribute is of type `ShutterState` instead of int.

Required for 
* DiamondLightSource/mx-bluesky#1769

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
