### PR TITLE
Make mock interlock safe

### DIFF
--- a/src/dodal/devices/beamlines/i15_1/robot.py
+++ b/src/dodal/devices/beamlines/i15_1/robot.py
@@ -81,7 +81,7 @@ class MockRobot(DeviceMock["Robot"]):
         def program_running(*_, **__):
             async def _program_running():
                 set_mock_value(device.program_running, ProgramRunning.PROGRAM_RUNNING)
-                await asyncio.sleep(5)
+                await asyncio.sleep(0.01)
                 set_mock_value(
                     device.program_running, ProgramRunning.NO_PROGRAM_RUNNING
                 )

--- a/src/dodal/devices/beamlines/i15_1/robot.py
+++ b/src/dodal/devices/beamlines/i15_1/robot.py
@@ -81,7 +81,7 @@ class MockRobot(DeviceMock["Robot"]):
         def program_running(*_, **__):
             async def _program_running():
                 set_mock_value(device.program_running, ProgramRunning.PROGRAM_RUNNING)
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(5)
                 set_mock_value(
                     device.program_running, ProgramRunning.NO_PROGRAM_RUNNING
                 )

--- a/src/dodal/devices/interlocks.py
+++ b/src/dodal/devices/interlocks.py
@@ -2,12 +2,15 @@ from abc import ABC, abstractmethod
 from math import isclose
 
 from ophyd_async.core import (
+    DeviceMock,
     EnumTypes,
     SignalR,
     StandardReadable,
     StandardReadableFormat,
     StrictEnum,
+    default_mock_class,
     derived_signal_r,
+    set_mock_value,
 )
 from ophyd_async.epics.core import epics_signal_r
 
@@ -81,6 +84,12 @@ class PSSInterlock(BaseInterlock):
         return isclose(float(status), PSS_SAFE_FOR_OPERATIONS, abs_tol=5e-2)
 
 
+class MockIntPLCInterlock(DeviceMock["IntPLCInterlock"]):
+    async def connect(self, device: "IntPLCInterlock") -> None:
+        set_mock_value(device.status, PLC_SAFE_FOR_OPERATIONS)
+
+
+@default_mock_class(MockIntPLCInterlock)
 class IntPLCInterlock(BaseInterlock):
     """Device to check the interlock state using integer PLC pv."""
 

--- a/tests/devices/test_interlocks.py
+++ b/tests/devices/test_interlocks.py
@@ -58,7 +58,7 @@ async def test_int_plc_interlock_is_readable(int_plc_interlock: IntPLCInterlock)
         int_plc_interlock,
         {
             f"{int_plc_interlock.name}-is_safe": partial_reading(True),
-            f"{int_plc_interlock.name}-status": partial_reading(1),
+            f"{int_plc_interlock.name}-status": partial_reading(65535),
         },
     )
 

--- a/tests/devices/test_interlocks.py
+++ b/tests/devices/test_interlocks.py
@@ -57,8 +57,8 @@ async def test_int_plc_interlock_is_readable(int_plc_interlock: IntPLCInterlock)
     await assert_reading(
         int_plc_interlock,
         {
-            f"{int_plc_interlock.name}-is_safe": partial_reading(False),
-            f"{int_plc_interlock.name}-status": partial_reading(0),
+            f"{int_plc_interlock.name}-is_safe": partial_reading(True),
+            f"{int_plc_interlock.name}-status": partial_reading(1),
         },
     )
 


### PR DESCRIPTION
By default the mock interlock should be safe so that plans generally pass the happy path. This helps in testing https://github.com/DiamondLightSource/daq-queuing-service/issues/45

### Instructions to reviewer on how to test:
1. Confirm changed test works

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
