### PR TITLE
mx-bluesky#1765 Refactor grid parameters

### DIFF
--- a/src/dodal/devices/detector/detector.py
+++ b/src/dodal/devices/detector/detector.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 from functools import cached_property
 from pathlib import Path
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, field_serializer, field_validator
 
 from dodal.common.beamlines.beamline_utils import get_config_client
 from dodal.devices.detector.det_dim_constants import (
@@ -15,7 +15,6 @@ from dodal.devices.detector.det_dist_to_beam_converter import (
     Axis,
     DetectorDistanceToBeamXYConverter,
 )
-from dodal.utils import get_run_number
 
 
 class TriggerMode(Enum):
@@ -46,25 +45,17 @@ class DetectorParams(BaseModel):
     num_triggers: int
     use_roi_mode: bool
     det_dist_to_beam_converter_path: str
-    override_run_number: int | None = Field(default=None, alias="run_number")
     trigger_mode: TriggerMode = TriggerMode.SET_FRAMES
     detector_size_constants: DetectorSizeConstants = EIGER2_X_16M_SIZE
     enable_dev_shm: bool = (
         False  # Remove in https://github.com/DiamondLightSource/hyperion/issues/1395
     )
+    run_number: int
 
     @cached_property
     def beam_xy_converter(self) -> DetectorDistanceToBeamXYConverter:
         return DetectorDistanceToBeamXYConverter(
             self.det_dist_to_beam_converter_path, get_config_client()
-        )
-
-    @property
-    def run_number(self) -> int:
-        return (
-            get_run_number(self.directory, self.prefix)
-            if self.override_run_number is None
-            else self.override_run_number
         )
 
     @field_serializer("detector_size_constants")

--- a/src/dodal/plans/configure_arm_trigger_and_disarm_detector.py
+++ b/src/dodal/plans/configure_arm_trigger_and_disarm_detector.py
@@ -15,6 +15,7 @@ from ophyd_async.fastcs.eiger import EigerDetector
 from dodal.beamlines.i03 import fastcs_eiger
 from dodal.devices.detector import DetectorParams
 from dodal.log import LOGGER, do_default_logging_setup
+from dodal.utils import get_run_number
 
 
 @bpp.run_decorator()
@@ -167,13 +168,14 @@ if __name__ == "__main__":
     )
 
     eiger = fastcs_eiger.build(connect_immediately=True, path_provider=path_provider)
