### PR TITLE
Fix build dependencies

### DIFF
--- a/docs/how-to/make-release.md
+++ b/docs/how-to/make-release.md
@@ -8,6 +8,7 @@ To make a new release, please follow this checklist:
 - Choose a new PEP440 compliant release number (see <https://peps.python.org/pep-0440/>) (The release version should 
   look like `{major}.{minor}.{patch}`). See [Deciding release numbers](#Deciding release numbers) if you're unsure on 
   what the release version should be.
+- Ensure that dependencies in pyproject.toml refer to release versions and not branches, otherwise the release will be rejected by PyPI 
 - Go to the GitHub [release] page
 - Choose `Draft New Release`
 - Click `Choose Tag` and supply the new tag you chose (click create new tag)

--- a/docs/how-to/make-release.md
+++ b/docs/how-to/make-release.md
@@ -8,7 +8,8 @@ To make a new release, please follow this checklist:
 - Choose a new PEP440 compliant release number (see <https://peps.python.org/pep-0440/>) (The release version should 
   look like `{major}.{minor}.{patch}`). See [Deciding release numbers](#Deciding release numbers) if you're unsure on 
   what the release version should be.
-- Ensure that dependencies in pyproject.toml refer to release versions and not branches, otherwise the release will be rejected by PyPI 
+- Ensure that dependencies in pyproject.toml refer to release versions and not branches, otherwise the release will be rejected by PyPI
+- If you updated the pyproject.toml, also run a `uv sync` to ensure that dependencies are updated, and then merge the changes back to ``main``
 - Go to the GitHub [release] page
 - Choose `Draft New Release`
 - Click `Choose Tag` and supply the new tag you chose (click create new tag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scanspec>=0.7.3",
     "pyzmq==27.1.0",
     "deepdiff",
-    "daq-config-server @ git+https://github.com/DiamondLightSource/daq-config-server.git@main", # For getting Configuration settings.
+    "daq-config-server >= 1.3.6", # For getting Configuration settings.
     "mysql-connector-python == 9.5.0",                                                          # Can unpin once https://github.com/DiamondLightSource/ispyb-api/pull/244 is merged and released
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -696,8 +696,8 @@ wheels = [
 
 [[package]]
 name = "daq-config-server"
-version = "1.3.3"
-source = { git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=main#0b988e177f949a8c6d8a0c2bf5faf1c4c3352b94" }
+version = "1.3.6"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "fastapi" },
@@ -710,6 +710,10 @@ dependencies = [
     { name = "urllib3" },
     { name = "uvicorn" },
     { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/74/56eddf2a44efd981cc5678e74fd777f37c045a7f9b71b01143ee8be45715/daq_config_server-1.3.6.tar.gz", hash = "sha256:ec25a69eca6fbeca309f04763d53728000e39d509a3f43353b76721985e34ee2", size = 232081, upload-time = "2026-06-10T13:30:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/0a/f225277d9b0133b6cd0e68f19d93af67db1fd76c9ccea9026563d53f2ffa/daq_config_server-1.3.6-py3-none-any.whl", hash = "sha256:948933c4d7f79ea609cff5774aeef3578ffda582d623e8d5bdf9aadf89df36b7", size = 33132, upload-time = "2026-06-10T13:30:52.176Z" },
 ]
 
 [[package]]
@@ -813,7 +817,7 @@ requires-dist = [
     { name = "aiohttp" },
     { name = "bluesky", specifier = ">=1.14.5" },
     { name = "click" },
-    { name = "daq-config-server", git = "https://github.com/DiamondLightSource/daq-config-server.git?rev=main" },
+    { name = "daq-config-server", specifier = ">=1.3.6" },
     { name = "deepdiff" },
     { name = "graypy" },
     { name = "mysql-connector-python", specifier = "==9.5.0" },


### PR DESCRIPTION
Update the daq-config-server version pin so that we can publish the release to PyPI, and update the release instructions.

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
