### PR TITLE
Added I23ZoomController to account for the differing PV names

### DIFF
--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -10,9 +10,13 @@ from dodal.beamlines.aithre import DISPLAY_CONFIG, ZOOM_PARAMS_FILE
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import HDF5_SUFFIX
 from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
+from dodal.devices.motors import XYZWrappedOmegaStage
 from dodal.device_manager import DeviceManager
 from dodal.devices.motors import SixAxisGonio
-from dodal.devices.oav.oav_detector import OAVBeamCentreFile
+from dodal.devices.oav.oav_detector import (
+    NullZoomController,
+    OAVBeamCentreFile,
+)
 from dodal.devices.oav.oav_parameters import OAVConfigBeamCentre
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.positioner import Positioner1D
@@ -25,6 +29,12 @@ from dodal.devices.zebra.zebra_constants_mapping import (
 from dodal.devices.zebra.zebra_controlled_shutter import MXZebraShutter
 from dodal.log import set_beamline as set_log_beamline
 from dodal.utils import BeamlinePrefix, get_beamline_name, get_hostname
+
+ZOOM_PARAMS_FILE = (
+    "/dls_sw/i23/software/gda_versions/gda/config/xml/jCameraManZoomLevels.xml"
+)
+DISPLAY_CONFIG = "/dls_sw/i23/software/daq_configuration/domain/display.configuration"
+I23_CONFIG_SERVER_ENDPOINT = "https://i23-daq-config.diamond.ac.uk"
 
 BL = get_beamline_name("i23")
 PREFIX = BeamlinePrefix(BL)
@@ -72,11 +82,12 @@ def _is_i23_machine():
 
 @devices.factory()
 def oav(config_client) -> OAVBeamCentreFile:
+    zoom = NullZoomController()
     return OAVBeamCentreFile(
         prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:",
         config=OAVConfigBeamCentre(ZOOM_PARAMS_FILE, DISPLAY_CONFIG, config_client),
+        zoom_controller=zoom,
     )
-
 
 @devices.factory()
 def pin_tip_detection() -> PinTipDetection:
@@ -89,8 +100,8 @@ def shutter() -> MXZebraShutter:
 
 
 @devices.factory()
-def gonio() -> SixAxisGonio:
-    return SixAxisGonio(f"{PREFIX.beamline_prefix}-MO-GONIO-01:")
+def gonio() -> XYZWrappedOmegaStage:
+    return XYZWrappedOmegaStage(f"{PREFIX.beamline_prefix}-MO-GONIO-01:")
 
 
 @devices.factory()

--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -13,10 +13,7 @@ from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvi
 from dodal.devices.motors import XYZWrappedOmegaStage
 from dodal.device_manager import DeviceManager
 from dodal.devices.motors import SixAxisGonio
-from dodal.devices.oav.oav_detector import (
-    NullZoomController,
-    OAVBeamCentreFile,
-)
+from dodal.devices.oav.oav_detector import OAVBeamCentreFile
 from dodal.devices.oav.oav_parameters import OAVConfigBeamCentre
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
 from dodal.devices.positioner import Positioner1D
@@ -82,11 +79,11 @@ def _is_i23_machine():
 
 @devices.factory()
 def oav(config_client) -> OAVBeamCentreFile:
-    zoom = NullZoomController()
     return OAVBeamCentreFile(
         prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:",
         config=OAVConfigBeamCentre(ZOOM_PARAMS_FILE, DISPLAY_CONFIG, config_client),
-        zoom_controller=zoom,
+        percentage_prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:ZOOM:",
+        level_prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:CAM:",
     )
 
 @devices.factory()

--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -10,9 +10,8 @@ from dodal.beamlines.aithre import DISPLAY_CONFIG, ZOOM_PARAMS_FILE
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.device_helpers import HDF5_SUFFIX
 from dodal.common.visit import LocalDirectoryServiceClient, StaticVisitPathProvider
-from dodal.devices.motors import XYZWrappedOmegaStage
 from dodal.device_manager import DeviceManager
-from dodal.devices.motors import SixAxisGonio
+from dodal.devices.motors import XYZWrappedOmegaStage
 from dodal.devices.oav.oav_detector import OAVBeamCentreFile
 from dodal.devices.oav.oav_parameters import OAVConfigBeamCentre
 from dodal.devices.oav.pin_image_recognition import PinTipDetection

--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -85,6 +85,7 @@ def oav(config_client) -> OAVBeamCentreFile:
         level_prefix=f"{PREFIX.beamline_prefix}-DI-OAV-01:CAM:",
     )
 
+
 @devices.factory()
 def pin_tip_detection() -> PinTipDetection:
     return PinTipDetection(f"{PREFIX.beamline_prefix}-DI-OAV-01:")

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -104,8 +104,16 @@ class ZoomController(BaseZoomController):
 
     DELAY_BETWEEN_MOTORS_AND_IMAGE_UPDATING_S = 2
 
