### PR TITLE
Update for daq config server 1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scanspec>=0.7.3",
     "pyzmq==27.1.0",
     "deepdiff",
-    "daq-config-server >= 1.3.6",      # For getting Configuration settings.
+    "daq-config-server >= 1.4.0",      # For getting Configuration settings.
     "mysql-connector-python == 9.5.0", # Can unpin once https://github.com/DiamondLightSource/ispyb-api/pull/244 is merged and released
 ]
 

--- a/src/dodal/beamlines/aithre.py
+++ b/src/dodal/beamlines/aithre.py
@@ -1,6 +1,6 @@
 from functools import cache
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.device_manager import DeviceManager
 from dodal.devices.aithre_lasershaping.goniometer import Goniometer

--- a/src/dodal/beamlines/i02_1.py
+++ b/src/dodal/beamlines/i02_1.py
@@ -3,7 +3,7 @@
 from functools import cache
 from os import getenv
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.beamline_utils import set_config_client

--- a/src/dodal/beamlines/i03.py
+++ b/src/dodal/beamlines/i03.py
@@ -1,7 +1,7 @@
 from functools import cache
 from os import getenv
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import PathProvider, Reference
 from ophyd_async.fastcs.eiger import EigerDetector as FastEiger
 from ophyd_async.fastcs.panda import HDFPanda

--- a/src/dodal/beamlines/i04.py
+++ b/src/dodal/beamlines/i04.py
@@ -1,6 +1,6 @@
 from functools import cache
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import Reference
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline

--- a/src/dodal/beamlines/i07.py
+++ b/src/dodal/beamlines/i07.py
@@ -1,6 +1,6 @@
 from functools import cache
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.common.beamlines.beamline_utils import set_config_client

--- a/src/dodal/beamlines/i09_1_shared.py
+++ b/src/dodal/beamlines/i09_1_shared.py
@@ -1,4 +1,4 @@
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.common.beamlines.beamline_utils import get_config_client, set_config_client
 from dodal.device_manager import DeviceManager

--- a/src/dodal/beamlines/i09_2_shared.py
+++ b/src/dodal/beamlines/i09_2_shared.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.device_manager import DeviceManager
 from dodal.devices.beamlines.i09.enums import Grating

--- a/src/dodal/beamlines/i10_shared.py
+++ b/src/dodal/beamlines/i10_shared.py
@@ -7,7 +7,7 @@ idd == id1,    idu == id2.
 
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.device_manager import DeviceManager

--- a/src/dodal/beamlines/i15_1.py
+++ b/src/dodal/beamlines/i15_1.py
@@ -1,7 +1,7 @@
 from functools import cache
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import PathProvider, StaticPathProvider, UUIDFilenameProvider
 from ophyd_async.epics.adcore import ADWriterFactory, ContAcqDetector, NDPluginBaseIO
 from ophyd_async.epics.motor import Motor

--- a/src/dodal/beamlines/i18.py
+++ b/src/dodal/beamlines/i18.py
@@ -1,7 +1,7 @@
 from functools import cache
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import PathProvider
 from ophyd_async.fastcs.panda import HDFPanda
 

