### PR TITLE
Remove restrictions on integer input for general maths conversions

### DIFF
--- a/src/dodal/common/general_maths/arithmetic_conversions.py
+++ b/src/dodal/common/general_maths/arithmetic_conversions.py
@@ -1,11 +1,11 @@
 """Provides functions to convert between common units for attenuation."""
 
 from numpy.polynomial import polynomial
-from pydantic import StrictFloat, validate_call
+from pydantic import StrictFloat, StrictInt, validate_call
 
 
 @validate_call
-def convert_percentage_to_factor(pc: StrictFloat) -> float:
+def convert_percentage_to_factor(pc: StrictFloat | StrictInt) -> float:
     """Takes a percentage value and converts it the corresponding multiplication factor.
 
     Args:
@@ -17,7 +17,7 @@ def convert_percentage_to_factor(pc: StrictFloat) -> float:
 
 
 @validate_call
-def convert_factor_to_percentage(f: StrictFloat) -> float:
+def convert_factor_to_percentage(f: StrictFloat | StrictInt) -> float:
     """Takes a multiplication factor and converts it to the corresponding percentage.
 
     Args:
@@ -30,7 +30,7 @@ def convert_factor_to_percentage(f: StrictFloat) -> float:
 
 
 @validate_call
-def convert_microns_to_cm(t_um: StrictFloat) -> float:
+def convert_microns_to_cm(t_um: StrictFloat | StrictInt) -> float:
     """Takes the numerical part of a distance in microns and converts this to cm.
 
     Args:
@@ -43,7 +43,7 @@ def convert_microns_to_cm(t_um: StrictFloat) -> float:
 
 
 @validate_call
-def convert_microns_to_mm(v_um: StrictFloat) -> float:
+def convert_microns_to_mm(v_um: StrictFloat | StrictInt) -> float:
     """Takes the numerical part of a distance in microns and converts this to mm.
 
     Args:
@@ -56,7 +56,7 @@ def convert_microns_to_mm(v_um: StrictFloat) -> float:
 
 
 @validate_call
-def convert_mm_to_microns(w_mm: StrictFloat) -> float:
+def convert_mm_to_microns(w_mm: StrictFloat | StrictInt) -> float:
     """Takes the numerical part of a distance in mm and converts this to microns.
 
     Args:
@@ -82,7 +82,7 @@ def convert_mm_to_cm(x_mm: StrictFloat) -> float:
 
 
 @validate_call
-def convert_cm_to_mm(y_cm: StrictFloat) -> float:
+def convert_cm_to_mm(y_cm: StrictFloat | StrictInt) -> float:
     """Takes the numerical part of a distance in cm and converts this to mm.
 
     Args:
@@ -95,7 +95,7 @@ def convert_cm_to_mm(y_cm: StrictFloat) -> float:
 
 
 @validate_call
-def convert_ev_to_kev(energy_ev: StrictFloat) -> float:
+def convert_ev_to_kev(energy_ev: StrictFloat | StrictInt) -> float:
     """Takes the numerical part of an x-ray energy in electron volts and converts this
     to keV.
 
@@ -110,7 +110,9 @@ def convert_ev_to_kev(energy_ev: StrictFloat) -> float:
 
 @validate_call
 def get_straight_line_y(
-    line_offset: StrictFloat, line_gradient: StrictFloat, x: StrictFloat
+    line_offset: StrictFloat | StrictInt,
+    line_gradient: StrictFloat | StrictInt,
+    x: StrictFloat | StrictInt,
 ) -> float:
     """Convenient internal conversion method which delegates to numpy for a 1st order polynomial (line).
 

--- a/src/dodal/common/general_maths/transmission_interconversion.py
+++ b/src/dodal/common/general_maths/transmission_interconversion.py
@@ -1,14 +1,16 @@
 import math
 from typing import Annotated
 
-from pydantic import Field, StrictFloat, validate_call
+from pydantic import Field, StrictFloat, StrictInt, validate_call
 
 _CANONICAL_BARNETT_CONVERSION = -1.0e3
 _REVERSE_BARNETT_CONVERSION = -1.0e-3
 
 
 @validate_call
-def attenuation_from_natural_log_of_transmission(ln_t: StrictFloat) -> float:
+def attenuation_from_natural_log_of_transmission(
+    ln_t: StrictFloat | StrictInt,
+) -> float:
     """Converts from natural log of transmission fraction into Barnett attenuation units.
 
     Args:
@@ -22,7 +24,7 @@ def attenuation_from_natural_log_of_transmission(ln_t: StrictFloat) -> float:
 
 @validate_call
 def attenuation_from_transmission(
-    transmission_as_fraction: Annotated[StrictFloat, Field(ge=0, le=1)],
+    transmission_as_fraction: Annotated[StrictFloat | StrictInt, Field(ge=0, le=1)],
 ) -> float:
     """Converts from transmission fraction into Barnett attenuation units.
 