+    storage_directory = "/dls/i03/data/2025/cm40607-2/test_new_eiger/"
     run_engine(
         configure_arm_trigger_and_disarm_detector(
             eiger=eiger,
             detector_params=DetectorParams(
                 expected_energy_ev=12800,
                 exposure_time_s=0.01,
-                directory="/dls/i03/data/2025/cm40607-2/test_new_eiger/",
+                directory=storage_directory,
                 prefix="",
                 detector_distance=255,
                 omega_start=0,
@@ -182,6 +184,7 @@ if __name__ == "__main__":
                 num_triggers=1,
                 use_roi_mode=False,
                 det_dist_to_beam_converter_path="/dls_sw/i03/software/daq_configuration/lookup/DetDistToBeamXYConverter.txt",
+                run_number=get_run_number(storage_directory, ""),
             ),
             trigger_info=TriggerInfo(
                 number_of_events=1,

--- a/tests/devices/detector/test_detector.py
+++ b/tests/devices/detector/test_detector.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -23,6 +23,7 @@ def create_det_params_with_dir_and_prefix(directory: str | Path, prefix="test"):
         use_roi_mode=False,
         det_dist_to_beam_converter_path=TEST_LUT_TXT,
         detector_size_constants=EIGER2_X_16M_SIZE,
+        run_number=123456,
     )
 
 
@@ -72,43 +73,6 @@ def test_correct_det_dist_to_beam_converter_path_passed_in(
     assert params.beam_xy_converter.lookup_file == "a fake directory"
 
 
-def test_run_number_correct_when_not_specified(tmp_path):
-    params = DetectorParams(
-        expected_energy_ev=100,
-        exposure_time_s=1.0,
-        directory=str(tmp_path),
-        prefix="test",
-        detector_distance=1.0,
-        omega_start=0.0,
-        omega_increment=0.0,
-        num_images_per_trigger=1,
-        num_triggers=1,
-        use_roi_mode=False,
-        det_dist_to_beam_converter_path="a fake directory",
-        detector_size_constants=EIGER2_X_16M_SIZE,
-    )
-    assert params.run_number == 1
-
-
-def test_run_number_correct_when_specified(tmp_path):
-    params = DetectorParams(
-        expected_energy_ev=100,
-        exposure_time_s=1.0,
-        directory=str(tmp_path),
-        run_number=6,
-        prefix="test",
-        detector_distance=1.0,
-        omega_start=0.0,
-        omega_increment=0.0,
-        num_images_per_trigger=1,
-        num_triggers=1,
-        use_roi_mode=False,
-        det_dist_to_beam_converter_path="a fake directory",
-        detector_size_constants=EIGER2_X_16M_SIZE,
-    )
-    assert params.run_number == 6
-
-
 def test_detector_params_is_serialisable(tmp_path):
     params = DetectorParams(
         expected_energy_ev=100,
@@ -123,9 +87,9 @@ def test_detector_params_is_serialisable(tmp_path):
         use_roi_mode=False,
         det_dist_to_beam_converter_path="a fake directory",
         detector_size_constants=EIGER2_X_16M_SIZE,
+        run_number=123456,
     )
     json = params.model_dump_json()
-    assert '"run_number"' not in json
     new_params = DetectorParams.model_validate_json(json)
     assert new_params == params
 
@@ -155,19 +119,3 @@ def test_detector_params_deserialisation_unchanged(tmp_path: Path):
     assert '"run_number": 17' in json
     new_params = DetectorParams.model_validate_json(json)
     assert new_params.run_number == 17
-
-
-@patch("os.listdir")
-def test_prefix_is_used_to_determine_run_number(
-    mock_listdir: MagicMock, tmp_path: Path
-):
-    foos = (f"foo_{i}.nxs" for i in range(4))
-    bars = (f"bar_{i}.nxs" for i in range(7))
-    bazs = (f"baz_{i}.nxs" for i in range(23, 29))
-    files = [*foos, *bars, *bazs]
-    mock_listdir.return_value = files
-
-    assert create_det_params_with_dir_and_prefix(tmp_path, "foo").run_number == 4
-    assert create_det_params_with_dir_and_prefix(tmp_path, "bar").run_number == 7
-    assert create_det_params_with_dir_and_prefix(tmp_path, "baz").run_number == 29
-    assert create_det_params_with_dir_and_prefix(tmp_path, "qux").run_number == 1

--- a/tests/devices/test_gridscan.py
+++ b/tests/devices/test_gridscan.py
@@ -1,11 +1,9 @@
 import asyncio
 from asyncio import wait_for
-from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import numpy as np
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky import preprocessors as bpp
@@ -303,11 +301,6 @@ def panda_grid_scan_params():
     )
 
 
-@pytest.fixture(params=["zebra_grid_scan_params", "panda_grid_scan_params"])
-def common_grid_scan_params(request: pytest.FixtureRequest):
-    return request.getfixturevalue(request.param)
-
-
 @pytest.fixture(
     params=[
         [
@@ -343,59 +336,6 @@ def grid_scan_devices_with_params_and_valid_state(request: pytest.FixtureRequest
             for signal, expected_value in request.param[2].items()
         },
     )
-
-
-@pytest.mark.parametrize(
-    "grid_position, expected",
-    [
-        [np.array([-1, 2, 4]), pytest.raises(IndexError)],
-        [np.array([11, 2, 4]), pytest.raises(IndexError)],
-        [np.array([1, 17, 4]), pytest.raises(IndexError)],
-        [np.array([1, 5, 22]), pytest.raises(IndexError)],
-        [np.array([0, 0, 0]), nullcontext(np.array([0, 1, 4]))],
-        [np.array([1, 1, 1]), nullcontext(np.array([0.3, 1.2, 4.1]))],
-        [np.array([2, 11, 16]), nullcontext(np.array([0.6, 3.2, 5.6]))],
-        [np.array([6, 5, 5]), nullcontext(np.array([1.8, 2.0, 4.5]))],
-        [np.array([-0.51, 5, 5]), pytest.raises(IndexError)],
-        [
-            np.array([-0.5, 5, 5]),
-            nullcontext(np.array([-0.5 * 0.3, 1 + 5 * 0.2, 4 + 5 * 0.1])),
-        ],
-        [np.array([5, -0.51, 5]), pytest.raises(IndexError)],
-        [
-            np.array([5, -0.5, 5]),
-            nullcontext(np.array([5 * 0.3, 1 - 0.5 * 0.2, 4 + 5 * 0.1])),
-        ],
-        [np.array([5, 5, -0.51]), pytest.raises(IndexError)],
-        [
-            np.array([5, 5, -0.5]),
-            nullcontext(np.array([5 * 0.3, 1 + 5 * 0.2, 4 - 0.5 * 0.1])),
-        ],
-        [np.array([9.51, 5, 5]), pytest.raises(IndexError)],
-        [
-            np.array([9.5, 5, 5]),
-            nullcontext(np.array([9.5 * 0.3, 1 + 5 * 0.2, 4 + 5 * 0.1])),
-        ],
-        [np.array([5, 14.51, 5]), pytest.raises(IndexError)],
-        [
-            np.array([5, 14.5, 5]),
-            nullcontext(np.array([5 * 0.3, 1 + 14.5 * 0.2, 4 + 5 * 0.1])),
-        ],
-        [np.array([5, 5, 19.51]), pytest.raises(IndexError)],
-        [
-            np.array([5, 5, 19.5]),
-            nullcontext(np.array([5 * 0.3, 1 + 5 * 0.2, 4 + 19.5 * 0.1])),
-        ],
-    ],
-)
-def test_given_x_y_z_out_of_range_then_converting_to_motor_coords_raises(
-    common_grid_scan_params: GridScanParamsCommon, grid_position, expected
-):
-    with expected as expected_value:
-        motor_position = common_grid_scan_params.grid_position_to_motor_position(
-            grid_position
-        )
-        assert np.allclose(motor_position, expected_value)
 
 
 def test_can_run_fast_grid_scan_in_run_engine(


### PR DESCRIPTION
Part of fix for:

* DiamondLightSource/mx-bluesky#1765

See also:

* DiamondLightSource/mx-bluesky#1787

This removes `grid_position_to_motor_position()`. The function is now part of `xrc_result_utils` in mx-bluesky.

### Instructions to reviewer on how to test:
1. Tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