--- a/src/dodal/beamlines/i19_1.py
+++ b/src/dodal/beamlines/i19_1.py
@@ -1,6 +1,6 @@
 from functools import cache
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.common.beamlines.beamline_utils import (
     set_beamline as set_utils_beamline,

--- a/src/dodal/beamlines/i19_2.py
+++ b/src/dodal/beamlines/i19_2.py
@@ -1,7 +1,7 @@
 from functools import cache
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import PathProvider
 from ophyd_async.fastcs.eiger import EigerDetector
 from ophyd_async.fastcs.panda import HDFPanda

--- a/src/dodal/beamlines/i19_optics.py
+++ b/src/dodal/beamlines/i19_optics.py
@@ -1,6 +1,6 @@
 from functools import cache
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.epics.motor import Motor
 
 from dodal.common.beamlines.beamline_utils import (

--- a/src/dodal/beamlines/i21.py
+++ b/src/dodal/beamlines/i21.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline
 from dodal.device_manager import DeviceManager

--- a/src/dodal/beamlines/i22.py
+++ b/src/dodal/beamlines/i22.py
@@ -1,7 +1,7 @@
 from functools import cache
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import (
     PathProvider,
     StaticPathProvider,

--- a/src/dodal/beamlines/i23.py
+++ b/src/dodal/beamlines/i23.py
@@ -1,7 +1,7 @@
 from functools import cache
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import InOut, PathProvider, StrictEnum
 from ophyd_async.epics.adcore import ADWriterFactory
 from ophyd_async.epics.adpilatus import PilatusDetector

--- a/src/dodal/beamlines/i24.py
+++ b/src/dodal/beamlines/i24.py
@@ -1,7 +1,7 @@
 from functools import cache
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import AutoMaxIncrementingPathProvider, PathProvider
 
 from dodal.common.beamlines.beamline_utils import BL, set_config_client

--- a/src/dodal/beamlines/k07.py
+++ b/src/dodal/beamlines/k07.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import StrictEnum
 
 from dodal.common.beamlines.beamline_utils import set_beamline as set_utils_beamline

--- a/src/dodal/beamlines/p38.py
+++ b/src/dodal/beamlines/p38.py
@@ -1,7 +1,7 @@
 from functools import cache
 from pathlib import Path
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import PathProvider
 from ophyd_async.epics.adaravis import AravisDetector
 from ophyd_async.epics.adcore import ADWriterFactory

--- a/src/dodal/common/beamlines/beamline_utils.py
+++ b/src/dodal/common/beamlines/beamline_utils.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from typing import Annotated, Final, TypeVar, cast
 
 from bluesky.run_engine import call_in_bluesky_event_loop
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd import Device as OphydV1Device
 from ophyd.sim import make_fake_device
 from ophyd_async.core import (

--- a/src/dodal/devices/beamlines/i03/undulator_dcm.py
+++ b/src/dodal/devices/beamlines/i03/undulator_dcm.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from bluesky.protocols import Movable
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables.mx_lut_models import (
     BeamlinePitchLookupTable,
     BeamlineRollLookupTable,

--- a/src/dodal/devices/beamlines/i07/id.py
+++ b/src/dodal/devices/beamlines/i07/id.py
@@ -1,5 +1,5 @@
 import numpy as np
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.devices.undulator import UndulatorInKeV, UndulatorOrder
 from dodal.devices.util.lookup_tables import energy_distance_table

--- a/src/dodal/devices/beamlines/i09_1_shared/hard_energy.py
+++ b/src/dodal/devices/beamlines/i09_1_shared/hard_energy.py
@@ -2,7 +2,7 @@ from asyncio import gather
 from typing import Protocol
 
 from bluesky.protocols import Locatable, Location, Movable
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables import GenericLookupTable
 from ophyd_async.core import (
     AsyncStatus,

--- a/src/dodal/devices/beamlines/i15_1/blower.py
+++ b/src/dodal/devices/beamlines/i15_1/blower.py
@@ -1,4 +1,4 @@
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )

--- a/src/dodal/devices/beamlines/i15_1/laue.py
+++ b/src/dodal/devices/beamlines/i15_1/laue.py
@@ -1,4 +1,4 @@
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1 import XpdfCrystalLookupTable
 from ophyd_async.core import StandardReadable, StandardReadableFormat, derived_signal_r
 from ophyd_async.epics.motor import Motor

--- a/src/dodal/devices/beamlines/i15_1/safe_or_beam_positioner.py
+++ b/src/dodal/devices/beamlines/i15_1/safe_or_beam_positioner.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 
 from bluesky.protocols import Movable
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
     TemperatureControllersConfig,

--- a/src/dodal/devices/beamlines/i19/access_controlled/energy_device.py
+++ b/src/dodal/devices/beamlines/i19/access_controlled/energy_device.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import AsyncStatus, StandardReadableFormat
 from ophyd_async.epics.core import epics_signal_r
 from pydantic import BaseModel

--- a/src/dodal/devices/detector/det_dist_to_beam_converter.py
+++ b/src/dodal/devices/detector/det_dist_to_beam_converter.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables import DetectorXYLookupTable
 
 from dodal.devices.util.lookup_tables import (

--- a/src/dodal/devices/focusing_mirror.py
+++ b/src/dodal/devices/focusing_mirror.py
@@ -1,6 +1,6 @@
 from typing import TypedDict
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import (
     AsyncStatus,
     Device,

--- a/src/dodal/devices/insertion_device/energy_motor_lookup.py
+++ b/src/dodal/devices/insertion_device/energy_motor_lookup.py
@@ -2,7 +2,7 @@ import asyncio
 from pathlib import Path
 
 from bluesky.protocols import Triggerable
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import AsyncStatus, Device, DeviceMock, DeviceVector
 from ophyd_async.epics.core import epics_signal_rw
 

--- a/src/dodal/devices/oav/oav_parameters.py
+++ b/src/dodal/devices/oav/oav_parameters.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 from xml.etree.ElementTree import Element
 
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models import DisplayConfig
 
 from dodal.devices.oav.pin_image_recognition import ScanDirections

--- a/src/dodal/devices/undulator.py
+++ b/src/dodal/devices/undulator.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 from bluesky.protocols import Locatable, Location, Movable
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables.insertion_device import (
     UndulatorEnergyGapLookupTable,
 )

--- a/src/dodal/testing/fixtures/config_server.py
+++ b/src/dodal/testing/fixtures/config_server.py
@@ -54,7 +54,7 @@ def mock_config_server():
     # Don't actually talk to central service during unit tests, and reset caches between test
 
     with patch(
-        "daq_config_server.app.client.ConfigClient.get_file_contents",
+        "daq_config_server.client.ConfigClient.get_file_contents",
         side_effect=fake_config_server_get_file_contents,
     ):
         yield

--- a/src/dodal/testing/fixtures/devices/apple2.py
+++ b/src/dodal/testing/fixtures/devices/apple2.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import (
     init_devices,
     set_mock_value,

--- a/src/dodal/testing/fixtures/devices/hard_undulator.py
+++ b/src/dodal/testing/fixtures/devices/hard_undulator.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables import GenericLookupTable
 
 from dodal.devices.beamlines.i09_1_shared.hard_undulator_functions import (

--- a/system_tests/test_oav_system.py
+++ b/system_tests/test_oav_system.py
@@ -1,7 +1,7 @@
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import init_devices
 from tests.devices.oav.test_data import TEST_OAV_ZOOM_LEVELS
 

--- a/tests/common/beamlines/test_beamline_parameters.py
+++ b/tests/common/beamlines/test_beamline_parameters.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.common.beamlines.beamline_parameters import (
     get_beamline_parameters,

--- a/tests/common/beamlines/test_config_client.py
+++ b/tests/common/beamlines/test_config_client.py
@@ -1,5 +1,5 @@
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.beamlines import i03, i04, i19_1, i19_2
 

--- a/tests/common/beamlines/test_device_instantiation.py
+++ b/tests/common/beamlines/test_device_instantiation.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import NotConnectedError
 
 from dodal.beamlines import all_beamline_modules

--- a/tests/devices/beamlines/i03/test_undulator_dcm.py
+++ b/tests/devices/beamlines/i03/test_undulator_dcm.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables.insertion_device import (
     UndulatorEnergyGapLookupTable,
 )

--- a/tests/devices/beamlines/i07/test_id.py
+++ b/tests/devices/beamlines/i07/test_id.py
@@ -1,5 +1,5 @@
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import init_devices
 
 from dodal.devices.beamlines.i07.id import InsertionDevice

--- a/tests/devices/beamlines/i09_1_shared/test_hard_energy.py
+++ b/tests/devices/beamlines/i09_1_shared/test_hard_energy.py
@@ -3,7 +3,7 @@ import re
 import pytest
 from bluesky.plan_stubs import mv
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import init_devices
 from ophyd_async.testing import (
     assert_reading,

--- a/tests/devices/beamlines/i09_1_shared/test_undulator_functions.py
+++ b/tests/devices/beamlines/i09_1_shared/test_undulator_functions.py
@@ -2,7 +2,7 @@ import re
 from unittest.mock import patch
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables import GenericLookupTable
 
 from dodal.devices.beamlines.i09_1_shared import (

--- a/tests/devices/beamlines/i09_2_shared/test_i09_apple2.py
+++ b/tests/devices/beamlines/i09_2_shared/test_i09_apple2.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import call
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import (
     get_mock_put,
     init_devices,

--- a/tests/devices/beamlines/i10/test_i10_apple2.py
+++ b/tests/devices/beamlines/i10/test_i10_apple2.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from bluesky.plans import scan
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from numpy import linspace, poly1d
 from ophyd_async.core import (
     callback_on_mock_put,

--- a/tests/devices/beamlines/i15_1/test_blower.py
+++ b/tests/devices/beamlines/i15_1/test_blower.py
@@ -1,5 +1,5 @@
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )

--- a/tests/devices/beamlines/i15_1/test_cobra.py
+++ b/tests/devices/beamlines/i15_1/test_cobra.py
@@ -1,4 +1,4 @@
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )

--- a/tests/devices/beamlines/i15_1/test_cryostream.py
+++ b/tests/devices/beamlines/i15_1/test_cryostream.py
@@ -1,4 +1,4 @@
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import (
     TemperatureControllerParams,
 )

--- a/tests/devices/beamlines/i15_1/test_laue_monochrometer.py
+++ b/tests/devices/beamlines/i15_1/test_laue_monochrometer.py
@@ -1,5 +1,5 @@
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1 import XpdfCrystalLookupTable
 from ophyd_async.core import init_devices
 from ophyd_async.testing import assert_reading, partial_reading

--- a/tests/devices/beamlines/i15_1/test_safe_or_beam_positioner.py
+++ b/tests/devices/beamlines/i15_1/test_safe_or_beam_positioner.py
@@ -1,5 +1,5 @@
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.i15_1.xpdf_parameters import TemperatureControllerParams
 from ophyd_async.core import get_mock_put, init_devices, set_mock_value
 

--- a/tests/devices/detector/test_det_resolution.py
+++ b/tests/devices/detector/test_det_resolution.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from numpy import isclose
 
 from dodal.common.beamlines.beamline_utils import set_config_client

--- a/tests/devices/oav/conftest.py
+++ b/tests/devices/oav/conftest.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import init_devices, set_mock_value
 
 from dodal.devices.oav.oav_detector import OAVBeamCentreFile, OAVBeamCentrePV

--- a/tests/devices/oav/test_oav.py
+++ b/tests/devices/oav/test_oav.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import init_devices, set_mock_value
 
 from dodal.devices.oav.oav_detector import (

--- a/tests/devices/oav/test_oav_parameters.py
+++ b/tests/devices/oav/test_oav_parameters.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 
 from dodal.devices.oav.oav_parameters import (
     OAVConfig,

--- a/tests/devices/test_beam_converter.py
+++ b/tests/devices/test_beam_converter.py
@@ -2,7 +2,7 @@ from math import isclose
 from unittest.mock import Mock
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables import DetectorXYLookupTable
 
 from dodal.devices.detector.det_dist_to_beam_converter import (

--- a/tests/devices/test_eiger.py
+++ b/tests/devices/test_eiger.py
@@ -4,7 +4,7 @@ import threading
 from unittest.mock import ANY, MagicMock, Mock, call, create_autospec, patch
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd.sim import NullStatus, make_fake_device
 from ophyd.status import Status
 from ophyd.utils import UnknownStatusFailure

--- a/tests/devices/test_focusing_mirror.py
+++ b/tests/devices/test_focusing_mirror.py
@@ -5,7 +5,7 @@ import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import (
     SignalR,
     callback_on_mock_put,

--- a/tests/devices/test_undulator.py
+++ b/tests/devices/test_undulator.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from bluesky import RunEngine
 from bluesky.plan_stubs import mv
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables.insertion_device import (
     UndulatorEnergyGapLookupTable,
 )

--- a/tests/devices/util/test_lookup_tables.py
+++ b/tests/devices/util/test_lookup_tables.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from daq_config_server.models.lookup_tables.insertion_device import (
     UndulatorEnergyGapLookupTable,
 )

--- a/tests/plan_stubs/test_topup_plan.py
+++ b/tests/plan_stubs/test_topup_plan.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import init_devices, set_mock_value
 
 from dodal.common.beamlines.beamline_utils import set_config_client

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -3,7 +3,7 @@ from pathlib import Path, PurePath
 from unittest.mock import patch
 
 import pytest
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import (
     PathProvider,
     StandardDetector,

--- a/tests/plans/device_setup_plans/test_setup_pin_tip.py
+++ b/tests/plans/device_setup_plans/test_setup_pin_tip.py
@@ -1,6 +1,6 @@
 import pytest
 from bluesky import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import init_devices
 
 from dodal.devices.oav.oav_parameters import OAVParameters

--- a/tests/plans/test_configure_arm_trigger_and_disarm_detector.py
+++ b/tests/plans/test_configure_arm_trigger_and_disarm_detector.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from bluesky.run_engine import RunEngine
-from daq_config_server import ConfigClient
+from daq_config_server.client import ConfigClient
 from ophyd_async.core import (
     DetectorTrigger,
     TriggerInfo,

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ wheels = [
 
 [[package]]
 name = "daq-config-server"
-version = "1.3.6"
+version = "1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -711,9 +711,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/74/56eddf2a44efd981cc5678e74fd777f37c045a7f9b71b01143ee8be45715/daq_config_server-1.3.6.tar.gz", hash = "sha256:ec25a69eca6fbeca309f04763d53728000e39d509a3f43353b76721985e34ee2", size = 232081, upload-time = "2026-06-10T13:30:53.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/78/25c91152458798845b2fb53bc047e28d52ba58012b3237e1ee717c3db350/daq_config_server-1.4.tar.gz", hash = "sha256:697440dca58812c871f847227b307de1d2464b61e0eaac91a320d3886aaa77db", size = 235581, upload-time = "2026-07-21T09:03:30.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/0a/f225277d9b0133b6cd0e68f19d93af67db1fd76c9ccea9026563d53f2ffa/daq_config_server-1.3.6-py3-none-any.whl", hash = "sha256:948933c4d7f79ea609cff5774aeef3578ffda582d623e8d5bdf9aadf89df36b7", size = 33132, upload-time = "2026-06-10T13:30:52.176Z" },
+    { url = "https://files.pythonhosted.org/packages/be/69/712db05bfbbee09963ed293bfde74b8de874ffa4d44a7dc137c9cb069aec/daq_config_server-1.4-py3-none-any.whl", hash = "sha256:8f71d6f43a732443a77a9581b323945b2c7489930725a0765aeff92d57ec2ebf", size = 35520, upload-time = "2026-07-21T09:03:29.217Z" },
 ]
 
 [[package]]
@@ -817,7 +817,7 @@ requires-dist = [
     { name = "aiohttp" },
     { name = "bluesky", specifier = ">=1.14.5" },
     { name = "click" },
-    { name = "daq-config-server", specifier = ">=1.3.6" },
+    { name = "daq-config-server", specifier = ">=1.4.0" },
     { name = "deepdiff" },
     { name = "graypy" },
     { name = "mysql-connector-python", specifier = "==9.5.0" },


### PR DESCRIPTION
Fixes dodal following changes to daq-config-server that removed the ConfigClient from the base package `__all__`

* DiamondLightSource/daq-config-server#195

This explicitly *does not* use the new mocking facility in the daq-config-server client; this update is merely in order to allow dodal to build and release successfully.

### Instructions to reviewer on how to test:
1. Tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