@@ -38,7 +40,7 @@ def attenuation_from_transmission(
 
 @validate_call
 def natural_log_of_transmission_from_attenuation(
-    attenuation_bn: Annotated[StrictFloat, Field(ge=0)],
+    attenuation_bn: Annotated[StrictFloat | StrictInt, Field(ge=0)],
 ) -> float:
     """Converts from Barnett attenuation units into natural log of transmission fraction.
 
@@ -53,7 +55,7 @@ def natural_log_of_transmission_from_attenuation(
 
 @validate_call
 def transmission_from_attenutation(
-    attenuation_bn: Annotated[StrictFloat, Field(ge=0)],
+    attenuation_bn: Annotated[StrictFloat | StrictInt, Field(ge=0)],
 ) -> float:
     """Converts from Barnett attenuation units into transmission fraction.
 

--- a/tests/common/general_maths/test_arithmetic_conversions.py
+++ b/tests/common/general_maths/test_arithmetic_conversions.py
@@ -20,42 +20,81 @@ from .operator_inversion_pairing import OperatorInversionPairing
 
 
 # expected success tests (the 'Happy Path'): All numbers here are arbitrary
-@pytest.mark.parametrize("input,result", [(1.0, 0.1), (100.0, 10.0)])
+@pytest.mark.parametrize(
+    "input,result",
+    [(1.0, 0.1), (100.0, 10.0), (22, 2.2), (-67, -6.7), (0, 0), (-105.2, -10.52)],
+)
 def test_conversion_from_millimetres_to_centimetres(input, result):
     assert convert_mm_to_cm(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1.0, 10), (0.1, 1.0)])
+@pytest.mark.parametrize(
+    "input,result",
+    [(1.0, 10.0), (10.0, 100.0), (44, 440), (-6.7, -67.0), (0, 0), (-10.52, -105.2)],
+)
 def test_conversion_from_centimetres_to_millimetres(input, result):
     assert convert_cm_to_mm(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(0.01, 1.0), (1.0, 100.0)])
+@pytest.mark.parametrize(
+    "input,result",
+    [(0.01, 1.0), (1.0, 100.0), (0, 0), (1.534, 153.4), (1, 100), (-0.5, -50.0)],
+)
 def test_conversion_to_percentage_from_factor(input, result):
     assert convert_factor_to_percentage(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1.0, 0.01), (100, 1.0)])
+@pytest.mark.parametrize(
+    "input,result",
+    [
+        (1.0, 0.01),
+        (100, 1.0),
+        (0, 0),
+        (86.8, 0.868),
+        (12, 0.12),
+        (-6, -0.06),
+        (-14.7, -0.147),
+    ],
+)
 def test_conversion_to_factor_from_percentage(input, result):
     assert convert_percentage_to_factor(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1000.0, 1.0), (10000.0, 10.0)])
+@pytest.mark.parametrize(
+    "input,result",
+    [(1000.0, 1.0), (10000.0, 10.0), (0, 0), (12000, 12), (-1489, -1.489), (13, 0.013)],
+)
 def test_conversion_from_microns_to_millimeters(input, result):
     assert convert_microns_to_mm(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1.0, 1000.0), (10, 10000.0)])
+@pytest.mark.parametrize(
+    "input,result",
+    [
+        (1.0, 1000.0),
+        (10, 10000.0),
+        (0, 0),
+        (17, 17000),
+        (-19, -19000),
+        (0.026, 26),
+        (0.00054, 0.54),
+    ],
+)
 def test_conversion_from_millimeters_to_microns(input, result):
     assert convert_mm_to_microns(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1000, 1.0), (100, 0.1)])
+@pytest.mark.parametrize(
+    "input,result", [(0, 0), (1000, 1.0), (100, 0.1), (12345.8, 12.3458)]
+)
 def test_conversion_from_electronvolts_to_kiloelectronvolts(input, result):
     assert convert_ev_to_kev(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(10000.0, 1.0), (1000, 0.1)])
+@pytest.mark.parametrize(
+    "input,result",
+    [(10000.0, 1.0), (1000, 0.1), (0, 0), (5, 0.0005), (52.06, 0.005206)],
+)
 def test_conversion_from_microns_to_centimetres(input, result):
     assert convert_microns_to_cm(input) == pytest.approx(result)
 
@@ -75,6 +114,10 @@ def test_conversion_from_microns_to_centimetres(input, result):
         (0.0, 3.2, -11.6, -37.12),
         (0.1, -3.2, -11.6, 37.22),
         (5.2, 0.0, -8.64, 5.2),
