### PR TITLE
Tighten up I19 Attenuator related definitions

### DIFF
--- a/src/dodal/devices/beamlines/i19/access_controlled/attenuator_motor_squad.py
+++ b/src/dodal/devices/beamlines/i19/access_controlled/attenuator_motor_squad.py
@@ -1,8 +1,15 @@
-from typing import Annotated, Any, Self
+from typing import Annotated, Self
 
 from ophyd_async.core import AsyncStatus
-from pydantic import BaseModel, model_validator
-from pydantic.types import PositiveInt, StringConstraints
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictFloat,
+    StrictInt,
+    model_validator,
+)
+from pydantic.types import StringConstraints
 
 from dodal.devices.beamlines.i19.access_controlled.blueapi_device import (
     OpticsBlueAPIDevice,
@@ -11,12 +18,18 @@ from dodal.devices.beamlines.i19.access_controlled.hutch_access import (
     ACCESS_DEVICE_NAME,
 )
 
-PermittedKeyStr = Annotated[str, StringConstraints(pattern="^[A-Za-z0-9-_]*$")]
+PermittedKeyStr = Annotated[str, StringConstraints(pattern="^[A-Za-z0-9-_]+$")]
 
 
-class AttenuatorMotorPositionDemands(BaseModel):
-    continuous_demands: dict[PermittedKeyStr, float] = {}
-    indexed_demands: dict[PermittedKeyStr, PositiveInt] = {}
+class AttenuatorMotorPositions(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    continuous_demands: dict[PermittedKeyStr, StrictFloat | StrictInt] = Field(
+        default_factory=dict, kw_only=True
+    )
+    indexed_demands: dict[PermittedKeyStr, Annotated[StrictInt, Field(gt=0)]] = Field(
+        default_factory=dict, kw_only=True
+    )
 
     @model_validator(mode="after")
     def no_keys_clash(self) -> Self:
@@ -29,7 +42,9 @@ class AttenuatorMotorPositionDemands(BaseModel):
             error_msg = f"Common {ks} found in distinct motor demands: {common_keys}"
             raise ValueError(error_msg)
 
-    def validated_complete_demand(self) -> dict[PermittedKeyStr, Any]:
+    def validated_complete_demand(
+        self,
+    ) -> dict[PermittedKeyStr, StrictInt | StrictFloat]:
         return self.continuous_demands | self.indexed_demands
 
 
@@ -52,7 +67,7 @@ class AttenuatorMotorSquad(OpticsBlueAPIDevice):
     """
 
     @AsyncStatus.wrap
-    async def set(self, value: AttenuatorMotorPositionDemands):
+    async def set(self, value: AttenuatorMotorPositions):
         request_params = {
             "name": "operate_motor_squad_plan",
             "params": {

--- a/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_positions.py
+++ b/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_positions.py
@@ -1,14 +1,17 @@
+import math
+
 import pytest
+from pydantic import ValidationError
 
 from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
-    AttenuatorMotorPositionDemands,
+    AttenuatorMotorPositions,
 )
 
 
 def test_that_attenuator_position_demand_can_be_created_with_only_one_wedge():
     wedge_position_demands = {"x": 0.5}
     wheel_position_demands = {}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=wedge_position_demands,
         indexed_demands=wheel_position_demands,
     )
@@ -18,7 +21,7 @@ def test_that_attenuator_position_demand_can_be_created_with_only_one_wedge():
 def test_that_attenuator_position_demand_with_only_one_wedge_provides_expected_rest_format():
     wedge_position_demands = {"y": 14.9}
     wheel_position_demands = {}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=wedge_position_demands,
         indexed_demands=wheel_position_demands,
     )
@@ -29,7 +32,7 @@ def test_that_attenuator_position_demand_with_only_one_wedge_provides_expected_r
 def test_that_attenuator_position_demand_can_be_created_with_only_one_wheel():
     wedge_position_demands = {}
     wheel_position_demands = {"w": 2}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=wedge_position_demands,
         indexed_demands=wheel_position_demands,
     )
@@ -39,7 +42,7 @@ def test_that_attenuator_position_demand_can_be_created_with_only_one_wheel():
 def test_that_attenuator_position_demand_with_only_one_wheel_provides_expected_rest_format():
     wedge_position_demands = {}
     wheel_position_demands = {"w": 6}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=wedge_position_demands,
         indexed_demands=wheel_position_demands,
     )
@@ -50,7 +53,7 @@ def test_that_attenuator_position_demand_with_only_one_wheel_provides_expected_r
 def test_that_empty_attenuator_position_demand_can_be_created():
     wedge_position_demands = {}
     wheel_position_demands = {}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=wedge_position_demands,
         indexed_demands=wheel_position_demands,
     )
@@ -60,7 +63,7 @@ def test_that_empty_attenuator_position_demand_can_be_created():
 def test_that_empty_attenuator_position_demand_provides_empty_rest_format():
     wedge_position_demands = {}
     wheel_position_demands = {}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=wedge_position_demands,
         indexed_demands=wheel_position_demands,
     )
@@ -71,7 +74,7 @@ def test_that_empty_attenuator_position_demand_provides_empty_rest_format():
 def test_that_attenuator_position_demand_triplet_can_be_created():
     standard_wedge_position_demand = {"x": 25.9, "y": 5.0}
     standard_wheel_position_demand = {"w": 4}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=standard_wedge_position_demand,
         indexed_demands=standard_wheel_position_demand,
     )
@@ -81,7 +84,7 @@ def test_that_attenuator_position_demand_triplet_can_be_created():
 def test_that_attenuator_position_demand_triplet_provides_expected_rest_format():
     wedge_position_demands = {"x": 0.1, "y": 90.1}
     wheel_position_demands = {"w": 6}
-    position_demand = AttenuatorMotorPositionDemands(
+    position_demand = AttenuatorMotorPositions(
         continuous_demands=wedge_position_demands,
         indexed_demands=wheel_position_demands,
     )
@@ -97,49 +100,121 @@ def test_that_attenuator_position_demand_triplet_provides_expected_rest_format()
 def test_that_attenuator_position_raises_error_when_discrete_and_continuous_demands_overload_axis_label():
     wedge_position_demands = {"x": 0.1, "v": 90.1}
     wheel_position_demands = {"w": 6, "v": 7}
-    anticipated_preamble: str = "1 validation error for AttenuatorMotorPositionDemands"
+    anticipated_preamble: str = (
+        f"1 validation error for {AttenuatorMotorPositions.__name__}"
+    )
     with pytest.raises(expected_exception=ValueError, match=anticipated_preamble):
-        AttenuatorMotorPositionDemands(
+        AttenuatorMotorPositions(
             continuous_demands=wedge_position_demands,
             indexed_demands=wheel_position_demands,
         )
 
 
-def test_that_attenuator_position_creation_raises_error_when_continuous_position_demand_is_none():
-    wedge_position_demands = {"x": None, "y": 90.1}
+@pytest.mark.parametrize(
+    "invalid_x",
+    [
+        None,
+        ValueError(),
+        "8.0",
+        "14",
+        "k",
+        "",
+        "game_over",
+        math.cos,
+        object(),
+        False,
+        True,
+    ],
+)
+def test_that_attenuator_position_creation_raises_error_when_continuous_position_demand_is_invalid(
+    invalid_x,
+):
+    wedge_position_demands = {"x": invalid_x, "y": 90.1}
     wheel_position_demands = {}
-    with pytest.raises(expected_exception=ValueError):
-        AttenuatorMotorPositionDemands(
+    with pytest.raises(expected_exception=ValidationError):
+        AttenuatorMotorPositions(
             continuous_demands=wedge_position_demands,
             indexed_demands=wheel_position_demands,
         )
 
 
-def test_that_attenuator_position_creation_raises_error_when_indexed_position_demand_is_none():
+@pytest.mark.parametrize(
+    "invalid_w",
+    [
+        None,
+        -3,
+        0,
+        "2.0",
+        "-12",
+        "q",
+        "",
+        "longer_string",
+        math.exp,
+        AttributeError(),
+        object(),
+        False,
+        True,
+    ],
+)
+def test_that_attenuator_position_creation_raises_error_when_indexed_position_demand_is_invalid(
+    invalid_w,
+):
     wedge_position_demands = {"x": 14.88, "y": 90.1}
-    wheel_position_demands = {"w": None, "v": 3}
-    with pytest.raises(expected_exception=ValueError):
-        AttenuatorMotorPositionDemands(
+    wheel_position_demands = {"w": invalid_w, "v": 3}
+    with pytest.raises(expected_exception=ValidationError):
+        AttenuatorMotorPositions(
             continuous_demands=wedge_position_demands,
             indexed_demands=wheel_position_demands,
         )
 
 
-def test_that_attenuator_position_creation_raises_error_when_continuous_position_key_is_none():
-    wedge_position_demands = {"x": 32.65, None: 80.1}
+@pytest.mark.parametrize(
+    "invalid_key",
+    [
+        None,
+        6,
+        -98.7,
+        "",
+        math.cos,
+        AttributeError(),
+        object(),
+        False,
+        True,
+    ],
+)
+def test_that_attenuator_position_creation_raises_error_when_continuous_position_key_is_invalid(
+    invalid_key,
+):
+    wedge_position_demands = {"x": 32.65, invalid_key: 80.1}
     wheel_position_demands = {"w": 8}
-    with pytest.raises(expected_exception=ValueError):
-        AttenuatorMotorPositionDemands(
+    with pytest.raises(expected_exception=ValidationError):
+        AttenuatorMotorPositions(
             continuous_demands=wedge_position_demands,
             indexed_demands=wheel_position_demands,
         )
 
 
-def test_that_attenuator_position_creation_raises_error_when_indexed_position_key_is_none():
+@pytest.mark.parametrize(
+    "invalid_key",
+    [
+        None,
+        44,
+        ValueError(),
+        -1.234,
+        "",
+        math.cos,
+        object(),
+        False,
+        True,
+    ],
+)
+def test_that_attenuator_position_creation_raises_error_when_indexed_position_key_is_invalid(
+    invalid_key,
+):
     wedge_position_demands = {"x": 24.08, "y": 71.4}
-    wheel_position_demands = {"w": 1, None: 2}
-    with pytest.raises(expected_exception=ValueError):
-        AttenuatorMotorPositionDemands(
+    wheel_position_demands = {"w": 1, invalid_key: 2}
+    with pytest.raises(expected_exception=ValidationError):
+        AttenuatorMotorPositions(
             continuous_demands=wedge_position_demands,
             indexed_demands=wheel_position_demands,
         )

--- a/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_squad.py
+++ b/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_squad.py
@@ -6,13 +6,13 @@ from aiohttp.client import ClientConnectionError
 from bluesky.run_engine import RunEngine
 
 from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
-    AttenuatorMotorPositionDemands,
+    AttenuatorMotorPositions,
     AttenuatorMotorSquad,
 )
 from dodal.devices.beamlines.i19.access_controlled.blueapi_device import HutchState
 
 
-def given_position_demands() -> AttenuatorMotorPositionDemands:
+def given_position_demands() -> AttenuatorMotorPositions:
     position_demand = MagicMock()
     restful_payload = {"x": 54.3, "y": 72.1, "w": 4}
     position_demand.validated_complete_demand = MagicMock(return_value=restful_payload)
@@ -69,7 +69,7 @@ async def test_when_motor_squad_is_set_that_expected_request_params_are_passed(
     motors: AttenuatorMotorSquad = await given_a_squad_of_attenuator_motors(
         invoking_hutch
     )
-    position_demands: AttenuatorMotorPositionDemands = given_position_demands()
+    position_demands: AttenuatorMotorPositions = given_position_demands()
     await motors.set(position_demands)  # when motor position demand is set
 
     expected_hutch: str = invoking_hutch.value
@@ -129,7 +129,7 @@ async def test_that_error_is_logged_when_response_to_position_demand_set_indicat
     motors: AttenuatorMotorSquad = await given_a_squad_of_attenuator_motors(
         invoking_hutch
     )
-    position_demands: AttenuatorMotorPositionDemands = given_position_demands()
+    position_demands: AttenuatorMotorPositions = given_position_demands()
 
     logger.error.assert_not_called()
     await motors.set(position_demands)


### PR DESCRIPTION
Contributes to #2123

* Rename the attenuator motor position dataclass to make it clear it can be used for more than just setting demands

* Fix associated test which was brittle on the class name

* Replace looser PositiveInt type ( which coerces ) with the stricter Annotated StrictInt type for wheel index positions

* Adjust tests of Attenuator positions to catch up with these changes -- widen tests of invalid definitions using parametized testing


### Instructions to reviewer on how to test:
1. Confirm renaming of production code and corresponding test classes makes coherent sense
2. Ensure all CI tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
