### PR TITLE
I15-1: Use defered moves on the hexapod

### DIFF
--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -18,6 +18,7 @@ from dodal.devices.beamlines.i15_1.attenuator import Attenuator
 from dodal.devices.beamlines.i15_1.blower import Blower
 from dodal.devices.beamlines.i15_1.cobra import Cobra
 from dodal.devices.beamlines.i15_1.cryostream import Cryostream
+from dodal.devices.beamlines.i15_1.hexapod import Hexapod
 from dodal.devices.beamlines.i15_1.laue import LaueMonochrometer
 from dodal.devices.beamlines.i15_1.puck_detector import PuckDetect
 from dodal.devices.beamlines.i15_1.robot import Robot
@@ -25,7 +26,7 @@ from dodal.devices.hutch_shutter import (
     InterlockedHutchShutter,
 )
 from dodal.devices.interlocks import EnumPLCInterlock, IntPLCInterlock, PSSInterlock
-from dodal.devices.motors import XYPhiStage, XYStage, XYZStage, YZStage
+from dodal.devices.motors import XYPhiStage, XYStage, YZStage
 from dodal.devices.slits import Slits
 from dodal.devices.synchrotron import Synchrotron
 from dodal.devices.tetramm import TetrammDetector
@@ -139,19 +140,10 @@ def f2y() -> Motor:
 
 
 @devices.factory()
