### PR TITLE
Allow for all scan directions in the OAV parameters

### DIFF
--- a/src/dodal/devices/oav/oav_parameters.py
+++ b/src/dodal/devices/oav/oav_parameters.py
@@ -7,8 +7,6 @@ from xml.etree.ElementTree import Element
 from daq_config_server import ConfigClient
 from daq_config_server.models import DisplayConfig
 
-from dodal.devices.oav.pin_image_recognition import ScanDirections
-
 # GDA currently assumes this aspect ratio for the OAV window size.
 # For some beamline this doesn't affect anything as the actual OAV aspect ratio
 # matches. Others need to take it into account to rescale the values stored in
@@ -101,9 +99,7 @@ class OAVParameters:
         self.open_ksize: int = update("open_ksize", int, default=0)
         self.close_ksize: int = update("close_ksize", int, default=5)
         self.min_callback_time: float = update("min_callback_time", float, default=0.08)
-        self.direction: ScanDirections = [*ScanDirections][
-            self.active_params["direction"]
-        ]
+        self.direction: int = update("direction", int)
         self.max_tip_distance: float = update("max_tip_distance", float, default=300)
 
     def get_max_tip_distance_in_pixels(self, microns_per_pixel: float) -> float:

--- a/src/dodal/devices/oav/oav_parameters.py
+++ b/src/dodal/devices/oav/oav_parameters.py
@@ -99,6 +99,8 @@ class OAVParameters:
         self.open_ksize: int = update("open_ksize", int, default=0)
         self.close_ksize: int = update("close_ksize", int, default=5)
         self.min_callback_time: float = update("min_callback_time", float, default=0.08)
+        # NOTE Keeping the direction as int as different beamlines may have different
+        # orientation, and we currently don't have the full picture
         self.direction: int = update("direction", int)
         self.max_tip_distance: float = update("max_tip_distance", float, default=300)
 


### PR DESCRIPTION
Temporarily reverts #2092 and changes the OAVParameters direction in order to allow values different from 0 and 1 from the OAVCentring file, eg. I19-1 has a direction value of "2", which is "up".

This issues should be fixed properly in a separate PR.

### Instructions to reviewer on how to test:
1. Run tests

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
