### PR TITLE
Update ophyd async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async[ca,pva]>=0.19.1",
+    "ophyd-async[ca,pva]>=0.19.2",
     "bluesky>=1.14.5",
     "pyepics",
     "pillow",
@@ -51,7 +51,7 @@ dev = [
     # Commented out due to dependency version conflict with pydantic 1.x
     # "copier",
     "myst-parser",
-    "ophyd_async[sim]>=v0.19.1",
+    "ophyd_async[sim]>=v0.19.2",
     "pre-commit",
     "psutil",
     "pydata-sphinx-theme>=0.12",

--- a/uv.lock
+++ b/uv.lock
@@ -820,7 +820,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "opencv-python-headless" },
     { name = "ophyd" },
-    { name = "ophyd-async", extras = ["ca", "pva"], specifier = ">=0.19.1" },
+    { name = "ophyd-async", extras = ["ca", "pva"], specifier = ">=0.19.2" },
     { name = "pillow" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyepics" },
@@ -839,7 +839,7 @@ dev = [
     { name = "ispyb" },
     { name = "mypy" },
     { name = "myst-parser" },
-    { name = "ophyd-async", extras = ["sim"], specifier = ">=0.19.1" },
+    { name = "ophyd-async", extras = ["sim"], specifier = ">=0.19.2" },
     { name = "pre-commit" },
     { name = "psutil" },
     { name = "pydata-sphinx-theme", specifier = ">=0.12" },
@@ -2252,7 +2252,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky" },
@@ -2266,9 +2266,9 @@ dependencies = [
     { name = "stamina" },
     { name = "velocity-profile" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/a5/1811d2cb16ca2a0aa0830a119ae55cd8b3435acd821b68eebe430524502d/ophyd_async-0.19.1.tar.gz", hash = "sha256:a98f3514e159b3777b9eaf3b9417a2238c4fefc5c657a82cb043174c569acc37", size = 588480, upload-time = "2026-06-11T19:09:20.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/d9/bc09637a5caff453a205fa3c26474f497964618b72074413a6315d36725b/ophyd_async-0.19.2.tar.gz", hash = "sha256:138dcd5ac2ccc30194c9d74525aefb291b8a0be2ef3468a60e294f0fcea5495a", size = 588686, upload-time = "2026-06-16T15:31:31.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/a3/b4605ee05a6a3480ad57cf0ac15e381f99189b022362f0c08044c86227d7/ophyd_async-0.19.1-py3-none-any.whl", hash = "sha256:bb4cc6751aee46e53c588b493ce0a8905c94fbf4b5092af2f774019846af7c74", size = 228222, upload-time = "2026-06-11T19:09:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/90/36/96ac313cc51e147556e80d2388ca7c55672d13c06cb87353d8d607125284/ophyd_async-0.19.2-py3-none-any.whl", hash = "sha256:2cdd5ce876ce00246d043c581b1bb4074984822a879a330637a3188ace8e1f3e", size = 228241, upload-time = "2026-06-16T15:31:29.546Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
This updates to the latest ophyd-async following
* bluesky/ophyd-async#1292

### Instructions to reviewer on how to test:
1. `dodal connect` works on beamlines with pandas

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