+        (4, 12.2, 88.6, 1084.92),
+        (-1.2, 0, 5.3, -1.2),
+        (-1.2, 2, 6.1, 11),
+        (7.8, 1.91, -4, 0.16),
     ],
 )
 def test_straight_line_conversion(c, m, x, expected_y):
@@ -93,12 +136,12 @@ def test_straight_line_conversion(c, m, x, expected_y):
         (
             convert_ev_to_kev,
             lambda k: k * 1000.0,
-            [16.83, 0.0, 0.037, 1.0, 6.208, 18, 12345.6, 28906.4],
+            [16.83, 0.0, 0.037, 1.0, 6.208, 18, 12345.6, 14283, 28906.4],
         ),
         (
             convert_mm_to_cm,
             convert_cm_to_mm,
-            [-16.83, 0.0, 0.037, 1.0, 6.208, 18, 102.99],
+            [-16.83, 0.0, 0.037, 1.0, 6.208, 18, 102.99, 16],
         ),
         (
             convert_microns_to_cm,
@@ -135,7 +178,7 @@ def test_reciprocal_function_pairs_nest_consistent_with_identity(
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_microns_to_cm_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -144,7 +187,7 @@ def test_convert_microns_to_cm_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_ev_to_kev_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -153,7 +196,7 @@ def test_convert_ev_to_kev_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_microns_to_mm_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -162,7 +205,7 @@ def test_convert_microns_to_mm_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_mm_to_microns_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -171,7 +214,7 @@ def test_convert_mm_to_microns_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), True],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_factor_to_percentage_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -180,7 +223,7 @@ def test_convert_factor_to_percentage_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_percentage_to_factor_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -189,7 +232,7 @@ def test_convert_percentage_to_factor_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_mm_to_cm_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -198,7 +241,7 @@ def test_convert_mm_to_cm_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), True],
+    ["", "a", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_convert_cm_to_mm_raises_error_with_bad_input(bad_input):
     with pytest.raises(pydantic.ValidationError):
@@ -207,7 +250,7 @@ def test_convert_cm_to_mm_raises_error_with_bad_input(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.log, object(), False],
+    ["", "a", [], None, math.log, object(), KeyError(), False, True],
 )
 def test_straight_line_calculator_raises_error_with_bad_offset(bad_input):
     _probe_x = 11.1
@@ -218,7 +261,7 @@ def test_straight_line_calculator_raises_error_with_bad_offset(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.sin, object(), True],
+    ["", "B", [], None, math.sin, object(), KeyError(), False, True],
 )
 def test_straight_line_calculator_raises_error_with_bad_gradient(bad_input):
     _probe_x = -11.1
@@ -229,7 +272,7 @@ def test_straight_line_calculator_raises_error_with_bad_gradient(bad_input):
 
 @pytest.mark.parametrize(
     "bad_input",
-    ["", "a", [], None, math.tan, object(), False],
+    ["", "W", [], None, math.tan, object(), AttributeError(), True, False],
 )
 def test_straight_line_calculator_raises_error_with_bad_x_value(bad_input):
     _line_offset = 0.1

--- a/tests/common/general_maths/test_transmission_interconversion.py
+++ b/tests/common/general_maths/test_transmission_interconversion.py
@@ -151,25 +151,33 @@ def test_transmission_attenuation_conversions_pair_off_to_form_identity_operatio
 
 
 # inauspicious:
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize(
+    "bad_input", ["a", [], None, KeyError(), math.sin, object(), False, True]
+)
 def test_natural_log_of_transmission_from_attenuation_raises_error(bad_input):
     with pytest.raises(ValidationError):
         natural_log_of_transmission_from_attenuation(bad_input)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize(
+    "bad_input", ["a", [], None, KeyError(), math.sin, object(), False, True]
+)
 def test_transmission_from_attenutation_raises_error(bad_input):
     with pytest.raises(ValidationError):
         transmission_from_attenutation(bad_input)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize(
+    "bad_input", ["a", [], None, KeyError(), math.sin, object(), False, True]
+)
 def test_attenuation_from_transmission_raises_error(bad_input):
     with pytest.raises(ValidationError):
         attenuation_from_transmission(bad_input)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize(
+    "bad_input", ["a", [], None, KeyError(), math.sin, object(), False, True]
+)
 def test_attenuation_from_natural_log_of_transmission_raises_error(bad_input):
     with pytest.raises(ValidationError):
         attenuation_from_natural_log_of_transmission(bad_input)


### PR DESCRIPTION
* Conversion functions were previously over-restricted to exclude integer input:  Integer input permission is hereby restored and test verified

* Unhappy path tests widened to cover a few more test cases

Fixes #2128 

### Instructions to reviewer on how to test:
1. Check all tests pass on CI
2. Confirm updates to production code and unit tests are consistent with issue aims

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