-def hexapod() -> XYZStage:
-    return XYZStage(
+def hexapod() -> Hexapod:
+    return Hexapod(
         f"{PREFIX.beamline_prefix}-MO-HEX-01:",
-    )
-
-
-@devices.factory()
-def hexapod_rotation() -> XYZStage:
-    return XYZStage(
-        f"{PREFIX.beamline_prefix}-MO-HEX-01:",
-        x_infix="RX",
-        y_infix="RY",
-        z_infix="RZ",
+        f"{PREFIX.beamline_prefix}-MO-STEP-05:CS2:DeferMoves",
     )
 
 

--- a/src/dodal/devices/beamlines/i15_1/hexapod.py
+++ b/src/dodal/devices/beamlines/i15_1/hexapod.py
@@ -1,0 +1,70 @@
+from typing import TypedDict
+
+from ophyd_async.core import AsyncStatus
+from ophyd_async.epics.core import epics_signal_rw
+from ophyd_async.epics.motor import Motor
+
+from dodal.devices.defered_move_utils import (
+    DeferMoves,
+    combined_move_to_motor_setpoints,
+    do_deferred_move,
+)
+from dodal.devices.motors import XYZStage
+from dodal.log import LOGGER
+
+
+class CombinedMove(TypedDict, total=False):
+    """A move on multiple axes at once using a deferred move.
+
+    Attributes:
+        x (float): target x-coordinate in mm
+        y (float): target y-coordinate in mm
+        z (float): target z-coordinate in mm
+        rx (float): target rx angle in degrees
+        ry (float): target rx angle in degrees
+        rz (float): target rx angle in degrees
+    """
+
+    x: float | None
+    y: float | None
+    z: float | None
+    rx: float | None
+    ry: float | None
+    rz: float | None
+
+
+class Hexapod(XYZStage):
+    """The Hexapod that holds the sample.
+
+    If you would like to use multiple axes at once use the combined move like:
+
+    >>> mv(hexapod, {"x": 10.0, "y":1.0})
+    """
+
+    DEFERRED_MOVE_SET_TIMEOUT = 5
+
+    def __init__(self, prefix: str, defer_move_pv: str, name: str = ""):
+        self.rx = Motor(f"{prefix}RX")
+        self.ry = Motor(f"{prefix}RY")
+        self.rz = Motor(f"{prefix}RZ")
+        self.defer_move = epics_signal_rw(DeferMoves, defer_move_pv)
+        super().__init__(prefix, name)
+
+    @AsyncStatus.wrap
+    async def set(self, value: CombinedMove):
+        """This will move all motion together in a deferred move.
+
+        Once defer_move is on, sets to any axis do not immediately move the axis. Instead
+        the setpoint will go to that value. Then, when defer_move is switched off all
+        axes will move at the same time. The put callbacks on the axes themselves will
+        only come back after the motion on that axis finished.
+        """
+        LOGGER.info("Doing hexapod deferred move")
+
+        motor_moves = combined_move_to_motor_setpoints(value, self)
+
+        await do_deferred_move(
+            self.defer_move,
+            motor_moves,
+            self.DEFERRED_MOVE_SET_TIMEOUT,
+        )

--- a/src/dodal/devices/defered_move_utils.py
+++ b/src/dodal/devices/defered_move_utils.py
@@ -1,0 +1,77 @@
+import asyncio
+from collections.abc import Mapping
+from contextlib import asynccontextmanager
+from typing import Any
+
+from ophyd_async.core import (
+    SignalW,
+    StandardReadable,
+    StrictEnum,
+    set_and_wait_for_value,
+)
+from ophyd_async.epics.motor import Motor
+
+
+class DeferMoves(StrictEnum):
+    ON = "Defer On"
+    OFF = "Defer Off"
+
+
+@asynccontextmanager
+async def _deferred_move(signal: SignalW[DeferMoves]):
+    await signal.set(DeferMoves.ON)
+    try:
+        yield
+    finally:
+        await signal.set(DeferMoves.OFF)
+
+
+def combined_move_to_motor_setpoints(
+    combined_move: Mapping[str, Any], device: StandardReadable
+):
+    motor_moves = {}
+    for motor_name, new_setpoint in combined_move.items():
+        if new_setpoint is not None and isinstance(new_setpoint, float | int):
+            try:
+                motor = getattr(device, motor_name)
+                assert isinstance(motor, Motor)
+            except Exception as e:
+                raise LookupError(
+                    f"Motor {motor_name} not found in combined move"
+                ) from e
+            motor_moves[motor] = new_setpoint
+    return motor_moves
+
+
+async def do_deferred_move(
+    defer_signal: SignalW[DeferMoves],
+    moves: dict[Motor, float],
+    timeout: float,
+):
+    """This will move all motion together in a deferred move.
+
+    Once defer_move is on, sets to any axis do not immediately move the axis. Instead
+    the setpoint will go to that value. Then, when defer_move is switched off all
+    axes will move at the same time. The put callbacks on the axes themselves will
+    only come back after the motion on that axis finished.
+    """
+    finished = []
+
+    async with _deferred_move(defer_signal):
+        for axis, value in moves.items():
+            # A regular motor move would do this internally but we ned to set the
+            # user_setpoint (see below)
+            await axis.check_value(value)
+
+            # Wait for the setpoint to reach the value so we know the IOC has received
+            # the put
+            status = await set_and_wait_for_value(
+                axis.user_setpoint,
+                value,
+                timeout=timeout,
+                wait_for_set_completion=False,
+            )
+
+            finished.append(status)
+
+    await asyncio.gather(*finished)

--- a/src/dodal/devices/defered_move_utils.py
+++ b/src/dodal/devices/defered_move_utils.py
@@ -59,7 +59,7 @@ async def do_deferred_move(
 
     async with _deferred_move(defer_signal):
         for axis, value in moves.items():
-            # A regular motor move would do this internally but we ned to set the
+            # A regular motor move would do this internally but we need to set the
             # user_setpoint (see below)
             await axis.check_value(value)
 

--- a/src/dodal/devices/defered_move_utils.py
+++ b/src/dodal/devices/defered_move_utils.py
@@ -28,7 +28,7 @@ async def _deferred_move(signal: SignalW[DeferMoves]):
 
 def combined_move_to_motor_setpoints(
     combined_move: Mapping[str, Any], device: StandardReadable
-):
+) -> dict[Motor, float]:
     motor_moves = {}
     for motor_name, new_setpoint in combined_move.items():
         if new_setpoint is not None and isinstance(new_setpoint, float | int):

--- a/src/dodal/devices/smargon.py
+++ b/src/dodal/devices/smargon.py
@@ -1,4 +1,3 @@
-import asyncio
 from enum import Enum
 from math import isclose
 from typing import TypedDict, cast
@@ -7,13 +6,16 @@ from bluesky.protocols import Movable
 from ophyd_async.core import (
     AsyncStatus,
     Device,
-    StrictEnum,
-    set_and_wait_for_value,
     wait_for_value,
 )
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 from ophyd_async.epics.motor import Motor
 
+from dodal.devices.defered_move_utils import (
+    DeferMoves,
+    combined_move_to_motor_setpoints,
+    do_deferred_move,
+)
 from dodal.devices.motors import XYZWrappedOmegaStage
 from dodal.devices.util.epics_util import SetWhenEnabled
 from dodal.log import LOGGER
@@ -61,11 +63,6 @@ class StubOffsets(Device):
             )
         else:
             await self.to_robot_load.set(1)
