### PR TITLE
Add blower control for i15-1

### DIFF
--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -87,6 +87,7 @@ def blower(config_client: ConfigClient) -> Blower:
     return Blower(
         f"{PREFIX.beamline_prefix}-EA-BLOW-01:",
         f"{PREFIX.beamline_prefix}-EA-BLOWR-01:TLATE",
+        f"{PREFIX.beamline_prefix}-DI-PHDGN-03:STA",
         config_client,
         XPDF_PARAMETERS_FILEPATH,
     )

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -83,8 +83,9 @@ def base_y() -> Motor:
 
 
 @devices.factory()
-def blower_z(config_client: ConfigClient) -> Blower:
+def blower(config_client: ConfigClient) -> Blower:
     return Blower(
+        f"{PREFIX.beamline_prefix}-EA-BLOW-01:",
         f"{PREFIX.beamline_prefix}-EA-BLOWR-01:TLATE",
         config_client,
         XPDF_PARAMETERS_FILEPATH,

--- a/src/dodal/common/enums.py
+++ b/src/dodal/common/enums.py
@@ -17,3 +17,11 @@ class EnabledDisabledUpper(StrictEnum):
 class InOutUpper(StrictEnum):
     IN = "IN"
     OUT = "OUT"
+
+
+class ValveState(StrictEnum):
+    FAULT = "Fault"
+    OPEN = "Open"
+    OPENING = "Opening"
+    CLOSED = "Closed"
+    CLOSING = "Closing"

--- a/src/dodal/devices/beamlines/i15_1/blower.py
+++ b/src/dodal/devices/beamlines/i15_1/blower.py
@@ -2,25 +2,54 @@ from daq_config_server import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )
-from ophyd_async.epics.core import epics_signal_rw
+from ophyd_async.core import derived_signal_rw
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw, epics_signal_w
 
+from dodal.common.enums import ValveState
 from dodal.devices.beamlines.i15_1.safe_or_beam_positioner import SafeOrBeamPositioner
 
 
 class Blower(SafeOrBeamPositioner):
+    """Blows hot air on to the sample, can be moved out of the beam to allow room for
+    a robot load. Temperatures are set in C.
+
+    For safety reasons the heater should only be turned on (set to a >0 temperature) if
+    the given pneumatic is open to allow airflow.
+    """
+
     def __init__(
         self,
         prefix: str,
         motion_pv: str,
+        pneumatic_pv: str,
         config_client: ConfigClient,
         xpdf_parameters_path: str,
     ):
-        with self.add_children_as_readables():
-            self.temperature = epics_signal_rw(float, f"{prefix}PV:RBV", f"{prefix}SP")
+        self._temperature_sp = epics_signal_w(float, f"{prefix}SP")
+        self._temperature_rbv = epics_signal_r(float, f"{prefix}PV:RBV")
 
-        self.ramp_rate = epics_signal_rw(float, f"{prefix}RR", f"{prefix}RR:RBV")
+        with self.add_children_as_readables():
+            self.temperature = derived_signal_rw(
+                self._get_temperature,
+                self._set_temperature,
+                temperature_rbv=self._temperature_rbv,
+            )
+
+        self._pneumatic = epics_signal_r(ValveState, pneumatic_pv)
+        self.ramp_rate_c_per_sec = epics_signal_rw(
+            float, f"{prefix}RR", f"{prefix}RR:RBV"
+        )
 
         super().__init__(motion_pv, config_client, xpdf_parameters_path)
+
+    def _get_temperature(self, temperature_rbv: float) -> float:
+        return temperature_rbv
+
+    async def _set_temperature(self, temperature: float):
+        pneumatic_state = await self._pneumatic.get_value()
+        if temperature > 0 and pneumatic_state != ValveState.OPEN:
+            raise ValueError("Blower cannot be turned on pneumatic is not open")
+        self._temperature_sp.set(temperature)
 
     def get_config(self) -> TemperatureControllerParams:
         return self.get_full_config().blower

--- a/src/dodal/devices/beamlines/i15_1/blower.py
+++ b/src/dodal/devices/beamlines/i15_1/blower.py
@@ -46,6 +46,10 @@ class Blower(SafeOrBeamPositioner):
         return temperature_rbv
 
     async def _set_temperature(self, temperature: float):
+        """Sets the temperature on the blower.
+
+        A negative or 0 temperature will turn the blower off.
+        """
         pneumatic_state = await self._pneumatic.get_value()
         if temperature > 0 and pneumatic_state != ValveState.OPEN:
             raise ValueError("Blower cannot be turned on pneumatic is not open")

--- a/src/dodal/devices/beamlines/i15_1/blower.py
+++ b/src/dodal/devices/beamlines/i15_1/blower.py
@@ -1,10 +1,26 @@
+from daq_config_server import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )
+from ophyd_async.epics.core import epics_signal_rw
 
 from dodal.devices.beamlines.i15_1.safe_or_beam_positioner import SafeOrBeamPositioner
 
 
 class Blower(SafeOrBeamPositioner):
