### PR TITLE
Update to ophyd-async 0.19.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "Ophyd devices and other utils that could be used across DLS beaml
 dependencies = [
     "click",
     "ophyd",
-    "ophyd-async[ca,pva]>=0.19.2",
+    "ophyd-async[ca,pva]>=0.19.3",
     "bluesky>=1.14.5",
     "pyepics",
     "pillow",
@@ -24,7 +24,7 @@ dependencies = [
     "requests",
     "graypy",
     "pydantic>=2.0",
-    "opencv-python-headless",                                                                   # For pin-tip detection.
+    "opencv-python-headless",          # For pin-tip detection.
     "numpy",
     "aiofiles",
     "aiohttp",
@@ -32,8 +32,8 @@ dependencies = [
     "scanspec>=0.7.3",
     "pyzmq==27.1.0",
     "deepdiff",
-    "daq-config-server >= 1.3.6", # For getting Configuration settings.
-    "mysql-connector-python == 9.5.0",                                                          # Can unpin once https://github.com/DiamondLightSource/ispyb-api/pull/244 is merged and released
+    "daq-config-server >= 1.3.6",      # For getting Configuration settings.
+    "mysql-connector-python == 9.5.0", # Can unpin once https://github.com/DiamondLightSource/ispyb-api/pull/244 is merged and released
 ]
 
 dynamic = ["version"]
@@ -51,7 +51,7 @@ dev = [
     # Commented out due to dependency version conflict with pydantic 1.x
     # "copier",
     "myst-parser",
-    "ophyd_async[sim]>=v0.19.2",
+    "ophyd_async[sim]>=v0.19.3",
     "pre-commit",
     "psutil",
     "pydata-sphinx-theme>=0.12",

--- a/src/dodal/devices/beamlines/i10_1/high_field_magnet/high_field_magnet.py
+++ b/src/dodal/devices/beamlines/i10_1/high_field_magnet/high_field_magnet.py
@@ -18,6 +18,7 @@ from ophyd_async.core import (
     StandardReadableFormat,
     StrictEnum,
     SubsetEnum,
+    TimeoutCalculator,
     WatchableAsyncStatus,
     derived_signal_r,
     error_if_none,
@@ -81,13 +82,13 @@ class ToleranceMovableLogic(MovableLogic[float]):
             raise ValueError(msg) from error
         return timeout
 
-    async def move(self, new_position: float, timeout: float | None) -> None:
+    async def move(self, new_position: float, timeout: TimeoutCalculator) -> None:
         await set_and_wait_for_other_value(
             set_signal=self.setpoint,
             set_value=new_position,
             match_signal=self.within_tolerance,
             match_value=True,
-            timeout=timeout,
+            timeout=timeout(),
         )
 
 

--- a/tests/devices/beamlines/i10_1/high_field_magnet/test_high_field_magnet.py
+++ b/tests/devices/beamlines/i10_1/high_field_magnet/test_high_field_magnet.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Mapping
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pytest
@@ -12,6 +12,7 @@ from ophyd_async.core import (
     init_devices,
     set_mock_value,
 )
+from ophyd_async.core._movable import MoveTimeout
 from ophyd_async.testing import assert_reading, partial_reading
 
 from dodal.devices.beamlines.i10_1.high_field_magnet.high_field_magnet import (
@@ -85,11 +86,17 @@ async def test_set_calculates_correct_timeout(
     set_mock_value(high_field_magnet.user_setpoint, 0.0)
 
     high_field_magnet.movable_logic.move = AsyncMock()
-    await high_field_magnet.set(new_position)
-    expected_timeout = new_position / sweep_rate + 2 * ramp_up_time + DEFAULT_TIMEOUT
-    high_field_magnet.movable_logic.move.assert_called_with(
-        new_position=new_position, timeout=expected_timeout
-    )
+    with patch("ophyd_async.core._movable.MoveTimeout") as mock_timeout_calculator:
+        await high_field_magnet.set(new_position)
+        print(mock_timeout_calculator.call_args)
+        print(mock_timeout_calculator.call_count)
+        expected_timeout = (
+            new_position / sweep_rate + 2 * ramp_up_time + DEFAULT_TIMEOUT
+        )
+        mock_timeout_calculator.assert_called_once_with(expected_timeout)
+        high_field_magnet.movable_logic.move.assert_called_with(
+            new_position=new_position, timeout=mock_timeout_calculator.return_value
+        )
 
 
 async def test_prepare(high_field_magnet: HighFieldMagnet):
@@ -191,7 +198,9 @@ async def test_tolerance_logic_calculate_timeout_with_zero_speed(
 
 async def test_tolerance_logic_move(high_field_magnet: HighFieldMagnet):
     set_mock_value(high_field_magnet.movable_logic.readback, 0.0)
-    move_task = high_field_magnet.movable_logic.move(new_position=10.0, timeout=5.0)
+    move_task = high_field_magnet.movable_logic.move(
+        new_position=10.0, timeout=MoveTimeout(5.0)
+    )
     for value in [2.0, 5.0, 8.0, 9.5, 13.0]:
         set_mock_value(high_field_magnet.movable_logic.readback, value)
         await asyncio.sleep(0.0)

--- a/tests/devices/beamlines/i10_1/high_field_magnet/test_high_field_magnet.py
+++ b/tests/devices/beamlines/i10_1/high_field_magnet/test_high_field_magnet.py
@@ -88,8 +88,6 @@ async def test_set_calculates_correct_timeout(
     high_field_magnet.movable_logic.move = AsyncMock()
     with patch("ophyd_async.core._movable.MoveTimeout") as mock_timeout_calculator:
         await high_field_magnet.set(new_position)
-        print(mock_timeout_calculator.call_args)
-        print(mock_timeout_calculator.call_count)
         expected_timeout = (
             new_position / sweep_rate + 2 * ramp_up_time + DEFAULT_TIMEOUT
         )

--- a/tests/devices/test_bart_robot.py
+++ b/tests/devices/test_bart_robot.py
@@ -152,10 +152,10 @@ async def test_given_program_not_running_but_pin_not_unmounting_when_load_pin_th
     device = bart_robot
     _set_fast_robot_timeouts(device)
     set_mock_value(device.gonio_pin_sensor, PinMounted.PIN_MOUNTED)
-    device.load = AsyncMock(side_effect=device.load)
+    device.load.trigger = AsyncMock(side_effect=device.load.trigger)
     with pytest.raises(RobotLoadError):
         await device.set(SampleLocation(15, 10))
-    device.load.trigger.assert_called_once()  # type:ignore
+    device.load.trigger.assert_called_once()
     last_log = patch_logger.mock_calls[1].args[0]
     assert WAIT_FOR_BEAMLINE_DISABLE_MSG in last_log
 
@@ -168,12 +168,12 @@ async def test_given_program_not_running_and_pin_unmounting_but_new_pin_not_moun
     device = bart_robot
     _set_fast_robot_timeouts(device)
     set_mock_value(device.gonio_pin_sensor, PinMounted.NO_PIN_MOUNTED)
-    device.load = AsyncMock(side_effect=device.load)
+    device.load.trigger = AsyncMock(side_effect=device.load.trigger)
     with pytest.raises(RobotLoadError) as exc_info:
         await device.set(SampleLocation(15, 10))
 
     try:
-        device.load.trigger.assert_called_once()  # type:ignore
+        device.load.trigger.assert_called_once()
         last_log = patch_logger.mock_calls[1].args[0]
         assert WAIT_FOR_BEAMLINE_DISABLE_MSG in last_log
     except AssertionError:

--- a/tests/devices/test_gridscan.py
+++ b/tests/devices/test_gridscan.py
@@ -459,7 +459,7 @@ async def test_timeout_on_complete_triggers_stop_and_logs_error(
     zebra_fast_grid_scan: ZebraFastGridScanThreeD,
 ):
     zebra_fast_grid_scan.COMPLETE_STATUS = 0.01
-    zebra_fast_grid_scan.stop_cmd = AsyncMock()
+    zebra_fast_grid_scan.stop_cmd.trigger = AsyncMock()
     set_mock_value(zebra_fast_grid_scan.status, 1)
     with pytest.raises(TimeoutError):
         await zebra_fast_grid_scan.complete()

--- a/uv.lock
+++ b/uv.lock
@@ -824,7 +824,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "opencv-python-headless" },
     { name = "ophyd" },
-    { name = "ophyd-async", extras = ["ca", "pva"], specifier = ">=0.19.2" },
+    { name = "ophyd-async", extras = ["ca", "pva"], specifier = ">=0.19.3" },
     { name = "pillow" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyepics" },
@@ -843,7 +843,7 @@ dev = [
     { name = "ispyb" },
     { name = "mypy" },
     { name = "myst-parser" },
-    { name = "ophyd-async", extras = ["sim"], specifier = ">=0.19.2" },
+    { name = "ophyd-async", extras = ["sim"], specifier = ">=0.19.3" },
     { name = "pre-commit" },
     { name = "psutil" },
     { name = "pydata-sphinx-theme", specifier = ">=0.12" },
@@ -2256,7 +2256,7 @@ wheels = [
 
 [[package]]
 name = "ophyd-async"
-version = "0.19.2"
+version = "0.19.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluesky" },
@@ -2270,9 +2270,9 @@ dependencies = [
     { name = "stamina" },
     { name = "velocity-profile" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/d9/bc09637a5caff453a205fa3c26474f497964618b72074413a6315d36725b/ophyd_async-0.19.2.tar.gz", hash = "sha256:138dcd5ac2ccc30194c9d74525aefb291b8a0be2ef3468a60e294f0fcea5495a", size = 588686, upload-time = "2026-06-16T15:31:31.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/20/1241051befc05c21c958206611f9ed058d81b8e8f92e3acf9f9d6936f2fc/ophyd_async-0.19.3.tar.gz", hash = "sha256:9cb76a8a08794a26c619a0420012e7248542501d036f16f3314221869e989984", size = 595679, upload-time = "2026-06-29T15:21:37.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/36/96ac313cc51e147556e80d2388ca7c55672d13c06cb87353d8d607125284/ophyd_async-0.19.2-py3-none-any.whl", hash = "sha256:2cdd5ce876ce00246d043c581b1bb4074984822a879a330637a3188ace8e1f3e", size = 228241, upload-time = "2026-06-16T15:31:29.546Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/76ac5e485f6405fc0f1dbbd1c98b7c1137d4aa5c1e49ea9e69bbd8d22ae1/ophyd_async-0.19.3-py3-none-any.whl", hash = "sha256:ef6201edb52e5a54008d57cad1808626aa6493ba4a8fd015e08d14bcffbb697a", size = 232796, upload-time = "2026-06-29T15:21:36.46Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Updated devices and tests to work with ophyd-async 0.19.3. The robot tests were failing with the below:

```/workspaces/dodal/tests/devices/test_gridscan.py::test_timeout_on_complete_triggers_stop_and_logs_error failed: Traceback (most recent call last): File "/root/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/warnings.py", line 538, in _warn_unawaited_coroutine warn(msg, category=RuntimeWarning, stacklevel=2, source=coro) RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited The above exception was the direct cause of the following exception: Traceback (most recent call last): File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/runner.py", line 353, in from_call result: TResult | None = func() ^^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/runner.py", line 245, in <lambda> lambda: runtest_hook(item=item, **kwds), ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_hooks.py", line 512, in __call__ return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec return self._inner_hookexec(hook_name, methods, kwargs, firstresult) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall raise exception File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall teardown.throw(exception) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/logging.py", line 850, in pytest_runtest_call yield File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall teardown.throw(exception) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper return result.get_result() ^^^^^^^^^^^^^^^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_result.py", line 103, in get_result raise exc.with_traceback(tb) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper res = yield ^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall teardown.throw(exception) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/capture.py", line 900, in pytest_runtest_call return (yield) ^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall teardown.throw(exception) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper return result.get_result() ^^^^^^^^^^^^^^^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_result.py", line 103, in get_result raise exc.with_traceback(tb) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper res = yield ^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall teardown.throw(exception) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/skipping.py", line 268, in pytest_runtest_call return (yield) ^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall res = hook_impl.function(*args) ^^^^^^^^^^^^^^^^^^^^^^^^^ File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/unraisableexception.py", line 158, in pytest_runtest_call collect_unraisable(item.config) File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/unraisableexception.py", line 79, in collect_unraisable raise errors[0] File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/unraisableexception.py", line 67, in collect_unraisable warnings.warn(pytest.PytestUnraisableExceptionWarning(msg)) pytest.PytestUnraisableExceptionWarning: Exception ignored in: <coroutine object AsyncMockMixin._execute_mock_call at 0x7fe68dd75840> Enable tracemalloc to get traceback where the object was allocated. See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.```

So have also fixed this.

### Instructions to reviewer on how to test:
1. Do thing x
2. Confirm thing y happens

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
