### PR TITLE
Addresses dodal#2103 apply physically realistic absorption bounds

### DIFF
--- a/src/dodal/common/general_maths/material_absorption_maths.py
+++ b/src/dodal/common/general_maths/material_absorption_maths.py
@@ -14,21 +14,20 @@ from dodal.common.general_maths.transmission_interconversion import (
 
 @validate_call
 def photon_mass_attenuation_per_unit_length(
-    energy_kev: StrictFloat,
-    photon_absorption_factor_per_unit_length: Annotated[StrictFloat, Field(ge=0)],
-    energy_dependence_exponent: Annotated[StrictFloat, Field(le=0)],
+    energy_kev: Annotated[StrictFloat, Field(gt=0)],
+    photon_absorption_factor_per_unit_length: Annotated[StrictFloat, Field(gt=0)],
+    energy_dependence_exponent: Annotated[StrictFloat, Field(lt=0)],
 ) -> float:
     """Calculates mass attenuation per unit length.
 
     Args:
-        energy_kev (StrictFloat): energy
-        photon_absorption_factor_per_unit_length(StrictFloat greater than/equal to 0): p
-        hoton absorption factor per unit length
-        energy_dependence_exponent (StrictFloat less than/equal to 0): energy
-        dependence exponent
+        energy_kev (StrictFloat): X-ray energy in keV (positive values only).
+        photon_absorption_factor_per_unit_length (StrictFloat): Factors of e,
+            in X-ray flux reduction, per unit depth of absorber (positive values only).
+        energy_dependence_exponent (StrictFloat): Roll off of absorption factor (negative values only).
 
     Returns:
-        (float): mass attenuation per unit length.
+        float: Mass attenuation per unit length.
     """
     return photon_absorption_factor_per_unit_length * (
         energy_kev**energy_dependence_exponent
@@ -44,16 +43,17 @@ def attenuation_at_depth_cm(
     0Bn to 1 and 2000 Bn to 1/(e^2).
 
     Args:
-        depth_cm (StrictFloat greater than/equal to 0):  depth of absorption
-        absorption_coefficient_per_cm (StrictFloat greater than/equal to 0): absorption
-        coefficient per cm
+        depth_cm (StrictFloat): Depth of absorber (zero or positive).
+        absorption_coefficient_per_cm (StrictFloat): Modelled absorption,
+            (zero or positive) coefficient per cm,
+            i.e. per cm factors of e reduction in flux.
 
     Raises:
-        ValueError: If either depth_cm or absorption_coefficient are negative, an error
-        is raised
+        ValueError: If either depth_cm or absorption_coefficient are negative,
+                    an error is raised, systems with optical gain are not modelled here.
 
     Returns:
-        (float): attenuation in Barnett units
+        float: Attenuation in Barnett units of a specific depth of absorber.
     """
     ln_t = -(depth_cm * absorption_coefficient_per_cm)
     return attenuation_from_natural_log_of_transmission(ln_t)
@@ -62,23 +62,26 @@ def attenuation_at_depth_cm(
 @validate_call
 def thickness_cm_required_to_attenuate(
     target_attenuation_bn: Annotated[StrictFloat, Field(ge=0)],
-    absorption_coefficient_per_cm: Annotated[StrictFloat, Field(ge=1.0e-14)],
+    absorption_coefficient_per_cm: Annotated[StrictFloat, Field(gt=1.0e-8)],
 ) -> float:
     """Calculates material depth in cm.
 
     Args:
-        target_attenuation_bn (StrictFloat greater than/equal to 0): Target attenuation
-        to meet in Barnett attenuation units.
-        absorption_coefficient_per_cm (StrictFloat greater than/equal to 0):  absorption
-        coefficient per cm
+        target_attenuation_bn (StrictFloat): Target attenuation, (zero or positive),
+            in logarithmic Barnett attenuation units.
+        absorption_coefficient_per_cm (StrictFloat): Factors of e per cm, reduction in flux.
+            N.B. This coefficient is positive (and greater than a lower bound for realism).
 
 
     Raises:
-        ValueError: if attenuation is below zero, or absorption is below the minimum
-        meaningful absorption coefficient, a value error is raised
+        ValueError: if attenuation is below zero,
+            or absorption is less than the lower bound set at the round magnitude 1.0e-8,
+        a value error is raised
+        (Bound set to a round number just below weakest absorption coefficient, of lightest gases,
+         starting around 3.0e-7 per cm for H2),
 
     Returns:
-        (float): material depth in cm.
+        float: material depth in cm.
     """
     ln_target_t = natural_log_of_transmission_from_attenuation(target_attenuation_bn)
     return -(ln_target_t / absorption_coefficient_per_cm)

--- a/tests/common/general_maths/test_material_absorption_maths.py
+++ b/tests/common/general_maths/test_material_absorption_maths.py
@@ -35,12 +35,22 @@ def test_photon_mass_attenuation_per_unit_length(
 @pytest.mark.parametrize(
     "target_attenuation_bn, absorption_coefficient_per_cm, required_cm",
     [
-        (0, 2.4, 0),  # tests attenuator thickness required for transparency is zero
+        (0, 2.4, 0),  # test that attenuator thickness required for transparency is zero
         (
             248.461,
             2.13,
             0.1166483568,
-        ),  # tests attenuator thickness required for arbitrary attenuation
+        ),  # test attenuator thickness required for arbitrary attenuation
+        (
+            248.461,
+            2.03,
+            0.12239458,
+        ),  # test that greater attenuator thickness is needed when material absorbs less
+        (
+            448.641,
+            2.13,
+            0.21062958,
+        ),  # test that greater attenuator thickness is needed to achieve more attenuation
     ],
 )
 def test_thickness_cm_required_to_attenuate(
@@ -74,72 +84,119 @@ def test_attenuation_at_depth_cm(depth_cm, absorption_coefficient_per_cm, result
 
 
 # inauspicious path
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
-def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_energy(bad_input):
+@pytest.mark.parametrize("negative_energy", [-0.1, -12.3, -9739.43])
+def test_photon_mass_attenuation_per_unit_length_errors_with_negative_energy(
+    negative_energy,
+):
+    _absorption_coefficient = 1.98e2
+    _roll_off = -1.75
     with pytest.raises(ValidationError):
-        photon_mass_attenuation_per_unit_length(bad_input, 1.0, 1.0)
+        photon_mass_attenuation_per_unit_length(
+            negative_energy, _absorption_coefficient, _roll_off
+        )
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
-def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_factor(bad_input):
+@pytest.mark.parametrize("invalid_energy", ["a", [], None, math.sin, object(), False])
+def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_energy(
+    invalid_energy,
+):
+    _absorption_coefficient = 1.98e2
+    _roll_off = -2.717
     with pytest.raises(ValidationError):
-        photon_mass_attenuation_per_unit_length(3500.0, bad_input, 1.0)
+        photon_mass_attenuation_per_unit_length(
+            invalid_energy, _absorption_coefficient, _roll_off
+        )
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize(
+    "invalid_absorption", ["a", [], None, math.sin, object(), False]
+)
+def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_factor(
+    invalid_absorption,
+):
+    _energy_kev = 4.512
+    _roll_off = -2.68
+    with pytest.raises(ValidationError):
+        photon_mass_attenuation_per_unit_length(
+            _energy_kev, invalid_absorption, _roll_off
+        )
+
+
+@pytest.mark.parametrize("invalid_roll_off", ["a", [], None, math.sin, object(), False])
 def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_exponent(
-    bad_input,
+    invalid_roll_off,
 ):
+    _energy_kev = 13.819
+    _absorption_coefficient = 24.8
     with pytest.raises(ValidationError):
-        photon_mass_attenuation_per_unit_length(3500.0, 1.0, bad_input)
+        photon_mass_attenuation_per_unit_length(
+            _energy_kev, _absorption_coefficient, invalid_roll_off
+        )
 
 
-def test_thickness_cm_required_to_attenuate_with_transparent_medium():
+def test_thickness_cm_required_to_attenuate_rejects_transparent_medium():
+    _energy_kev = 7.213
+    transparent_medium = 0.0
     with pytest.raises(ValueError):
-        transparent_medium = 1.0e-15
-        thickness_cm_required_to_attenuate(3500.0, transparent_medium)
+        thickness_cm_required_to_attenuate(_energy_kev, transparent_medium)
 
 
-def test_thickness_required_to_attenuate_raises_error_for_gain():
-    with pytest.raises(ValidationError):
-        thickness_cm_required_to_attenuate(-1, 1)
+@pytest.mark.parametrize("unphysical_alpha", [1.0e-15, 3.8e-12, 7.205e-9, -1.6, -0.002])
+def test_thickness_cm_required_to_attenuate_rejects_unphysical_media(unphysical_alpha):
+    _target_attenuation = 750.0
+    with pytest.raises(ValueError):
+        thickness_cm_required_to_attenuate(_target_attenuation, unphysical_alpha)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize(
+    "invalid_target_attenuation", ["a", [], None, math.sin, object(), False]
+)
 def test_thickness_required_to_attenuate_raises_error_with_invalid_target_attenuation(
-    bad_input,
+    invalid_target_attenuation,
 ):
+    _absorption_coefficient = 2.4
     with pytest.raises(ValidationError):
-        thickness_cm_required_to_attenuate(bad_input, 1.0)
+        thickness_cm_required_to_attenuate(
+            invalid_target_attenuation, _absorption_coefficient
+        )
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize(
+    "invalid_absorption", ["a", [], None, math.sin, object(), False]
+)
 def test_thickness_required_to_attenuate_raises_error_with_invalid_absorption(
-    bad_input,
+    invalid_absorption,
 ):
+    _target_attenuation = 1148.2
     with pytest.raises(ValidationError):
-        thickness_cm_required_to_attenuate(1.0, bad_input)
+        thickness_cm_required_to_attenuate(_target_attenuation, invalid_absorption)
 
 
-@pytest.mark.parametrize("bad_input", [-1, -5, -0.1])
-def test_attenuation_at_depth_raises_error_with_invalid_absorption(bad_input):
+@pytest.mark.parametrize("optical_gain", [-1, -5, -0.1])
+def test_attenuation_at_depth_raises_error_with_ineligible_optical_gain(optical_gain):
+    _depth_cm = 0.152
     with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(1.0, bad_input)
+        attenuation_at_depth_cm(_depth_cm, optical_gain)
 
 
-@pytest.mark.parametrize("bad_input", [-1, -5, -0.1])
-def test_attenuation_at_depth_raises_error_for_unphysical_depths(bad_input):
+@pytest.mark.parametrize("unphysical_depth", [-1, -5, -0.1])
+def test_attenuation_at_depth_raises_error_for_unphysical_depths(unphysical_depth):
+    _absorption_coefficient = 1.1
     with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(bad_input, 1.0)
+        attenuation_at_depth_cm(unphysical_depth, _absorption_coefficient)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), True])
-def test_attenuation_at_depth_raises_error_with_invalid_depth(bad_input):
+@pytest.mark.parametrize("invalid_depth", ["a", [], None, math.sin, object(), True])
+def test_attenuation_at_depth_raises_error_with_invalid_depth(invalid_depth):
+    _absorption_coefficient = 3.7
     with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(bad_input, 1.0)
+        attenuation_at_depth_cm(invalid_depth, _absorption_coefficient)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
-def test_attenuation_at_depth_raises_error_with_invalid_attenuation(bad_input):
+@pytest.mark.parametrize(
+    "invalid_absorption", ["a", [], None, math.sin, object(), False]
+)
+def test_attenuation_at_depth_raises_error_with_invalid_attenuation(invalid_absorption):
+    _depth_cm = 0.425
     with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(1.0, bad_input)
+        attenuation_at_depth_cm(_depth_cm, invalid_absorption)


### PR DESCRIPTION
* Tightens permitted absorption coefficients to match physically possible materials

* Consolidates related unit tests

Fixes #2103 

### Instructions to reviewer on how to test:
1. Ensure all tests still pass 

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