+    def __init__(
+        self,
+        prefix: str,
+        motion_pv: str,
+        config_client: ConfigClient,
+        xpdf_parameters_path: str,
+    ):
+        with self.add_children_as_readables():
+            self.temperature = epics_signal_rw(float, f"{prefix}PV:RBV", f"{prefix}SP")
+
+        self.ramp_rate = epics_signal_rw(float, f"{prefix}RR", f"{prefix}RR:RBV")
+
+        super().__init__(motion_pv, config_client, xpdf_parameters_path)
+
     def get_config(self) -> TemperatureControllerParams:
         return self.get_full_config().blower

--- a/src/dodal/devices/pressure_jump_cell.py
+++ b/src/dodal/devices/pressure_jump_cell.py
@@ -20,6 +20,8 @@ from ophyd_async.core import (
 )
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
+from dodal.common.enums import ValveState
+
 OPENSEQ_PULSE_LENGTH = 0.2
 
 
@@ -52,14 +54,6 @@ class PumpMotorDirectionState(StrictEnum):
     EMPTY = ""
     FORWARD = "Forward"
     REVERSE = "Reverse"
-
-
-class ValveState(StrictEnum):
-    FAULT = "Fault"
-    OPEN = "Open"
-    OPENING = "Opening"
-    CLOSED = "Closed"
-    CLOSING = "Closing"
 
 
 class FastValveState(StrictEnum):

--- a/tests/devices/beamlines/i15_1/test_blower.py
+++ b/tests/devices/beamlines/i15_1/test_blower.py
@@ -4,6 +4,7 @@ from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )
 from ophyd_async.core import get_mock_put, init_devices, set_mock_value
+from ophyd_async.testing import assert_reading, partial_reading
 
 from dodal.common.enums import ValveState
 from dodal.devices.beamlines.i15_1.blower import Blower
@@ -56,3 +57,16 @@ async def test_given_pneumatic_is_closed_then_temperature_can_be_turned_off(
 
     await blower.temperature.set(0)
     get_mock_put(blower._temperature_sp).assert_called_once_with(0)
+
+
+async def test_when_temperature_is_read_then_read_underlying_pv(
+    blower: Blower,
+):
+    set_mock_value(blower._temperature_rbv, 100)
+
+    await assert_reading(
+        blower.temperature,
+        {
+            "blower-temperature": partial_reading(100),
+        },
+    )

--- a/tests/devices/beamlines/i15_1/test_blower.py
+++ b/tests/devices/beamlines/i15_1/test_blower.py
@@ -1,14 +1,23 @@
+import pytest
 from daq_config_server import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )
+from ophyd_async.core import get_mock_put, init_devices, set_mock_value
 
+from dodal.common.enums import ValveState
 from dodal.devices.beamlines.i15_1.blower import Blower
 from tests.test_data import TEST_XPDF_LOCAL_PARAMETERS
 
 
-def test_blower_config_client_reads_config_file_successfully():
-    blower = Blower("", ConfigClient(""), TEST_XPDF_LOCAL_PARAMETERS)
+@pytest.fixture
+async def blower():
+    async with init_devices(mock=True):
+        blower = Blower("", "", "", ConfigClient(""), TEST_XPDF_LOCAL_PARAMETERS)
+    return blower
+
+
+def test_blower_config_client_reads_config_file_successfully(blower: Blower):
     assert blower.get_config() == TemperatureControllerParams(
         beam_position=44.7,
         safe_position=2.0,
@@ -20,3 +29,30 @@ def test_blower_config_client_reads_config_file_successfully():
         use_fast_cool=None,
         calibration_file="blower_cal_10_03_2026.txt",
     )
+
+
+async def test_given_pneumatic_is_open_then_temperature_can_be_changed(blower: Blower):
+    set_mock_value(blower._pneumatic, ValveState.OPEN)
+
+    await blower.temperature.set(100)
+    get_mock_put(blower._temperature_sp).assert_called_once_with(100)
+
+
+async def test_given_pneumatic_is_closed_then_temperature_can_not_be_turned_on(
+    blower: Blower,
+):
+    set_mock_value(blower._pneumatic, ValveState.CLOSED)
+
+    with pytest.raises(ValueError):
+        await blower.temperature.set(100)
+    get_mock_put(blower._temperature_sp).assert_not_called()
+
+
+async def test_given_pneumatic_is_closed_then_temperature_can_be_turned_off(
+    blower: Blower,
+):
+    set_mock_value(blower._pneumatic, ValveState.CLOSED)
+    set_mock_value(blower._pneumatic, ValveState.CLOSED)
+
+    await blower.temperature.set(0)
+    get_mock_put(blower._temperature_sp).assert_called_once_with(0)


### PR DESCRIPTION
Fixes #2109 

Need to merge https://github.com/DiamondLightSource/crystallography-bluesky/pull/93 at the same time

### Instructions to reviewer on how to test:
1. Confirm tests pass
2. Confirm a `dodal connect i15-1` passes

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