-
-
-class DeferMoves(StrictEnum):
-    ON = "Defer On"
-    OFF = "Defer Off"
 
 
 class CombinedMove(TypedDict, total=False):
@@ -125,21 +122,12 @@ class Smargon(XYZWrappedOmegaStage, Movable):
         axes will move at the same time. The put callbacks on the axes themselves will
         only come back after the motion on that axis finished.
         """
-        LOGGER.info("Doing smargon move...")
-        await self.defer_move.set(DeferMoves.ON)
-        try:
-            finished_moving = []
-            for motor_name, new_setpoint in value.items():
-                if new_setpoint is not None and isinstance(new_setpoint, int | float):
-                    axis = getattr(self, motor_name)
-                    await axis.check_value(new_setpoint)
-                    put_completion = await set_and_wait_for_value(
-                        axis.user_setpoint,
-                        new_setpoint,
-                        timeout=self.DEFERRED_MOVE_SET_TIMEOUT,
-                        wait_for_set_completion=False,
-                    )
-                    finished_moving.append(put_completion)
-        finally:
-            await self.defer_move.set(DeferMoves.OFF)
-        await asyncio.gather(*finished_moving)
+        LOGGER.info("Doing smargon deferred move")
+
+        motor_moves = combined_move_to_motor_setpoints(value, self)
+
+        await do_deferred_move(
+            self.defer_move,
+            motor_moves,
+            self.DEFERRED_MOVE_SET_TIMEOUT,
+        )

--- a/tests/devices/beamlines/i15_1/test_hexapod.py
+++ b/tests/devices/beamlines/i15_1/test_hexapod.py
@@ -1,0 +1,147 @@
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock, call
+
+import pytest
+from ophyd_async.core import get_mock_put, init_devices, set_mock_value
+from ophyd_async.epics.motor import MotorLimitsError
+
+from dodal.devices.beamlines.i15_1.hexapod import CombinedMove, Hexapod
+from dodal.devices.defered_move_utils import DeferMoves
+
+
+@pytest.fixture
+async def hexapod() -> AsyncGenerator[Hexapod]:
+    async with init_devices(mock=True):
+        hexapod = Hexapod("", "")
+    yield hexapod
+
+
+@pytest.mark.parametrize(
+    "test_x, test_y, test_z, test_rx, test_ry, test_rz",
+    [
+        (2000, 20, 30, 15, 25, 35),  # x goes beyond upper limit
+        (-2000, 20, 30, 15, 25, 35),  # x goes beyond lower limit
+        (10, 2000, 30, 15, 25, 35),  # y goes beyond upper limit
+        (10, -2000, 30, 15, 25, 35),  # y goes beyond lower limit
+        (10, 20, 2000, 15, 25, 35),  # z goes beyond upper limit
+        (10, 20, -2000, 15, 25, 35),  # z goes beyond lower limit
+        (10, 20, 30, 2000, 25, 35),  # rx goes beyond upper limit
+        (10, 20, 30, -2000, 25, 35),  # rx goes beyond lower limit
+        (10, 20, 30, 15, 2000, 35),  # ry goes beyond upper limit
+        (10, 20, 30, 15, -2000, 35),  # ry goes beyond lower limit
+        (10, 20, 30, 15, 25, 2000),  # rz goes beyond upper limit
+        (10, 20, 30, 15, 25, -2000),  # rz goes beyond lower limit
+    ],
+)
+async def test_given_set_with_value_outside_motor_limit(
+    hexapod: Hexapod, test_x, test_y, test_z, test_rx, test_ry, test_rz
+):
+    for motor in [
+        hexapod.x,
+        hexapod.y,
+        hexapod.z,
+        hexapod.rx,
+        hexapod.ry,
+        hexapod.rz,
+    ]:
+        set_mock_value(motor.low_limit_travel, -1999)
+        set_mock_value(motor.high_limit_travel, 1999)
+        set_mock_value(motor.dial_low_limit_travel, -1999)
+        set_mock_value(motor.dial_high_limit_travel, 1999)
+
+    with pytest.raises(MotorLimitsError):
+        await hexapod.set(
+            CombinedMove(
+                x=test_x,
+                y=test_y,
+                z=test_z,
+                rx=test_rx,
+                ry=test_ry,
+                rz=test_rz,
+            )
+        )
+
+
+async def test_given_set_with_single_value_then_that_motor_moves(hexapod: Hexapod):
+    await hexapod.set(CombinedMove(x=10))
+
+    get_mock_put(hexapod.x.user_setpoint).assert_called_once_with(10)
+    get_mock_put(hexapod.defer_move).assert_has_calls(
+        [call(DeferMoves.ON), call(DeferMoves.OFF)]
+    )
+
+
+async def test_given_set_with_none_then_that_motor_does_not_move(hexapod: Hexapod):
+    await hexapod.set(CombinedMove(x=10, y=None))
+
+    get_mock_put(hexapod.x.user_setpoint).assert_called_once_with(10)
+    get_mock_put(hexapod.y.user_setpoint).assert_not_called()
+    get_mock_put(hexapod.defer_move).assert_has_calls(
+        [call(DeferMoves.ON), call(DeferMoves.OFF)]
+    )
+
+
+async def test_given_set_with_all_values_then_motors_move(hexapod: Hexapod):
+    await hexapod.set(CombinedMove(x=10, y=20, z=30, rx=15, ry=25, rz=35))
+
+    get_mock_put(hexapod.x.user_setpoint).assert_called_once_with(10)
+    get_mock_put(hexapod.y.user_setpoint).assert_called_once_with(20)
+    get_mock_put(hexapod.z.user_setpoint).assert_called_once_with(30)
+    get_mock_put(hexapod.rx.user_setpoint).assert_called_once_with(15)
+    get_mock_put(hexapod.ry.user_setpoint).assert_called_once_with(25)
+    get_mock_put(hexapod.rz.user_setpoint).assert_called_once_with(35)
+
+    get_mock_put(hexapod.defer_move).assert_has_calls(
+        [call(DeferMoves.ON), call(DeferMoves.OFF)]
+    )
+
+
+async def test_given_set_with_all_values_then_motors_set_in_order(hexapod: Hexapod):
+    parent = MagicMock()
+    parent.attach_mock(get_mock_put(hexapod.defer_move), "defer_move")
+    parent.attach_mock(get_mock_put(hexapod.x.user_setpoint), "x")
+    parent.attach_mock(get_mock_put(hexapod.y.user_setpoint), "y")
+    parent.attach_mock(get_mock_put(hexapod.z.user_setpoint), "z")
+    parent.attach_mock(get_mock_put(hexapod.rx.user_setpoint), "rx")
+    parent.attach_mock(get_mock_put(hexapod.ry.user_setpoint), "ry")
+    parent.attach_mock(get_mock_put(hexapod.rz.user_setpoint), "rz")
+
+    await hexapod.set(CombinedMove(x=10, y=20, z=30, rx=15, ry=25, rz=35))
+
+    assert len(parent.mock_calls) == 8
+    parent.assert_has_calls(
+        [
+            call.defer_move(DeferMoves.ON),
+            call.x(10),
+            call.y(20),
+            call.z(30),
+            call.rx(15),
+            call.ry(25),
+            call.rz(35),
+            call.defer_move(DeferMoves.OFF),
+        ],
+    )
+
+
+async def test_given_set_fails_then_defer_moves_turned_back_off(hexapod: Hexapod):
+    class MyError(Exception): ...
+
+    hexapod.x.user_setpoint.set = MagicMock(side_effect=MyError())
+    with pytest.raises(MyError):
+        await hexapod.set(CombinedMove(x=10))
+
+    get_mock_put(hexapod.defer_move).assert_has_calls(
+        [call(DeferMoves.ON), call(DeferMoves.OFF)]
+    )
+
+
+async def test_given_motor_does_not_change_setpoint_then_deferred_move_times_out(
+    hexapod: Hexapod,
+):
+    hexapod.DEFERRED_MOVE_SET_TIMEOUT = 0.01  # type: ignore
+
+    # Override the callback so it doesn't change the `user_setpoint`
+    hexapod.x.user_setpoint.set = MagicMock()
+
+    with pytest.raises(TimeoutError):
+        await hexapod.set(CombinedMove(x=10))

--- a/tests/devices/test_smargon.py
+++ b/tests/devices/test_smargon.py
@@ -100,7 +100,7 @@ async def test_given_center_disp_low_when_stub_offsets_set_to_center_and_moved_t
         (10, 20, 30, 15, -2000),  # phi goes beyond lower limit
     ],
 )
-async def test_given_set_with_value_outside_motor_limit(
+async def test_given_set_with_value_outside_motor_limit_then_error_raised(
     smargon: Smargon, test_x, test_y, test_z, test_chi, test_phi
 ):
     for motor in [


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/crystallography-bluesky/issues/94

### Instructions to reviewer on how to test:
1. Confirm tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
