### PR TITLE
Improve I19 Filter Wheel 1 Selection

### DIFF
--- a/src/dodal/devices/attenuator/filter_selections.py
+++ b/src/dodal/devices/attenuator/filter_selections.py
@@ -72,13 +72,16 @@ class I02_1FilterFourSelections(SubsetEnum):  # noqa: N801
     TI500 = "Ti500"
 
 
+# Enum maps names of positions in epics ( controls software ) onto wheel slot locations
+# Other mappings from these locations to specific details of foil absorber etc is handled
+# elsewhere in I19 transmission code
 class I19FilterOneSelections(StrictEnum):
-    AIR1 = "1 - "
-    AL = "2 - Al"
-    AIR3 = "3 - "
-    AU = "4 - Au"
-    AIR5 = "5 - "
-    FE = "6 - Fe"
+    W1S1 = "1 - "
+    W1S2 = "2 - Al"
+    W1S3 = "3 - "
+    W1S4 = "4 - Au"
+    W1S5 = "5 - "
+    W1S6 = "6 - Fe"
 
 
 class I24FilterOneSelections(SubsetEnum):


### PR DESCRIPTION
Addresses #2136

* Replaces brittle enumeration of I19 filter wheel one which was tightly coupled to interchangeable installed filters in favour of mapping to wheel slot locations. e.g. W1S4

* The mapping from slot label to absorber specifics and business logic exclusions etc has to be done outside this enum no matter what form it takes

* This change renders the labelling less brittle as old label AIR5 would have become redundant when slot 5 sees a future foil filter added.

* Note the abuse of an enum is (temporarily at least) a necessary evil imposed by the assumptions in the design of the standard FilterWheel class

### Instructions to reviewer on how to test:
1. See if You agree with the explanation of rationale behind the change
2. Confirm no CI tests ( nor dodal connect ) is affected ( the latter shouldn't be as the filter wheel device is skipped for now )

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