-    def __init__(self, prefix: str, name: str = "", percentage_prefix: str = "", level_prefix: str = "") -> None:
-        self.percentage = epics_signal_rw(float, f"{percentage_prefix or prefix}ZOOMPOSCMD")
+    def __init__(
+        self,
+        prefix: str,
+        name: str = "",
+        percentage_prefix: str = "",
+        level_prefix: str = "",
+    ) -> None:
+        self.percentage = epics_signal_rw(
+            float, f"{percentage_prefix or prefix}ZOOMPOSCMD"
+        )
 
         # Level is the string description of the zoom level e.g. "1.0x" or "1.0"
         self.level = epics_signal_rw(str, f"{level_prefix or prefix}MP:SELECT")
@@ -182,7 +190,7 @@ class OAV(StandardReadable):
         if not zoom_controller:
             if percentage_prefix:
                 self.zoom_controller = ZoomController(
-                "", name, percentage_prefix, level_prefix
+                    "", name, percentage_prefix, level_prefix
                 )
             else:
                 self.zoom_controller = ZoomController(

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -27,7 +27,7 @@ from dodal.devices.oav.oav_parameters import (
 from dodal.devices.oav.snapshots.snapshot import Snapshot
 from dodal.devices.oav.snapshots.snapshot_with_grid import SnapshotWithGrid
 from dodal.log import LOGGER
-
+from dataclasses import dataclass
 
 class Coords(IntEnum):
     X = 0
@@ -104,11 +104,11 @@ class ZoomController(BaseZoomController):
 
     DELAY_BETWEEN_MOTORS_AND_IMAGE_UPDATING_S = 2
 
-    def __init__(self, prefix: str, name: str = "") -> None:
-        self.percentage = epics_signal_rw(float, f"{prefix}ZOOMPOSCMD")
+    def __init__(self, prefix: str, name: str = "", percentage_prefix: str = "", level_prefix: str = "") -> None:
+        self.percentage = epics_signal_rw(float, f"{percentage_prefix or prefix}ZOOMPOSCMD")
 
         # Level is the string description of the zoom level e.g. "1.0x" or "1.0"
-        self.level = epics_signal_rw(str, f"{prefix}MP:SELECT")
+        self.level = epics_signal_rw(str, f"{level_prefix or prefix}MP:SELECT")
 
         super().__init__(name=name)
 
@@ -166,6 +166,8 @@ class OAV(StandardReadable):
         name: str = "",
         mjpeg_prefix: str = "MJPG",
         zoom_controller: BaseZoomController | None = None,
+        percentage_prefix: str = "",
+        level_prefix: str = "",
         x_direction: int = -1,
         y_direction: int = -1,
         z_direction: int = 1,
@@ -178,9 +180,14 @@ class OAV(StandardReadable):
         _bl_prefix = prefix.split("-")[0]
 
         if not zoom_controller:
-            self.zoom_controller = ZoomController(
-                f"{_bl_prefix}-EA-OAV-01:FZOOM:", name
-            )
+            if percentage_prefix:
+                self.zoom_controller = ZoomController(
+                "", name, percentage_prefix, level_prefix
+                )
+            else:
+                self.zoom_controller = ZoomController(
+                    f"{_bl_prefix}-EA-OAV-01:FZOOM:", name
+                )
         else:
             self.zoom_controller = zoom_controller
 
@@ -258,6 +265,8 @@ class OAVBeamCentreFile(OAV):
         name: str = "",
         mjpeg_prefix: str = "MJPG",
         zoom_controller: BaseZoomController | None = None,
+        percentage_prefix: str = "",
+        level_prefix: str = "",
         mjpg_x_size_pv: str = "ArraySize1_RBV",
         mjpg_y_size_pv: str = "ArraySize2_RBV",
         x_direction: int = -1,
@@ -270,6 +279,8 @@ class OAVBeamCentreFile(OAV):
             name=name,
             mjpeg_prefix=mjpeg_prefix,
             zoom_controller=zoom_controller,
+            percentage_prefix=percentage_prefix,
+            level_prefix=level_prefix,
             mjpg_x_size_pv=mjpg_x_size_pv,
             mjpg_y_size_pv=mjpg_y_size_pv,
             x_direction=x_direction,

--- a/src/dodal/devices/oav/oav_detector.py
+++ b/src/dodal/devices/oav/oav_detector.py
@@ -27,7 +27,7 @@ from dodal.devices.oav.oav_parameters import (
 from dodal.devices.oav.snapshots.snapshot import Snapshot
 from dodal.devices.oav.snapshots.snapshot_with_grid import SnapshotWithGrid
 from dodal.log import LOGGER
-from dataclasses import dataclass
+
 
 class Coords(IntEnum):
     X = 0


### PR DESCRIPTION
Other mx-beamlines use a different PV name for zoom. Created a ZoomController specific to I23.

Fixes diamondlightsource/mx-bluesky#1771

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
