### PR TITLE
Pin daq config server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scanspec>=0.7.3",
     "pyzmq==27.1.0",
     "deepdiff",
-    "daq-config-server >= 1.3.6",      # For getting Configuration settings.
+    "daq-config-server >= 1.3.6,<1.4.0",      # For getting Configuration settings.
     "mysql-connector-python == 9.5.0", # Can unpin once https://github.com/DiamondLightSource/ispyb-api/pull/244 is merged and released
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ requires-dist = [
     { name = "aiohttp" },
     { name = "bluesky", specifier = ">=1.14.5" },
     { name = "click" },
-    { name = "daq-config-server", specifier = ">=1.3.6" },
+    { name = "daq-config-server", specifier = ">=1.3.6,<1.4.0" },
     { name = "deepdiff" },
     { name = "graypy" },
     { name = "mysql-connector-python", specifier = "==9.5.0" },


### PR DESCRIPTION
Pins daq-config-server to < 1.4.0 while

* DiamondLightSource/dodal#2099

is yet to be merged, following release of daq-config-server which contains

* DiamondLightSource/daq-config-server#195


### Instructions to reviewer on how to test:
1. Tests pass

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
