### PR TITLE
Add MaterialAbsorptionSpectrum

### DIFF
--- a/src/dodal/common/general_maths/absorber_geometry.py
+++ b/src/dodal/common/general_maths/absorber_geometry.py
@@ -1,8 +1,10 @@
 from collections.abc import Callable
-from typing import Annotated, Literal, Protocol, Self, runtime_checkable
+from functools import cached_property
+from typing import Annotated, Literal, Protocol, runtime_checkable
 
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     PrivateAttr,
     StrictFloat,
@@ -15,6 +17,10 @@ from dodal.common.general_maths.arithmetic_conversions import (
     convert_microns_to_cm,
     convert_mm_to_cm,
     get_straight_line_y,
+)
+from dodal.common.general_maths.interval import (
+    FloatInterval,
+    OpenInterval,
 )
 
 SupportedThicknessUnits = Annotated[
@@ -92,21 +98,23 @@ class WedgeGeometry(BaseModel):
 
     tip_mm: StrictFloat
     taper_cotangent: StrictFloat
-    _taper_gradient: float = PrivateAttr(default=0.0)
+
+    model_config = ConfigDict(frozen=True)
 
     @field_validator("taper_cotangent")
     @classmethod
-    def validate_taper_is_thin(cls, value: float) -> float:
-        bound = 5.0  # round number cotangent limit for thin wedge
-        if -bound < value < bound:
-            msg: str = f"taper_contangent must correspond to thin wedge, of magnitude {bound} or larger"
-            raise ValueError(msg)
+    def validate_taper_is_thin(cls, value: float, _magnitude=5) -> float:
+        _invalid_taper_range: FloatInterval = OpenInterval(
+            lower=-_magnitude, upper=_magnitude
+        )  # round number cotangent limit for thin wedge
+        if value in _invalid_taper_range:
+            _msg: str = f"taper_contangent must correspond to thin wedge, of magnitude {_magnitude} or larger"
+            raise ValueError(_msg)
         return value
 
-    @model_validator(mode="after")
-    def _calculate_gradient(self) -> Self:
-        self._taper_gradient = 1.0 / self.taper_cotangent
-        return self
+    @cached_property
+    def _taper_gradient(self) -> float:
+        return 1.0 / self.taper_cotangent
 
     def motor_position_mm_for_thickness_cm(
         self, *, thickness_cm: Annotated[StrictFloat, Field(ge=0.0)]

--- a/src/dodal/common/general_maths/absorbers.py
+++ b/src/dodal/common/general_maths/absorbers.py
@@ -1,26 +1,20 @@
-from typing import Annotated, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
-from pydantic import ConfigDict, Field, StrictFloat, validate_call
-from pydantic.dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict, StrictFloat, validate_call
 
 from dodal.common.general_maths.absorber_geometry import (
     TaperedGeometryProvider,
     ThicknessProvider,
 )
-from dodal.common.general_maths.material_absorption_maths import AbsorptionCalculator
-from dodal.common.general_maths.transmission_interconversion import (
+from dodal.common.general_maths.material_absorption_maths import (
+    MaterialAbsorptionSpectrum,
     attenuation_from_natural_log_of_transmission,
 )
-
-XrayEnergy = Annotated[
-    StrictFloat,
-    Field(gt=0.1, le=30.0, description="X-rays from 0.1 keV to 30.0"),
-]
 
 
 @runtime_checkable
 class FixedDepth(Protocol):
-    def calculate_absorption_bn(self, xray_energy_kev: XrayEnergy) -> float:
+    def calculate_absorption_bn(self, *, xray_energy_kev: float) -> float:
         """Calculates absorption for a flat absorber of fixed depth.
 
         Typical use case is a foil absorber in a filter wheel.
@@ -39,8 +33,9 @@ class FixedDepth(Protocol):
 class VariableDepth(Protocol):
     def calculate_absorption_bn(
         self,
-        xray_energy_kev: XrayEnergy,
-        motor_position_mm: StrictFloat,
+        *,
+        xray_energy_kev: float,
+        motor_position_mm: float,
     ) -> float:
         """Calculates absorption for an absorber of variable depth.
 
@@ -57,8 +52,7 @@ class VariableDepth(Protocol):
         ...
 
 
-@dataclass(kw_only=True, frozen=True, config=ConfigDict(arbitrary_types_allowed=True))
-class Absorber:
+class Absorber(BaseModel):
     """Base class for individual attenuating absorber.
 
     This is a system level entity in the business logic of a transmission subsystem,
@@ -69,9 +63,10 @@ class Absorber:
         material_absorption_model: Material specific model for photon mass attenuation calculation.
     """
 
-    material_absorption_model: AbsorptionCalculator
+    spectrum: MaterialAbsorptionSpectrum
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
-    def _attenuation_bn(self, xray_energy_kev, thickness_cm):
+    def _attenuation_bn(self, *, xray_energy_kev, thickness_cm):
         """Common internal conversion calculator.
 
         Extracts material photon mass attenuation from material calculator,
@@ -84,15 +79,12 @@ class Absorber:
         Returns:
             Attenuation in 'system budget friendly' logarithmic units (Barnett units, Bn).
         """
-        _alpha = self.material_absorption_model.absorption_coefficient_per_cm(
-            energy_kev=xray_energy_kev
-        )
+        _alpha = self.spectrum.absorption_coefficient_per_cm(energy_kev=xray_energy_kev)
         _ln_t = -(thickness_cm * _alpha)
         return attenuation_from_natural_log_of_transmission(_ln_t)
 
 
-@dataclass(kw_only=True, frozen=True, config=ConfigDict(arbitrary_types_allowed=True))
-class FoilAbsorber(Absorber, FixedDepth):
+class FoilAbsorber(Absorber):
     """System level representation of an foil absorbing filter, typically wheel mounted.
 
     Attributes:
@@ -105,7 +97,7 @@ class FoilAbsorber(Absorber, FixedDepth):
     geometry_model: ThicknessProvider
 
     @validate_call
-    def calculate_absorption_bn(self, xray_energy_kev: XrayEnergy) -> float:
+    def calculate_absorption_bn(self, *, xray_energy_kev: StrictFloat) -> float:
         # see Protocol API for FixedDepth (absorber)
         _thickness_cm = self.geometry_model.get_thickness_cm()
         return self._attenuation_bn(
@@ -113,8 +105,7 @@ class FoilAbsorber(Absorber, FixedDepth):
         )
 
 
-@dataclass(kw_only=True, frozen=True, config=ConfigDict(arbitrary_types_allowed=True))
-class WedgeAbsorber(Absorber, VariableDepth):
+class WedgeAbsorber(Absorber):
     """System level representation of an foil absorbing filter, typically wheel mounted.
 
     Attributes:
@@ -129,7 +120,8 @@ class WedgeAbsorber(Absorber, VariableDepth):
     @validate_call
     def calculate_absorption_bn(
         self,
-        xray_energy_kev: XrayEnergy,
+        *,
+        xray_energy_kev: StrictFloat,
         motor_position_mm: StrictFloat,
     ) -> float:
         # see Protocol API for VariableDepth (absorber)

--- a/src/dodal/common/general_maths/interval.py
+++ b/src/dodal/common/general_maths/interval.py
@@ -1,0 +1,76 @@
+from pydantic import BaseModel, ConfigDict, StrictFloat, model_validator
+
+
+class FloatInterval(BaseModel):
+    """Base class for immutable range of floating point values.
+
+    N.B. Specific sub classes cover different end point types ( closed / open ).
+
+    Attributes:
+        lower: The lower endpoint defining the interval.
+        upper: The upper endpoint defining the interval.
+    """
+
+    lower: StrictFloat
+    upper: StrictFloat
+
+    model_config = ConfigDict(frozen=True)
+
+    @model_validator(mode="after")
+    def _ensure_order(self) -> "FloatInterval":
+        if self.lower > self.upper:
+            _msg = f"Interval is inverted! Lower endpoint {self.lower} cannot be greater than the upper {self.upper}."
+            raise ValueError(_msg)
+        return self
+
+    def _includes(self, x: float) -> bool:
+        """Internal method to impose the specific interval type definition, endpoints are closed or open.
+
+        Args:
+            x: the value to be checked against the interval endpoints.
+
+        Returns:
+            True if the interval includes the input value.
+        """
+        ...
+
+    def __contains__(self, item: object) -> bool:
+        if isinstance(item, (int, float)):
+            return self._includes(item)
+        if isinstance(item, FloatInterval):
+            return item.lower in self and item.upper in self
+        return False
+
+    def __hash__(self) -> int:
+        # Generate a stable hash based on the interval boundaries and class type
+        # (ensuring ClosedInterval vs OpenInterval with same numbers hash differently)
+        _hashable_innards = (type(self), self.lower, self.upper)
+        return hash(_hashable_innards)
+
+
+class ClosedInterval(FloatInterval):
+    """Interval with inclusive end points."""
+
+    def _includes(self, x: float) -> bool:
+        return self.lower <= x <= self.upper
+
+
+class ClosedOpenInterval(FloatInterval):
+    """Interval with inclusive lower endpoint and exclusive upper endpoint."""
+
+    def _includes(self, x: float) -> bool:
+        return self.lower <= x < self.upper
+
+
+class OpenInterval(FloatInterval):
+    """Interval with exclusive end points."""
+
+    def _includes(self, x: float) -> bool:
+        return self.lower < x < self.upper
+
+
+class OpenClosedInterval(FloatInterval):
+    """Interval with exclusive lower endpoint and inclusive upper endpoint."""
+
+    def _includes(self, x: float) -> bool:
+        return self.lower < x <= self.upper

--- a/src/dodal/common/general_maths/material_absorption_maths.py
+++ b/src/dodal/common/general_maths/material_absorption_maths.py
@@ -1,29 +1,31 @@
 from collections.abc import Callable
-from typing import Annotated
+from typing import Annotated, Final, Protocol, runtime_checkable
 
 from numpy.polynomial import polynomial
 from pydantic import (
+    BaseModel,
+    ConfigDict,
     Field,
     StrictFloat,
     validate_call,
 )
 
+from dodal.common.general_maths.interval import ClosedInterval
 from dodal.common.general_maths.transmission_interconversion import (
     attenuation_from_natural_log_of_transmission,
     natural_log_of_transmission_from_attenuation,
 )
 
 
-class AbsorptionCalculator:
+@runtime_checkable
+class AbsorptionCalculator(Protocol):
     """Interface for calculating absorption (due to mass attenuation) per cm as a function of x-ray energy in keV.
+
     Reports back a natural log based absorption factor as function of x-ray energy.
     """
 
-    def __init__(self, _calculation: Callable[[float], float]):
-        self._calculate = _calculation
-
     def absorption_coefficient_per_cm(
-        self, energy_kev: Annotated[StrictFloat, Field(gt=0)]
+        self, *, energy_kev: Annotated[StrictFloat, Field(gt=0)]
     ) -> float:
         """Logarithmic contribution to x-ray absorption per cm (depth into absorber) at a particular photon energy.
 
@@ -42,25 +44,40 @@ class AbsorptionCalculator:
         Returns:
             (float): Model adjustment of attenuation per cm of absorber material depth.
         """
+        ...
+
+
+class BaseAbsorptionCalculator(AbsorptionCalculator):
+    def __init__(self, _calculation: Callable[[float], float]):
+        # store the calculator functionality in the base class
+        self._calculate: Final[Callable[[float], float]] = _calculation
+
+    @validate_call
+    def absorption_coefficient_per_cm(
+        self, *, energy_kev: Annotated[StrictFloat, Field(gt=0)]
+    ) -> float:
         return self._calculate(energy_kev)
 
 
-class CompoundAbsorptionCalculator(AbsorptionCalculator):
+class CompoundAbsorptionCalculator(BaseAbsorptionCalculator):
     """Advanced physics model for mass attenuation per cm as a function of x-ray energy in keV.
+
     Applies effects from several absorption term calculations.
 
     Attributes:
         contributers (list[AbsorptionCalculator])
     """
 
-    def __init__(self, contributions: list[AbsorptionCalculator]):
+    def __init__(self, *, contributions: list[AbsorptionCalculator]):
         super().__init__(
             # lambda k is energy in keV
-            lambda k: sum(c.absorption_coefficient_per_cm(k) for c in contributions)
+            lambda k: sum(
+                c.absorption_coefficient_per_cm(energy_kev=k) for c in contributions
+            )
         )
 
 
-class PolynomialAbsorptionCorrection(AbsorptionCalculator):
+class PolynomialAbsorptionCorrection(BaseAbsorptionCalculator):
     """Corrective model for mass attenuation per cm as a function of x-ray energy in keV.
     Provides terms for correcting a baseline mass attenuation.
 
@@ -68,7 +85,7 @@ class PolynomialAbsorptionCorrection(AbsorptionCalculator):
         corrective_terms (float): Polynomial coefficients to correct the baseline modelled absorption per cm
     """
 
-    def __init__(self, coefficients_per_cm: list[float]):
+    def __init__(self, *, coefficients_per_cm: list[float]):
 
         def _calculate_correction(energy_kev: float) -> float:
             correction = polynomial.polyval(energy_kev, coefficients_per_cm)
@@ -77,8 +94,9 @@ class PolynomialAbsorptionCorrection(AbsorptionCalculator):
         super().__init__(_calculate_correction)
 
 
-class SingleRollOffAbsorptionCalculator(AbsorptionCalculator):
+class SingleRollOffAbsorptionCalculator(BaseAbsorptionCalculator):
     """Simplest physics model for mass attenuation per cm as a function of x-ray energy in keV.
+
     Typically appropriate where one element dominates the absorption,
     and energies passed in as calculation arguments are above the elements absorption resonance edge.
 
@@ -90,15 +108,100 @@ class SingleRollOffAbsorptionCalculator(AbsorptionCalculator):
 
     def __init__(
         self,
+        *,
         material_factor_per_cm: Annotated[StrictFloat, Field(gt=0)],
         roll_off: Annotated[StrictFloat, Field(lt=0)],
     ):
         # lambda k is energy in keV
         super().__init__(
             lambda k: photon_mass_attenuation_per_unit_length(
-                k, material_factor_per_cm, roll_off
+                energy_kev=k,
+                photon_absorption_factor_per_unit_length=material_factor_per_cm,
+                energy_dependence_exponent=roll_off,
             )
         )
+
+
+class AbsorptionSpectrumSegment(BaseModel):
+    """Pairing off of an energy interval against a particular parameterised absorption calculator.
+
+    Attributes:
+        kev_energy_interval: An inclusive, continuous energy interval.
+        absorption_calculator: An energy appropriate absorption calculator.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    kev_energy_interval: ClosedInterval
+    absorption_calculator: AbsorptionCalculator
+
+
+class MaterialAbsorptionSpectrum(BaseModel):
+    """Mapping across N x-ray energy intervals, of interval specific absorption calculator(s).
+
+    For a given material, one or more energy ranges (in keV) will each have a model calculating the "regional" absorption curve.
+
+    Attributes:
+        intervals: A tuple of AbsorptionIntervalModels
+
+
+    Example:
+        ```python
+        spectrum = MaterialAbsorptionSpectrum(
+            intervals=(
+                AbsorptionIntervalModel(
+                    kev_energy_range=ClosedInterval(lower=5.0, upper=12.3),
+                    absorption_calculator=SingleRollOffAbsorptionCalculator(
+                        material_factor_per_cm=3145.8, roll_off=-2.94
+                    )
+                ),
+                AbsorptionIntervalModel(
+                    kev_energy_range=ClosedInterval(lower=22.0, upper=50.0),
+                    absorption_calculator=SingleRollOffAbsorptionCalculator(
+                        material_factor_per_cm=1145.1, roll_off=-3.27
+                    )
+                )
+            )
+        )
+        ```
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+    intervals: tuple[AbsorptionSpectrumSegment, ...] = Field(
+        default_factory=tuple,
+        description="Sequence of energy intervals with their specific absorption curve calculator",
+        min_length=1,
+    )
+
+    def absorption_coefficient_per_cm(
+        self, *, energy_kev: Annotated[StrictFloat, Field(gt=0)]
+    ) -> float:
+        """Logarithmic contribution to x-ray absorption per cm (depth into absorber) at a particular photon energy.
+
+        Notes:
+        1) The cm as a typical unit length scale is a de facto standard in the field.
+        2a) The absorption coefficient is in factors of e.
+        2b) Barnett absorption units are only used once this coefficient is combined with depth in cm.
+        3a) Negative contributions to a sum have to be permitted so the output,
+            of a specific calculator instance, can be a float of either sign.
+        3b) Sub-classes may implicitly restrict this expectation.
+            Real materials the final absorption will be positive.
+
+        Args:
+            energy_kev (StrictFloat): The individual energy per photon in kilo-electronvolts
+
+        Returns:
+            (float): Model adjustment of attenuation per cm of absorber material depth.
+        """
+        # Iterate sequentially through our modelled energy intervals
+        for absorption_model in self.intervals:
+            if energy_kev in absorption_model.kev_energy_interval:
+                absorption_coeff = (
+                    absorption_model.absorption_calculator.absorption_coefficient_per_cm
+                )
+                return absorption_coeff(energy_kev=energy_kev)
+        _msg = f"Absorption of x-ray energy at {energy_kev} keV is outside the valid interval of any calculator in this modelled spectrum."
+        raise ValueError(_msg)
 
 
 @validate_call

--- a/src/dodal/common/general_maths/transmission_interconversion.py
+++ b/src/dodal/common/general_maths/transmission_interconversion.py
@@ -3,6 +3,8 @@ from typing import Annotated
 
 from pydantic import Field, StrictFloat, validate_call
 
+CANONICAL_NON_ABSORPTION = 0  # Absorption (Bn) when absorber is absent
+
 _CANONICAL_BARNETT_CONVERSION = -1.0e3
 _REVERSE_BARNETT_CONVERSION = -1.0e-3
 

--- a/tests/common/general_maths/test_absorber_geometry.py
+++ b/tests/common/general_maths/test_absorber_geometry.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any, Literal
 
 import pydantic
 import pytest
@@ -9,7 +10,7 @@ from dodal.common.general_maths.absorber_geometry import FoilGeometry, WedgeGeom
 
 
 @pytest.mark.parametrize(
-    "distance_unit, numerical_thickness_in_specified_unit, expected_thickness_cm",
+    "_distance_unit, _numerical_thickness_in_specified_unit, _expected_thickness_cm",
     [
         ("cm", 0.193, 0.193),
         ("um", 150.0, 0.015),
@@ -18,16 +19,18 @@ from dodal.common.general_maths.absorber_geometry import FoilGeometry, WedgeGeom
     ],
 )
 def test_foil_absorber_reports_thickness_in_cm_when_validly_specified(
-    distance_unit, numerical_thickness_in_specified_unit, expected_thickness_cm
-):
+    _distance_unit: str,
+    _numerical_thickness_in_specified_unit: float,
+    _expected_thickness_cm: float,
+) -> None:
     flat_absorber = FoilGeometry(
-        unit=distance_unit, numerical_value=numerical_thickness_in_specified_unit
+        unit=_distance_unit, numerical_value=_numerical_thickness_in_specified_unit
     )
-    assert flat_absorber.get_thickness_cm() == pytest.approx(expected_thickness_cm)
+    assert flat_absorber.get_thickness_cm() == pytest.approx(_expected_thickness_cm)
 
 
 @pytest.mark.parametrize(
-    "tip, taper_cotangent, probed_position_mm, expected_thickness_cm",
+    "_tip, _taper_cotangent, _probed_position_mm, _expected_thickness_cm",
     [
         (-5, 5.0, -5.0, 0.0),
         (2, -10.0, -15.2, 0.172),
@@ -36,16 +39,19 @@ def test_foil_absorber_reports_thickness_in_cm_when_validly_specified(
     ],
 )
 def test_wedge_geometry_reports_correct_thickness_in_cm(
-    tip, taper_cotangent, probed_position_mm, expected_thickness_cm
-):
-    wedge_absorber = WedgeGeometry(tip_mm=tip, taper_cotangent=taper_cotangent)
+    _tip: float | Literal[-5] | Literal[2],
+    _taper_cotangent: float,
+    _probed_position_mm: float,
+    _expected_thickness_cm: float,
+) -> None:
+    wedge_absorber = WedgeGeometry(tip_mm=_tip, taper_cotangent=_taper_cotangent)
     assert wedge_absorber.thickness_cm_at_motor_position_mm(
-        motor_position_mm=probed_position_mm
-    ) == pytest.approx(expected_thickness_cm)
+        motor_position_mm=_probed_position_mm
+    ) == pytest.approx(_expected_thickness_cm)
 
 
 @pytest.mark.parametrize(
-    "tip, taper_cotangent, required_thickness_cm, expected_motor_position_mm",
+    "_tip, _taper_cotangent, _required_thickness_cm, _expected_motor_position_mm",
     [
         (-5.0, 10.0, 0.04, -1.0),
         (3, -10.0, 0.172, -14.2),
@@ -54,19 +60,22 @@ def test_wedge_geometry_reports_correct_thickness_in_cm(
     ],
 )
 def test_wedge_geometry_reports_correct_motor_position_mm_to_achieve_requested_thickness(
-    tip, taper_cotangent, required_thickness_cm, expected_motor_position_mm
-):
-    wedge_absorber = WedgeGeometry(tip_mm=tip, taper_cotangent=taper_cotangent)
+    _tip: float | Literal[3],
+    _taper_cotangent: float,
+    _required_thickness_cm: float,
+    _expected_motor_position_mm: float,
+) -> None:
+    wedge_absorber = WedgeGeometry(tip_mm=_tip, taper_cotangent=_taper_cotangent)
     assert wedge_absorber.motor_position_mm_for_thickness_cm(
-        thickness_cm=required_thickness_cm
-    ) == pytest.approx(expected_motor_position_mm)
+        thickness_cm=_required_thickness_cm
+    ) == pytest.approx(_expected_motor_position_mm)
 
 
 # inauspicious path
 
 
 @pytest.mark.parametrize(
-    "bad_input",
+    "_bad_number",
     [
         "",
         "k",
@@ -81,14 +90,14 @@ def test_wedge_geometry_reports_correct_motor_position_mm_to_achieve_requested_t
     ],
 )
 def test_foil_absorber_raises_error_when_given_invalid_input_for_numerical_thickness(
-    bad_input,
+    _bad_number: Any,
 ):
     with pytest.raises(pydantic.ValidationError):
-        FoilGeometry(unit="cm", numerical_value=bad_input)
+        FoilGeometry(unit="cm", numerical_value=_bad_number)
 
 
 @pytest.mark.parametrize(
-    "unsupported_unit",
+    "_unsupported_unit",
     [
         "",
         "12",
@@ -105,14 +114,14 @@ def test_foil_absorber_raises_error_when_given_invalid_input_for_numerical_thick
     ],
 )
 def test_foil_absorber_raises_error_when_asked_to_use_unsupported_distance_units(
-    unsupported_unit,
+    _unsupported_unit: Any,
 ):
     with pytest.raises(KeyError):
-        FoilGeometry(unit=unsupported_unit, numerical_value=1.1)
+        FoilGeometry(unit=_unsupported_unit, numerical_value=1.1)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
+    "_bad_input",
     [
         -9,
         0,
@@ -127,13 +136,15 @@ def test_foil_absorber_raises_error_when_asked_to_use_unsupported_distance_units
         False,
     ],
 )
-def test_foil_absorber_raises_error_when_given_invalid_distance_units(bad_input):
+def test_foil_absorber_raises_error_when_given_invalid_distance_units(
+    _bad_input: Any,
+) -> None:
     with pytest.raises(pydantic.ValidationError):
-        FoilGeometry(unit=bad_input, numerical_value=1.1)
+        FoilGeometry(unit=_bad_input, numerical_value=1.1)
 
 
 @pytest.mark.parametrize(
-    "taper_cotangent",
+    "_taper_cotangent",
     [
         0,
         1,
@@ -148,13 +159,15 @@ def test_foil_absorber_raises_error_when_given_invalid_distance_units(bad_input)
         1.16,
     ],
 )
-def test_wedge_absorber_raises_error_when_given_chunky_wedge_angle(taper_cotangent):
+def test_wedge_absorber_raises_error_when_given_chunky_wedge_angle(
+    _taper_cotangent: float,
+) -> None:
     with pytest.raises(pydantic.ValidationError):
-        WedgeGeometry(tip_mm=4.8, taper_cotangent=taper_cotangent)
+        WedgeGeometry(tip_mm=4.8, taper_cotangent=_taper_cotangent)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
+    "_bad_input",
     [
         "",
         "k",
@@ -166,13 +179,15 @@ def test_wedge_absorber_raises_error_when_given_chunky_wedge_angle(taper_cotange
         True,
     ],
 )
-def test_wedge_absorber_raises_error_when_given_invalid_input_for_taper(bad_input):
+def test_wedge_absorber_raises_error_when_given_invalid_input_for_taper(
+    _bad_input: Any,
+) -> None:
     with pytest.raises(pydantic.ValidationError):
-        WedgeGeometry(tip_mm=3.17, taper_cotangent=bad_input)
+        WedgeGeometry(tip_mm=3.17, taper_cotangent=_bad_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
+    "_bad_input",
     [
         "",
         "k",
@@ -185,7 +200,7 @@ def test_wedge_absorber_raises_error_when_given_invalid_input_for_taper(bad_inpu
     ],
 )
 def test_wedge_absorber_raises_error_when_given_invalid_input_for_tip_position(
-    bad_input,
+    _bad_input: Any,
 ):
     with pytest.raises(pydantic.ValidationError):
-        WedgeGeometry(tip_mm=bad_input, taper_cotangent=-7.6)
+        WedgeGeometry(tip_mm=_bad_input, taper_cotangent=-7.6)

--- a/tests/common/general_maths/test_absorber_geometry.py
+++ b/tests/common/general_maths/test_absorber_geometry.py
@@ -91,7 +91,7 @@ def test_wedge_geometry_reports_correct_motor_position_mm_to_achieve_requested_t
 )
 def test_foil_absorber_raises_error_when_given_invalid_input_for_numerical_thickness(
     _bad_number: Any,
-):
+) -> None:
     with pytest.raises(pydantic.ValidationError):
         FoilGeometry(unit="cm", numerical_value=_bad_number)
 
@@ -115,7 +115,7 @@ def test_foil_absorber_raises_error_when_given_invalid_input_for_numerical_thick
 )
 def test_foil_absorber_raises_error_when_asked_to_use_unsupported_distance_units(
     _unsupported_unit: Any,
-):
+) -> None:
     with pytest.raises(KeyError):
         FoilGeometry(unit=_unsupported_unit, numerical_value=1.1)
 
@@ -201,6 +201,6 @@ def test_wedge_absorber_raises_error_when_given_invalid_input_for_taper(
 )
 def test_wedge_absorber_raises_error_when_given_invalid_input_for_tip_position(
     _bad_input: Any,
-):
+) -> None:
     with pytest.raises(pydantic.ValidationError):
         WedgeGeometry(tip_mm=_bad_input, taper_cotangent=-7.6)

--- a/tests/common/general_maths/test_absorbers.py
+++ b/tests/common/general_maths/test_absorbers.py
@@ -9,21 +9,25 @@ from dodal.common.general_maths.absorber_geometry import (
     ThicknessProvider,
 )
 from dodal.common.general_maths.absorbers import FoilAbsorber, WedgeAbsorber
+from dodal.common.general_maths.interval import ClosedInterval
 from dodal.common.general_maths.material_absorption_maths import (
+    AbsorptionSpectrumSegment,
+    MaterialAbsorptionSpectrum,
     SingleRollOffAbsorptionCalculator,
 )
 
 # happy path
 
 
-def test_that_wedge_absorber_asks_geometry_model_for_thickness():
-    material_absorption_strut = MagicMock(spec=SingleRollOffAbsorptionCalculator)
+def test_that_wedge_absorber_asks_geometry_model_for_thickness() -> None:
+    material_absorption_strut = MagicMock(spec=MaterialAbsorptionSpectrum)
     material_absorption_strut.absorption_coefficient_per_cm.return_value = 1.9
     geometry_model = MagicMock(spec=TaperedGeometryProvider)
     geometry_model.taper_cotangent = 12.3
     geometry_model.thickness_cm_at_motor_position_mm.return_value = 0.5
+
     wedge_absorber = WedgeAbsorber(
-        material_absorption_model=material_absorption_strut,
+        spectrum=material_absorption_strut,
         geometry_model=geometry_model,
     )
     wedge_absorber.calculate_absorption_bn(
@@ -35,14 +39,14 @@ def test_that_wedge_absorber_asks_geometry_model_for_thickness():
     )
 
 
-def test_that_wedge_absorber_reports_faithful_absorption_result():
-    material_absorption_strut = MagicMock(spec=SingleRollOffAbsorptionCalculator)
+def test_that_wedge_absorber_reports_faithful_absorption_result() -> None:
+    material_absorption_strut = MagicMock(spec=MaterialAbsorptionSpectrum)
     material_absorption_strut.absorption_coefficient_per_cm.return_value = 2.5
     geometry_model = MagicMock(spec=TaperedGeometryProvider)
     geometry_model.taper_cotangent = 19.1
     geometry_model.thickness_cm_at_motor_position_mm.return_value = 0.72
     wedge_absorber = WedgeAbsorber(
-        material_absorption_model=material_absorption_strut,
+        spectrum=material_absorption_strut,
         geometry_model=geometry_model,
     )
     result = wedge_absorber.calculate_absorption_bn(
@@ -53,26 +57,26 @@ def test_that_wedge_absorber_reports_faithful_absorption_result():
     assert result == pytest.approx(expected_result)
 
 
-def test_that_foil_absorber_asks_geometry_model_for_thickness():
-    material_absorption_strut = MagicMock(spec=SingleRollOffAbsorptionCalculator)
+def test_that_foil_absorber_asks_geometry_model_for_thickness() -> None:
+    material_absorption_strut = MagicMock(spec=MaterialAbsorptionSpectrum)
     material_absorption_strut.absorption_coefficient_per_cm.return_value = 1.8
     geometry_model = MagicMock(spec=ThicknessProvider)
     geometry_model.get_thickness_cm.return_value = 0.5
     foil_absorber = FoilAbsorber(
-        material_absorption_model=material_absorption_strut,
+        spectrum=material_absorption_strut,
         geometry_model=geometry_model,
     )
     foil_absorber.calculate_absorption_bn(xray_energy_kev=12.3450)  # energy irrelevant
     geometry_model.get_thickness_cm.assert_called_once()
 
 
-def test_that_foil_absorber_reports_faithful_absorption_result():
-    material_absorption_strut = MagicMock(spec=SingleRollOffAbsorptionCalculator)
+def test_that_foil_absorber_reports_faithful_absorption_result() -> None:
+    material_absorption_strut = MagicMock(spec=MaterialAbsorptionSpectrum)
     material_absorption_strut.absorption_coefficient_per_cm.return_value = 0.63
     geometry_model = MagicMock(spec=ThicknessProvider)
     geometry_model.get_thickness_cm.return_value = 0.85
     foil_absorber = FoilAbsorber(
-        material_absorption_model=material_absorption_strut,
+        spectrum=material_absorption_strut,
         geometry_model=geometry_model,
     )
     result = foil_absorber.calculate_absorption_bn(
@@ -86,14 +90,44 @@ def test_that_foil_absorber_reports_faithful_absorption_result():
 
 
 @pytest.mark.parametrize(
-    "invalid_xray_energy",
+    "_out_of_bounds_xray_energy",
     [
-        None,
-        78,
-        106.7,
+        0,
+        4.309,
         -21.4501,
         -8,
-        0.02,
+        -0.02,
+        28.971,
+    ],
+)
+def test_that_foil_absorber_reports_raises_error_when_xray_energy_is_out_of_bounds(
+    _out_of_bounds_xray_energy,
+) -> None:
+    baseline_calculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=2.5, roll_off=-0.97
+    )
+    valid_energy_interval = ClosedInterval(lower=4.5, upper=18.92)
+    segment = AbsorptionSpectrumSegment(
+        kev_energy_interval=valid_energy_interval,
+        absorption_calculator=baseline_calculator,
+    )
+    spectrum = MaterialAbsorptionSpectrum(intervals=(segment,))
+    geometry_model = MagicMock(spec=ThicknessProvider)
+    geometry_model.get_thickness_cm.return_value = 0.85
+    foil_absorber = FoilAbsorber(
+        spectrum=spectrum,
+        geometry_model=geometry_model,
+    )
+    with pytest.raises(ValueError):
+        foil_absorber.calculate_absorption_bn(
+            xray_energy_kev=_out_of_bounds_xray_energy
+        )
+
+
+@pytest.mark.parametrize(
+    "_invalid_xray_energy",
+    [
+        None,
         "",
         "J",
         object(),
@@ -104,29 +138,70 @@ def test_that_foil_absorber_reports_faithful_absorption_result():
     ],
 )
 def test_that_foil_absorber_reports_raises_error_when_xray_energy_is_invalid(
-    invalid_xray_energy,
-):
-    material_absorption_strut = MagicMock(spec=SingleRollOffAbsorptionCalculator)
-    material_absorption_strut.absorption_coefficient_per_cm.return_value = 0.63
+    _invalid_xray_energy,
+) -> None:
+    baseline_calculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=2.5, roll_off=-0.97
+    )
+    valid_energy_interval = ClosedInterval(lower=4.5, upper=18.92)
+    segment = AbsorptionSpectrumSegment(
+        kev_energy_interval=valid_energy_interval,
+        absorption_calculator=baseline_calculator,
+    )
+    spectrum = MaterialAbsorptionSpectrum(intervals=(segment,))
     geometry_model = MagicMock(spec=ThicknessProvider)
     geometry_model.get_thickness_cm.return_value = 0.85
     foil_absorber = FoilAbsorber(
-        material_absorption_model=material_absorption_strut,
+        spectrum=spectrum,
         geometry_model=geometry_model,
     )
     with pytest.raises(ValidationError):
-        foil_absorber.calculate_absorption_bn(xray_energy_kev=invalid_xray_energy)
+        foil_absorber.calculate_absorption_bn(xray_energy_kev=_invalid_xray_energy)
 
 
 @pytest.mark.parametrize(
-    "invalid_xray_energy",
+    "_out_of_bounds_xray_energy",
     [
-        None,
-        42,
-        50.6,
+        0,
+        2.4,
+        1,
+        88,
+        75.32,
+        -50.6,
         -21.4501,
         -6,
-        0.04,
+    ],
+)
+def test_that_wedge_absorber_reports_raises_error_when_xray_energy_is_not_covered_by_modelled_spectrum(
+    _out_of_bounds_xray_energy,
+) -> None:
+    baseline_calculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=2.5, roll_off=-0.97
+    )
+    valid_energy_interval = ClosedInterval(lower=4.5, upper=18.92)
+    segment = AbsorptionSpectrumSegment(
+        kev_energy_interval=valid_energy_interval,
+        absorption_calculator=baseline_calculator,
+    )
+    spectrum = MaterialAbsorptionSpectrum(intervals=(segment,))
+    geometry_model = MagicMock(spec=TaperedGeometryProvider)
+    geometry_model.taper_cotangent = 19.1
+    geometry_model.thickness_cm_at_motor_position_mm.return_value = 0.72
+    wedge_absorber = WedgeAbsorber(
+        spectrum=spectrum,
+        geometry_model=geometry_model,
+    )
+    with pytest.raises(ValueError):
+        wedge_absorber.calculate_absorption_bn(
+            xray_energy_kev=_out_of_bounds_xray_energy,
+            motor_position_mm=12.8,  # energy, motor position irrelevant
+        )
+
+
+@pytest.mark.parametrize(
+    "_invalid_xray_energy",
+    [
+        None,
         "",
         "o",
         object(),
@@ -137,26 +212,33 @@ def test_that_foil_absorber_reports_raises_error_when_xray_energy_is_invalid(
     ],
 )
 def test_that_wedge_absorber_reports_raises_error_when_xray_energy_is_invalid(
-    invalid_xray_energy,
-):
-    material_absorption_strut = MagicMock(spec=SingleRollOffAbsorptionCalculator)
-    material_absorption_strut.absorption_coefficient_per_cm.return_value = 2.5
+    _invalid_xray_energy,
+) -> None:
+    baseline_calculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=2001.5, roll_off=-1.75
+    )
+    valid_energy_interval = ClosedInterval(lower=3.5, upper=28.92)
+    segment = AbsorptionSpectrumSegment(
+        kev_energy_interval=valid_energy_interval,
+        absorption_calculator=baseline_calculator,
+    )
+    spectrum = MaterialAbsorptionSpectrum(intervals=(segment,))
     geometry_model = MagicMock(spec=TaperedGeometryProvider)
-    geometry_model.taper_cotangent = 19.1
-    geometry_model.thickness_cm_at_motor_position_mm.return_value = 0.72
+    geometry_model.taper_cotangent = 15.1
+    geometry_model.thickness_cm_at_motor_position_mm.return_value = 0.82
     wedge_absorber = WedgeAbsorber(
-        material_absorption_model=material_absorption_strut,
+        spectrum=spectrum,
         geometry_model=geometry_model,
     )
     with pytest.raises(ValidationError):
         wedge_absorber.calculate_absorption_bn(
-            xray_energy_kev=invalid_xray_energy,
+            xray_energy_kev=_invalid_xray_energy,
             motor_position_mm=12.8,  # energy, motor position irrelevant
         )
 
 
 @pytest.mark.parametrize(
-    "invalid_motor_position",
+    "_invalid_motor_position",
     [
         None,
         "",
@@ -169,19 +251,19 @@ def test_that_wedge_absorber_reports_raises_error_when_xray_energy_is_invalid(
     ],
 )
 def test_that_wedge_absorber_reports_raises_error_when_motor_position_is_invalid(
-    invalid_motor_position,
-):
-    material_absorption_strut = MagicMock(spec=SingleRollOffAbsorptionCalculator)
+    _invalid_motor_position,
+) -> None:
+    material_absorption_strut = MagicMock(spec=MaterialAbsorptionSpectrum)
     material_absorption_strut.absorption_coefficient_per_cm.return_value = 2.5
     geometry_model = MagicMock(spec=TaperedGeometryProvider)
     geometry_model.taper_cotangent = 18.1
     geometry_model.thickness_cm_at_motor_position_mm.return_value = 0.62
     wedge_absorber = WedgeAbsorber(
-        material_absorption_model=material_absorption_strut,
+        spectrum=material_absorption_strut,
         geometry_model=geometry_model,
     )
     with pytest.raises(ValidationError):
         wedge_absorber.calculate_absorption_bn(
             xray_energy_kev=21.7,
-            motor_position_mm=invalid_motor_position,  # energy, motor position irrelevant
+            motor_position_mm=_invalid_motor_position,  # energy, motor position irrelevant
         )

--- a/tests/common/general_maths/test_arithmetic_conversions.py
+++ b/tests/common/general_maths/test_arithmetic_conversions.py
@@ -1,5 +1,6 @@
 import math
 from collections.abc import Callable
+from typing import Any, Final
 
 import pydantic
 import pytest
@@ -21,43 +22,58 @@ from tests.common.general_maths.operator_inversion_pairing import (
 
 
 # expected success tests (the 'Happy Path'): All numbers here are arbitrary
-@pytest.mark.parametrize("input,result", [(1.0, 0.1), (100.0, 10.0)])
-def test_conversion_from_millimetres_to_centimetres(input, result):
+@pytest.mark.parametrize(
+    "input,result", [(19.2, 1.92), (105.1, 10.51), (0, 0), (0.72, 0.072)]
+)
+def test_conversion_from_millimetres_to_centimetres(input, result) -> None:
     assert convert_mm_to_cm(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1.0, 10), (0.1, 1.0)])
-def test_conversion_from_centimetres_to_millimetres(input, result):
+@pytest.mark.parametrize("input,result", [(3.6, 36), (2, 20), (0, 0), (0.254, 2.54)])
+def test_conversion_from_centimetres_to_millimetres(input, result) -> None:
     assert convert_cm_to_mm(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(0.01, 1.0), (1.0, 100.0)])
-def test_conversion_to_percentage_from_factor(input, result):
+@pytest.mark.parametrize(
+    "input,result", [(0.063, 6.3), (1, 100), (0, 0), (0.548, 54.8)]
+)
+def test_conversion_to_percentage_from_factor(input, result) -> None:
     assert convert_factor_to_percentage(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1.0, 0.01), (100, 1.0)])
-def test_conversion_to_factor_from_percentage(input, result):
+@pytest.mark.parametrize(
+    "input,result", [(1.0, 0.01), (100, 1), (0, 0), (82.6, 0.826), (0.4, 0.004)]
+)
+def test_conversion_to_factor_from_percentage(input, result) -> None:
     assert convert_percentage_to_factor(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1000.0, 1.0), (10000.0, 10.0)])
-def test_conversion_from_microns_to_millimeters(input, result):
+@pytest.mark.parametrize(
+    "input,result", [(0, 0), (512.4, 0.5124), (1000.0, 1.0), (12708.0, 12.708)]
+)
+def test_conversion_from_microns_to_millimeters(input, result) -> None:
     assert convert_microns_to_mm(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1.0, 1000.0), (10, 10000.0)])
-def test_conversion_from_millimeters_to_microns(input, result):
+@pytest.mark.parametrize(
+    "input,result", [(0, 0), (0.42, 420), (1.0, 1000.0), (12.5, 12500.0)]
+)
+def test_conversion_from_millimeters_to_microns(input, result) -> None:
     assert convert_mm_to_microns(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(1000, 1.0), (100, 0.1)])
-def test_conversion_from_electronvolts_to_kiloelectronvolts(input, result):
+@pytest.mark.parametrize(
+    "input,result", [(12398.425, 12.398425), (2050, 2.05), (813, 0.813)]
+)
+def test_conversion_from_electronvolts_to_kiloelectronvolts(input, result) -> None:
     assert convert_ev_to_kev(input) == pytest.approx(result)
 
 
-@pytest.mark.parametrize("input,result", [(10000.0, 1.0), (1000, 0.1)])
-def test_conversion_from_microns_to_centimetres(input, result):
+@pytest.mark.parametrize(
+    "input,result",
+    [(0, 0), (40000.0, 4.0), (1200, 0.12), (7056, 0.7056), (804.2, 0.08042)],
+)
+def test_conversion_from_microns_to_centimetres(input, result) -> None:
     assert convert_microns_to_cm(input) == pytest.approx(result)
 
 
@@ -78,7 +94,7 @@ def test_conversion_from_microns_to_centimetres(input, result):
         (5.2, 0.0, -8.64, 5.2),
     ],
 )
-def test_straight_line_conversion(c, m, x, expected_y):
+def test_straight_line_conversion(c, m, x, expected_y) -> None:
     assert get_straight_line_y(line_offset=c, line_gradient=m, x=x) == pytest.approx(
         expected_y
     )
@@ -122,7 +138,7 @@ def test_reciprocal_function_pairs_nest_consistent_with_identity(
     f: Callable[[float], float],
     g: Callable[[float], float],
     numerical_args: list[float],
-):
+) -> None:
     for op_pair in [
         OperatorInversionPairing(f, g),
         OperatorInversionPairing(g, f),
@@ -133,107 +149,129 @@ def test_reciprocal_function_pairs_nest_consistent_with_identity(
 
 # The inauspicuous path
 
+NON_NUMERICAL_EXAMPLES: Final[list[Any]] = [
+    "",
+    "a",
+    [],
+    None,
+    math.sin,
+    object(),
+    KeyError(),
+    False,
+    True,
+]
+
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_microns_to_cm_raises_error_with_bad_input(bad_input):
+def test_convert_microns_to_cm_raises_error_with_non_numerical_input(
+    non_numerical_input,
+) -> None:
     with pytest.raises(pydantic.ValidationError):
-        convert_microns_to_cm(bad_input)
+        convert_microns_to_cm(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_ev_to_kev_raises_error_with_bad_input(bad_input):
+def test_convert_ev_to_kev_raises_error_with_non_numerical_input(non_numerical_input):
     with pytest.raises(pydantic.ValidationError):
-        convert_ev_to_kev(bad_input)
+        convert_ev_to_kev(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_microns_to_mm_raises_error_with_bad_input(bad_input):
+def test_convert_microns_to_mm_raises_error_with_non_numerical_input(
+    non_numerical_input,
+):
     with pytest.raises(pydantic.ValidationError):
-        convert_microns_to_mm(bad_input)
+        convert_microns_to_mm(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_mm_to_microns_raises_error_with_bad_input(bad_input):
+def test_convert_mm_to_microns_raises_error_with_non_numerical_input(
+    non_numerical_input,
+):
     with pytest.raises(pydantic.ValidationError):
-        convert_mm_to_microns(bad_input)
+        convert_mm_to_microns(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), True],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_factor_to_percentage_raises_error_with_bad_input(bad_input):
+def test_convert_factor_to_percentage_raises_error_with_non_numerical_input(
+    non_numerical_input,
+):
     with pytest.raises(pydantic.ValidationError):
-        convert_factor_to_percentage(bad_input)
+        convert_factor_to_percentage(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_percentage_to_factor_raises_error_with_bad_input(bad_input):
+def test_convert_percentage_to_factor_raises_error_with_non_numerical_input(
+    non_numerical_input,
+):
     with pytest.raises(pydantic.ValidationError):
-        convert_percentage_to_factor(bad_input)
+        convert_percentage_to_factor(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_mm_to_cm_raises_error_with_bad_input(bad_input):
+def test_convert_mm_to_cm_raises_error_with_non_numerical_input(non_numerical_input):
     with pytest.raises(pydantic.ValidationError):
-        convert_mm_to_cm(bad_input)
+        convert_mm_to_cm(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), True],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_convert_cm_to_mm_raises_error_with_bad_input(bad_input):
+def test_convert_cm_to_mm_raises_error_with_non_numerical_input(non_numerical_input):
     with pytest.raises(pydantic.ValidationError):
-        convert_cm_to_mm(bad_input)
+        convert_cm_to_mm(non_numerical_input)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.log, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_straight_line_calculator_raises_error_with_bad_offset(bad_input):
+def test_straight_line_calculator_raises_error_with_bad_offset(non_numerical_input):
     _probe_x = 11.1
     _line_gradient = -2.07
     with pytest.raises(pydantic.ValidationError):
-        get_straight_line_y(bad_input, _line_gradient, _probe_x)
+        get_straight_line_y(non_numerical_input, _line_gradient, _probe_x)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.sin, object(), True],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_straight_line_calculator_raises_error_with_bad_gradient(bad_input):
+def test_straight_line_calculator_raises_error_with_bad_gradient(non_numerical_input):
     _probe_x = -11.1
     _line_offset = 14.2
     with pytest.raises(pydantic.ValidationError):
-        get_straight_line_y(_line_offset, bad_input, _probe_x)
+        get_straight_line_y(_line_offset, non_numerical_input, _probe_x)
 
 
 @pytest.mark.parametrize(
-    "bad_input",
-    ["", "a", [], None, math.tan, object(), False],
+    "non_numerical_input",
+    NON_NUMERICAL_EXAMPLES,
 )
-def test_straight_line_calculator_raises_error_with_bad_x_value(bad_input):
+def test_straight_line_calculator_raises_error_with_bad_x_value(non_numerical_input):
     _line_offset = 0.1
     _line_gradient = 5.4
     with pytest.raises(pydantic.ValidationError):
-        get_straight_line_y(_line_offset, _line_gradient, bad_input)
+        get_straight_line_y(_line_offset, _line_gradient, non_numerical_input)

--- a/tests/common/general_maths/test_interval.py
+++ b/tests/common/general_maths/test_interval.py
@@ -1,0 +1,209 @@
+import pytest
+
+from dodal.common.general_maths.interval import (
+    ClosedInterval,
+    ClosedOpenInterval,
+    FloatInterval,
+    OpenClosedInterval,
+    OpenInterval,
+)
+
+# Happy path
+
+
+@pytest.mark.parametrize(
+    "_interval_cls",
+    [ClosedInterval, ClosedOpenInterval, OpenClosedInterval, OpenInterval],
+)
+@pytest.mark.parametrize(
+    "_probed_x, _lower, _upper",
+    [
+        (
+            0.0,
+            -1.5,
+            2.1,
+        ),
+        (
+            4.2,
+            1.2,
+            402.87,
+        ),
+        (
+            -7.09,
+            -14.2,
+            -5.44,
+        ),
+    ],
+)
+def test_all_interval_types_recognise_point_when_unamiguously_within(
+    _interval_cls: type[FloatInterval], _probed_x: float, _lower: float, _upper: float
+) -> None:
+    interval = _interval_cls(lower=_lower, upper=_upper)
+    assert _probed_x in interval
+
+
+@pytest.mark.parametrize(
+    "_interval_cls",
+    [ClosedInterval, ClosedOpenInterval, OpenClosedInterval, OpenInterval],
+)
+@pytest.mark.parametrize(
+    "_probed_x, _lower, _upper",
+    [
+        (
+            10.0,
+            -1.5,
+            2.1,
+        ),
+        (
+            -4.2,
+            1.2,
+            402.87,
+        ),
+        (
+            -17.09,
+            -14.2,
+            -5.44,
+        ),
+    ],
+)
+def test_all_interval_types_recognise_point_when_unamiguously_without(
+    _interval_cls: type[FloatInterval], _probed_x: float, _lower: float, _upper: float
+) -> None:
+    interval = _interval_cls(lower=_lower, upper=_upper)
+    assert _probed_x not in interval
+
+
+@pytest.mark.parametrize(
+    "_interval_cls",
+    [
+        ClosedOpenInterval,
+        OpenClosedInterval,
+        OpenInterval,
+    ],
+)
+def test_other_interval_types_avoid_hash_collisions_with_closed_interval(
+    _interval_cls,
+) -> None:
+    a: int = 4
+    b: int = 5
+    _benchmark = ClosedInterval(lower=a, upper=b)
+    _other = _interval_cls(lower=a, upper=b)
+    assert hash(_benchmark) != hash(_other)
+
+
+@pytest.mark.parametrize(
+    "_interval_cls",
+    [
+        OpenClosedInterval,
+        OpenInterval,
+    ],
+)
+def test_other_interval_types_avoid_hash_collisions_with_closed_open_interval(
+    _interval_cls,
+) -> None:
+    a: int = 4
+    b: int = 5
+    _benchmark = ClosedOpenInterval(lower=a, upper=b)
+    _other = _interval_cls(lower=a, upper=b)
+    assert hash(_benchmark) != hash(_other)
+
+
+def test_open_closed_and_open_intervals_do_not_suffer_hash_collisions() -> None:
+    a: int = 4
+    b: int = 5
+    _benchmark = OpenClosedInterval(lower=a, upper=b)
+    _other = OpenInterval(lower=a, upper=b)
+    assert hash(_benchmark) != hash(_other)
+
+
+@pytest.mark.parametrize(
+    "_interval_cls",
+    [ClosedInterval, ClosedOpenInterval, OpenClosedInterval, OpenInterval],
+)
+@pytest.mark.parametrize(
+    "_lower, _upper",
+    [
+        (
+            -1.5,
+            2.1,
+        ),
+        (
+            1.2,
+            402.87,
+        ),
+        (
+            -17.09,
+            14.2,
+        ),
+    ],
+)
+def test_all_interval_types_recognise_another_interval_lies_outside(
+    _interval_cls: type[FloatInterval], _lower: float, _upper: float
+) -> None:
+    _probe_external_interval = ClosedInterval(lower=101.4, upper=952.93)
+    _outer_interval = _interval_cls(lower=_lower, upper=_upper)
+    assert _probe_external_interval not in _outer_interval
+
+
+@pytest.mark.parametrize(
+    "_interval_cls",
+    [ClosedInterval, ClosedOpenInterval, OpenClosedInterval, OpenInterval],
+)
+@pytest.mark.parametrize(
+    "_lower, _upper",
+    [
+        (
+            -1.5,
+            2.1,
+        ),
+        (
+            1.2,
+            402.87,
+        ),
+        (
+            -17.09,
+            14.2,
+        ),
+    ],
+)
+def test_all_interval_types_recognise_another_interval_lies_inside(
+    _interval_cls: type[FloatInterval], _lower: float, _upper: float
+) -> None:
+    _probe_inner_interval = ClosedInterval(lower=1.4, upper=1.93)
+    _outer_interval = _interval_cls(lower=_lower, upper=_upper)
+    assert _probe_inner_interval in _outer_interval
+
+
+# Not sharply testing end points as these tests will be brittle to machine epsilon
+# Therefore excluding tests of inclusivity on end points
+# also excluding tests of zero length intervals - given those are impractical it's no great loss
+
+# Inauspicious path
+
+
+@pytest.mark.parametrize(
+    "_interval_cls",
+    [ClosedInterval, ClosedOpenInterval, OpenClosedInterval, OpenInterval],
+)
+@pytest.mark.parametrize(
+    "_lower, _upper",
+    [
+        (
+            -1,
+            0,
+        ),
+        (
+            -77.8,
+            34.6,
+        ),
+        (
+            -24.5,
+            -12.02,
+        ),
+    ],
+)
+def test_any_interval_types_rejects_misordered_endpoints(
+    _interval_cls: type[FloatInterval], _lower: float, _upper: float
+) -> None:
+    with pytest.raises(ValueError):
+        _interval_cls(lower=_upper, upper=_lower)

--- a/tests/common/general_maths/test_material_absorption_maths.py
+++ b/tests/common/general_maths/test_material_absorption_maths.py
@@ -1,13 +1,18 @@
 import math
-from typing import cast
+from typing import Any, Final, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
+from dodal.common.general_maths.interval import (
+    ClosedInterval,
+)
 from dodal.common.general_maths.material_absorption_maths import (
     AbsorptionCalculator,
+    AbsorptionSpectrumSegment,
     CompoundAbsorptionCalculator,
+    MaterialAbsorptionSpectrum,
     PolynomialAbsorptionCorrection,
     SingleRollOffAbsorptionCalculator,
     attenuation_at_depth_cm,
@@ -26,35 +31,41 @@ from dodal.common.general_maths.material_absorption_maths import (
 )
 def test_simple_absorption_calculator_invokes_photon_mass_attenuation_calculator(
     mock_pma_calc: MagicMock,
-):
+) -> None:
     _material_factor = 3.1415926
     _roll_off = -2.71828
-    calculator = SingleRollOffAbsorptionCalculator(_material_factor, _roll_off)
+    calculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=_material_factor, roll_off=_roll_off
+    )
     _x_ray_kev = 15.6302
-    calculator.absorption_coefficient_per_cm(_x_ray_kev)
-    mock_pma_calc.assert_called_once_with(_x_ray_kev, _material_factor, _roll_off)
+    calculator.absorption_coefficient_per_cm(energy_kev=_x_ray_kev)
+    mock_pma_calc.assert_called_once_with(
+        energy_kev=_x_ray_kev,
+        photon_absorption_factor_per_unit_length=_material_factor,
+        energy_dependence_exponent=_roll_off,
+    )
 
 
 # N.B. the mathematical validity of results from a compound absorption calculator
 # are not tested here - since that would duplicate the validatity tests of numerical calculations
 # already checked against the contributing calculators within
-def test_compound_absorption_calculator_invokes_contributing_calculators():
+def test_compound_absorption_calculator_invokes_contributing_calculators() -> None:
     mock_calcs: list[MagicMock] = [
         MagicMock(spec=AbsorptionCalculator),
         MagicMock(spec=AbsorptionCalculator),
     ]
     calcs = cast(list[AbsorptionCalculator], mock_calcs)
-    compound_calculator = CompoundAbsorptionCalculator(calcs)
+    compound_calculator = CompoundAbsorptionCalculator(contributions=calcs)
     _x_ray_kev = 12.6039
-    compound_calculator.absorption_coefficient_per_cm(_x_ray_kev)
+    compound_calculator.absorption_coefficient_per_cm(energy_kev=_x_ray_kev)
     for mocked_calculator in mock_calcs:
         mocked_calculator.absorption_coefficient_per_cm.assert_called_once_with(
-            _x_ray_kev
+            energy_kev=_x_ray_kev
         )
 
 
 @pytest.mark.parametrize(
-    "energy_kev, polynomial_coefficients, expected_absorption_coefficient",
+    "_energy_kev, _polynomial_coefficients, _expected_absorption_coefficient",
     [
         (
             8.3328,
@@ -74,17 +85,19 @@ def test_compound_absorption_calculator_invokes_contributing_calculators():
     ],
 )
 def test_corrective_polynomial_absorption_calculator(
-    energy_kev, polynomial_coefficients, expected_absorption_coefficient
-):
-    corrective_calculator = PolynomialAbsorptionCorrection(polynomial_coefficients)
+    _energy_kev, _polynomial_coefficients, _expected_absorption_coefficient
+) -> None:
+    corrective_calculator = PolynomialAbsorptionCorrection(
+        coefficients_per_cm=_polynomial_coefficients
+    )
     assert corrective_calculator.absorption_coefficient_per_cm(
-        energy_kev
-    ) == pytest.approx(expected_absorption_coefficient)
+        energy_kev=_energy_kev
+    ) == pytest.approx(_expected_absorption_coefficient)
 
 
 @pytest.mark.parametrize(
-    "energy_kev, photon_absorption_factor_per_unit_length, energy_dependence_exponent, "
-    "result",
+    "_energy_kev, _photon_absorption_factor_per_unit_length, _energy_dependence_exponent,"
+    "_result",
     [
         (5.042, 1.98e2, -2.717, 2.44170544),  # At an arbitrary energy 5.042 keV
         (8.3328, 2.5706e3, -2.83, 6.3708311),  # Nickel energy 8.3328 keV
@@ -99,18 +112,20 @@ def test_corrective_polynomial_absorption_calculator(
     ],
 )
 def test_photon_mass_attenuation_per_unit_length(
-    energy_kev,
-    photon_absorption_factor_per_unit_length,
-    energy_dependence_exponent,
-    result,
-):
+    _energy_kev,
+    _photon_absorption_factor_per_unit_length,
+    _energy_dependence_exponent,
+    _result,
+) -> None:
     assert photon_mass_attenuation_per_unit_length(
-        energy_kev, photon_absorption_factor_per_unit_length, energy_dependence_exponent
-    ) == pytest.approx(result)
+        energy_kev=_energy_kev,
+        photon_absorption_factor_per_unit_length=_photon_absorption_factor_per_unit_length,
+        energy_dependence_exponent=_energy_dependence_exponent,
+    ) == pytest.approx(_result)
 
 
 @pytest.mark.parametrize(
-    "target_attenuation_bn, absorption_coefficient_per_cm, required_cm",
+    "_target_attenuation_bn, _absorption_coefficient_per_cm, _required_cm",
     [
         (0, 2.4, 0),  # test that attenuator thickness required for transparency is zero
         (
@@ -131,15 +146,15 @@ def test_photon_mass_attenuation_per_unit_length(
     ],
 )
 def test_thickness_cm_required_to_attenuate(
-    target_attenuation_bn, absorption_coefficient_per_cm, required_cm
-):
+    _target_attenuation_bn, _absorption_coefficient_per_cm, _required_cm
+) -> None:
     assert thickness_cm_required_to_attenuate(
-        target_attenuation_bn, absorption_coefficient_per_cm
-    ) == pytest.approx(required_cm, rel=1e-6)
+        _target_attenuation_bn, _absorption_coefficient_per_cm
+    ) == pytest.approx(_required_cm, rel=1e-6)
 
 
 @pytest.mark.parametrize(
-    "depth_cm, absorption_coefficient_per_cm, result",
+    "_depth_cm, _absorption_coefficient_per_cm, _result",
     [
         (
             0.5,
@@ -154,128 +169,292 @@ def test_thickness_cm_required_to_attenuate(
         (0.0, 2.5, 0),  # tests attenuation is zero after zero depth
     ],
 )
-def test_attenuation_at_depth_cm(depth_cm, absorption_coefficient_per_cm, result):
+def test_attenuation_at_depth_cm(
+    _depth_cm, _absorption_coefficient_per_cm, _result
+) -> None:
     assert attenuation_at_depth_cm(
-        depth_cm, absorption_coefficient_per_cm
-    ) == pytest.approx(result, rel=1e-6)
+        _depth_cm, _absorption_coefficient_per_cm
+    ) == pytest.approx(_result, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    "_lower,_upper", [(12.1, 21.9), (4.8, 49.67), (0.1, 20.01), (15, 31)]
+)
+def test_single_band_material_absorption_spectrum_performs_in_band_calculation(
+    _lower: float, _upper: float
+) -> None:
+    _energy_interval: ClosedInterval = ClosedInterval(lower=_lower, upper=_upper)
+    _calculator: AbsorptionCalculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=1234.5, roll_off=-1.84
+    )
+    _model1 = AbsorptionSpectrumSegment(
+        kev_energy_interval=_energy_interval, absorption_calculator=_calculator
+    )
+    _single_interval: tuple[AbsorptionSpectrumSegment, ...] = (_model1,)
+    _spectrum_calculator = MaterialAbsorptionSpectrum(intervals=_single_interval)
+    assert _spectrum_calculator.absorption_coefficient_per_cm(
+        energy_kev=20.0
+    ) == pytest.approx(4.984205)
+
+
+@pytest.mark.parametrize(
+    "_in_band_kev",
+    [
+        13.1,
+        24.91,
+    ],
+)
+@pytest.mark.parametrize(
+    "_lower,_upper", [(12.1, 15.9), (4.8, 19.67), (10.1, 20.01), (5, 18)]
+)
+def test_multi_band_material_absorption_spectrum_performs_in_band_calculation(
+    _in_band_kev, _lower: float, _upper: float
+) -> None:
+    _energy_interval1: ClosedInterval = ClosedInterval(lower=_lower, upper=_upper)
+    _calculator1: AbsorptionCalculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=6234.5, roll_off=-1.84
+    )
+    _model1 = AbsorptionSpectrumSegment(
+        kev_energy_interval=_energy_interval1, absorption_calculator=_calculator1
+    )
+    _energy_interval2: ClosedInterval = ClosedInterval(lower=23.1, upper=38.6)
+    _calculator2: AbsorptionCalculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=2824.5, roll_off=-2.84
+    )
+    _model2 = AbsorptionSpectrumSegment(
+        kev_energy_interval=_energy_interval2, absorption_calculator=_calculator2
+    )
+    _multi_interval: tuple[AbsorptionSpectrumSegment, ...] = (
+        _model1,
+        _model2,
+    )
+    _spectrum_calculator = MaterialAbsorptionSpectrum(intervals=_multi_interval)
+
+    assert (
+        _spectrum_calculator.absorption_coefficient_per_cm(energy_kev=_in_band_kev)
+        > 0.25
+    )
 
 
 # inauspicious path
 
+INVALID_TRIAL_VALUES: Final[list[Any]] = [
+    True,
+    "",
+    "a",
+    "b00m!",
+    [],
+    KeyError(),
+    None,
+    math.sin,
+    object(),
+    False,
+]
 
-@pytest.mark.parametrize("negative_energy", [-0.1, -12.3, -9739.43])
+
+@pytest.mark.parametrize("_negative_energy", [-0.1, -12.3, -9739.43])
 def test_photon_mass_attenuation_per_unit_length_errors_with_negative_energy(
-    negative_energy,
-):
+    _negative_energy,
+) -> None:
     _absorption_coefficient = 1.98e2
     _roll_off = -1.75
     with pytest.raises(ValidationError):
         photon_mass_attenuation_per_unit_length(
-            negative_energy, _absorption_coefficient, _roll_off
+            energy_kev=_negative_energy,
+            photon_absorption_factor_per_unit_length=_absorption_coefficient,
+            energy_dependence_exponent=_roll_off,
         )
 
 
-@pytest.mark.parametrize("invalid_energy", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize("_invalid_energy", INVALID_TRIAL_VALUES)
 def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_energy(
-    invalid_energy,
-):
+    _invalid_energy,
+) -> None:
     _absorption_coefficient = 1.98e2
     _roll_off = -2.717
     with pytest.raises(ValidationError):
         photon_mass_attenuation_per_unit_length(
-            invalid_energy, _absorption_coefficient, _roll_off
+            energy_kev=_invalid_energy,
+            photon_absorption_factor_per_unit_length=_absorption_coefficient,
+            energy_dependence_exponent=_roll_off,
         )
 
 
-@pytest.mark.parametrize(
-    "invalid_absorption", ["a", [], None, math.sin, object(), False]
-)
+@pytest.mark.parametrize("_invalid_absorption", INVALID_TRIAL_VALUES)
 def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_factor(
-    invalid_absorption,
-):
+    _invalid_absorption,
+) -> None:
     _energy_kev = 4.512
     _roll_off = -2.68
     with pytest.raises(ValidationError):
         photon_mass_attenuation_per_unit_length(
-            _energy_kev, invalid_absorption, _roll_off
+            energy_kev=_energy_kev,
+            photon_absorption_factor_per_unit_length=_invalid_absorption,
+            energy_dependence_exponent=_roll_off,
         )
 
 
-@pytest.mark.parametrize("invalid_roll_off", ["a", [], None, math.sin, object(), False])
+@pytest.mark.parametrize("_invalid_roll_off", INVALID_TRIAL_VALUES)
 def test_photon_mass_attenuation_per_unit_length_errors_with_invalid_exponent(
-    invalid_roll_off,
-):
+    _invalid_roll_off,
+) -> None:
     _energy_kev = 13.819
     _absorption_coefficient = 2.148
     with pytest.raises(ValidationError):
         photon_mass_attenuation_per_unit_length(
-            _energy_kev, _absorption_coefficient, invalid_roll_off
+            energy_kev=_energy_kev,
+            photon_absorption_factor_per_unit_length=_absorption_coefficient,
+            energy_dependence_exponent=_invalid_roll_off,
         )
 
 
-def test_thickness_cm_required_to_attenuate_rejects_transparent_medium():
-    _energy_kev = 7.213
+def test_thickness_cm_required_to_attenuate_rejects_transparent_medium() -> None:
+    _target_attenuation_bn = 2713.83
     transparent_medium = 0.0
     with pytest.raises(ValueError):
-        thickness_cm_required_to_attenuate(_energy_kev, transparent_medium)
-
-
-@pytest.mark.parametrize("unphysical_alpha", [1.0e-15, 3.8e-12, 7.205e-9, -1.6, -0.002])
-def test_thickness_cm_required_to_attenuate_rejects_unphysical_media(unphysical_alpha):
-    _target_attenuation = 750.0
-    with pytest.raises(ValueError):
-        thickness_cm_required_to_attenuate(_target_attenuation, unphysical_alpha)
+        thickness_cm_required_to_attenuate(
+            target_attenuation_bn=_target_attenuation_bn,
+            absorption_coefficient_per_cm=transparent_medium,
+        )
 
 
 @pytest.mark.parametrize(
-    "invalid_target_attenuation", ["a", [], None, math.sin, object(), False]
+    "_unphysical_alpha", [1.0e-15, 3.8e-12, 7.205e-9, -1.6, -0.002]
 )
+def test_thickness_cm_required_to_attenuate_rejects_unphysical_media(
+    _unphysical_alpha,
+) -> None:
+    _target_attenuation = 750.0
+    with pytest.raises(ValueError):
+        thickness_cm_required_to_attenuate(
+            target_attenuation_bn=_target_attenuation,
+            absorption_coefficient_per_cm=_unphysical_alpha,
+        )
+
+
+@pytest.mark.parametrize("_invalid_target_attenuation", INVALID_TRIAL_VALUES)
 def test_thickness_required_to_attenuate_raises_error_with_invalid_target_attenuation(
-    invalid_target_attenuation,
-):
+    _invalid_target_attenuation,
+) -> None:
     _absorption_coefficient = 2.4
     with pytest.raises(ValidationError):
         thickness_cm_required_to_attenuate(
-            invalid_target_attenuation, _absorption_coefficient
+            target_attenuation_bn=_invalid_target_attenuation,
+            absorption_coefficient_per_cm=_absorption_coefficient,
+        )
+
+
+@pytest.mark.parametrize("_invalid_absorption", INVALID_TRIAL_VALUES)
+def test_thickness_required_to_attenuate_raises_error_with_invalid_absorption(
+    _invalid_absorption,
+) -> None:
+    _target_attenuation = 1148.2
+    with pytest.raises(ValidationError):
+        thickness_cm_required_to_attenuate(
+            target_attenuation_bn=_target_attenuation,
+            absorption_coefficient_per_cm=_invalid_absorption,
+        )
+
+
+@pytest.mark.parametrize("_optical_gain", [-1, -5, -0.1])
+def test_attenuation_at_depth_raises_error_with_ineligible_optical_gain(
+    _optical_gain,
+) -> None:
+    _depth_cm = 0.152
+    with pytest.raises(ValidationError):
+        attenuation_at_depth_cm(
+            depth_cm=_depth_cm, absorption_coefficient_per_cm=_optical_gain
+        )
+
+
+@pytest.mark.parametrize("_unphysical_depth", [-1, -5, -0.1])
+def test_attenuation_at_depth_raises_error_for_unphysical_depths(
+    _unphysical_depth,
+) -> None:
+    _absorption_coefficient = 1.1
+    with pytest.raises(ValidationError):
+        attenuation_at_depth_cm(
+            depth_cm=_unphysical_depth,
+            absorption_coefficient_per_cm=_absorption_coefficient,
+        )
+
+
+@pytest.mark.parametrize("_invalid_depth", INVALID_TRIAL_VALUES)
+def test_attenuation_at_depth_raises_error_with_invalid_depth(_invalid_depth) -> None:
+    _absorption_coefficient = 3.7
+    with pytest.raises(ValidationError):
+        attenuation_at_depth_cm(
+            depth_cm=_invalid_depth,
+            absorption_coefficient_per_cm=_absorption_coefficient,
+        )
+
+
+@pytest.mark.parametrize("_invalid_absorption", INVALID_TRIAL_VALUES)
+def test_attenuation_at_depth_raises_error_with_invalid_attenuation(
+    _invalid_absorption,
+) -> None:
+    _depth_cm = 0.425
+    with pytest.raises(ValidationError):
+        attenuation_at_depth_cm(
+            depth_cm=_depth_cm, absorption_coefficient_per_cm=_invalid_absorption
         )
 
 
 @pytest.mark.parametrize(
-    "invalid_absorption", ["a", [], None, math.sin, object(), False]
+    "_out_of_band_kev",
+    [
+        (2.1, 96.3),
+    ],
 )
-def test_thickness_required_to_attenuate_raises_error_with_invalid_absorption(
-    invalid_absorption,
-):
-    _target_attenuation = 1148.2
-    with pytest.raises(ValidationError):
-        thickness_cm_required_to_attenuate(_target_attenuation, invalid_absorption)
-
-
-@pytest.mark.parametrize("optical_gain", [-1, -5, -0.1])
-def test_attenuation_at_depth_raises_error_with_ineligible_optical_gain(optical_gain):
-    _depth_cm = 0.152
-    with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(_depth_cm, optical_gain)
-
-
-@pytest.mark.parametrize("unphysical_depth", [-1, -5, -0.1])
-def test_attenuation_at_depth_raises_error_for_unphysical_depths(unphysical_depth):
-    _absorption_coefficient = 1.1
-    with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(unphysical_depth, _absorption_coefficient)
-
-
-@pytest.mark.parametrize("invalid_depth", ["a", [], None, math.sin, object(), True])
-def test_attenuation_at_depth_raises_error_with_invalid_depth(invalid_depth):
-    _absorption_coefficient = 3.7
-    with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(invalid_depth, _absorption_coefficient)
+@pytest.mark.parametrize(
+    "_lower,_upper", [(12.1, 21.9), (4.8, 49.67), (10.1, 20.01), (15, 31)]
+)
+def test_single_band_material_absorption_spectrum_rejects_out_of_band_calculation(
+    _out_of_band_kev, _lower: float, _upper: float
+) -> None:
+    _energy_interval: ClosedInterval = ClosedInterval(lower=_lower, upper=_upper)
+    _calculator: AbsorptionCalculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=1234.5, roll_off=-1.84
+    )
+    _model1 = AbsorptionSpectrumSegment(
+        kev_energy_interval=_energy_interval, absorption_calculator=_calculator
+    )
+    _single_interval: tuple[AbsorptionSpectrumSegment, ...] = (_model1,)
+    _spectrum_calculator = MaterialAbsorptionSpectrum(intervals=_single_interval)
+    with pytest.raises(ValueError):
+        _spectrum_calculator.absorption_coefficient_per_cm(energy_kev=_out_of_band_kev)
 
 
 @pytest.mark.parametrize(
-    "invalid_absorption", ["a", [], None, math.tan, object(), False]
+    "_out_of_band_kev",
+    [
+        (3.1, 22.83),
+    ],
 )
-def test_attenuation_at_depth_raises_error_with_invalid_attenuation(invalid_absorption):
-    _depth_cm = 0.425
-    with pytest.raises(ValidationError):
-        attenuation_at_depth_cm(_depth_cm, invalid_absorption)
+@pytest.mark.parametrize(
+    "_lower,_upper", [(12.1, 15.9), (4.8, 19.67), (10.1, 20.01), (5, 11)]
+)
+def test_multi_band_material_absorption_spectrum_rejects_out_of_band_calculation(
+    _out_of_band_kev, _lower: float, _upper: float
+) -> None:
+    _energy_interval1: ClosedInterval = ClosedInterval(lower=_lower, upper=_upper)
+    _calculator1: AbsorptionCalculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=1234.5, roll_off=-1.84
+    )
+    _model1 = AbsorptionSpectrumSegment(
+        kev_energy_interval=_energy_interval1, absorption_calculator=_calculator1
+    )
+    _energy_interval2: ClosedInterval = ClosedInterval(lower=23.1, upper=38.6)
+    _calculator2: AbsorptionCalculator = SingleRollOffAbsorptionCalculator(
+        material_factor_per_cm=234.5, roll_off=-2.84
+    )
+    _model2 = AbsorptionSpectrumSegment(
+        kev_energy_interval=_energy_interval2, absorption_calculator=_calculator2
+    )
+    _multi_interval: tuple[AbsorptionSpectrumSegment, ...] = (
+        _model2,
+        _model1,
+    )
+    _spectrum_calculator = MaterialAbsorptionSpectrum(intervals=_multi_interval)
+    with pytest.raises(ValueError):
+        _spectrum_calculator.absorption_coefficient_per_cm(energy_kev=_out_of_band_kev)

--- a/tests/common/general_maths/test_transmission_interconversion.py
+++ b/tests/common/general_maths/test_transmission_interconversion.py
@@ -1,5 +1,6 @@
 import math
 from collections.abc import Callable
+from typing import Any, Final
 
 import pytest
 from pydantic import ValidationError
@@ -32,7 +33,7 @@ from .operator_inversion_pairing import OperatorInversionPairing
         ),  # tests transmission from arbitrary strong attenuation is strong attenuation
     ],
 )
-def test_transmission_from_attenutation(attenuation_bn, result):
+def test_transmission_from_attenutation(attenuation_bn, result) -> None:
     assert transmission_from_attenutation(attenuation_bn) == pytest.approx(result)
 
 
@@ -55,7 +56,7 @@ def test_transmission_from_attenutation(attenuation_bn, result):
         ),  # tests attenuation from natural log arbitrary low transmission
     ],
 )
-def test_natural_log_of_transmission_from_attenuation(attenuation_bn, result):
+def test_natural_log_of_transmission_from_attenuation(attenuation_bn, result) -> None:
     assert natural_log_of_transmission_from_attenuation(
         attenuation_bn
     ) == pytest.approx(result)
@@ -76,7 +77,7 @@ def test_natural_log_of_transmission_from_attenuation(attenuation_bn, result):
         ),  # tests attenuation from arbitrary high attenuation
     ],
 )
-def test_attenuation_from_transmission(transmission_as_fraction, result):
+def test_attenuation_from_transmission(transmission_as_fraction, result) -> None:
     assert attenuation_from_transmission(transmission_as_fraction) == pytest.approx(
         result
     )
@@ -97,7 +98,7 @@ def test_attenuation_from_transmission(transmission_as_fraction, result):
         ),  # tests log from arbitrary low transmission
     ],
 )
-def test_attenuation_from_natural_log_of_transmission(ln_t, result):
+def test_attenuation_from_natural_log_of_transmission(ln_t, result) -> None:
     assert attenuation_from_natural_log_of_transmission(ln_t) == pytest.approx(result)
 
 
@@ -124,7 +125,7 @@ def test_attenuation_log_transmssion_conversions_reciprocate_as_expected(
     f: Callable[[float], float],
     g: Callable[[float], float],
     numerical_args: list[float],
-):
+) -> None:
     op_pair = OperatorInversionPairing(f, g)
     for x in numerical_args:
         assert op_pair.composed_operator_is_consistent_with_identity_operator(x)
@@ -144,32 +145,47 @@ def test_transmission_attenuation_conversions_pair_off_to_form_identity_operatio
     f: Callable[[float], float],
     g: Callable[[float], float],
     numerical_args: list[float],
-):
+) -> None:
     for op_pair in [OperatorInversionPairing(f, g), OperatorInversionPairing(g, f)]:
         for x in numerical_args:
             assert op_pair.composed_operator_is_consistent_with_identity_operator(x)
 
 
-# inauspicious:
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
-def test_natural_log_of_transmission_from_attenuation_raises_error(bad_input):
+# inauspicious path tests
+
+INVALID_TRIAL_VALUES: Final[list[Any]] = [
+    True,
+    "",
+    "a",
+    "b00m!",
+    [],
+    KeyError(),
+    None,
+    math.tan,
+    object(),
+    False,
+]
+
+
+@pytest.mark.parametrize("bad_input", INVALID_TRIAL_VALUES)
+def test_natural_log_of_transmission_from_attenuation_raises_error(bad_input) -> None:
     with pytest.raises(ValidationError):
         natural_log_of_transmission_from_attenuation(bad_input)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
-def test_transmission_from_attenutation_raises_error(bad_input):
+@pytest.mark.parametrize("bad_input", INVALID_TRIAL_VALUES)
+def test_transmission_from_attenutation_raises_error(bad_input) -> None:
     with pytest.raises(ValidationError):
         transmission_from_attenutation(bad_input)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
-def test_attenuation_from_transmission_raises_error(bad_input):
+@pytest.mark.parametrize("bad_input", INVALID_TRIAL_VALUES)
+def test_attenuation_from_transmission_raises_error(bad_input) -> None:
     with pytest.raises(ValidationError):
         attenuation_from_transmission(bad_input)
 
 
-@pytest.mark.parametrize("bad_input", ["a", [], None, math.sin, object(), False])
-def test_attenuation_from_natural_log_of_transmission_raises_error(bad_input):
+@pytest.mark.parametrize("bad_input", INVALID_TRIAL_VALUES)
+def test_attenuation_from_natural_log_of_transmission_raises_error(bad_input) -> None:
     with pytest.raises(ValidationError):
         attenuation_from_natural_log_of_transmission(bad_input)


### PR DESCRIPTION
* Addresses #2150, #2148 

* Add new types for mathematical interval in all its closed/open ended variants

* Use this interval to adjust some of the internal validation in existing general_maths classes

* Address issues with inconsistent types across absorption related classes old code had incoherent blends of dataclass, pydantic BaseModel and Protocol which the IDE flagged - or showed up in debugging tests that failed midway through the updates here

* Also tidied other inconsitencies and room for optimisation -- unbalanced mocking in behaviour tests was defeating internal validation so that has been addressed -- repeated and unnecessarily short lists of invalid test inputs have been extended and made a constant in the test suite allowing them to be maintained in one location

* Other similar small tweaks to existing code or tests such as explicitly adding missing type hints, for example -> None to the return signature from tests

Addresses #2150 

### Instructions to reviewer on how to test:
1. Check the added classes for Interval types and MaterialAbsorptionSpectrum
2. Check the tests added for these new classes cover all the sensible test cases (note the caveats in test comments for Intervals)
3. Check other updates necessitated by either consistency / getting tests to now pass in light of the update
4. Confirm the CI tests and codecoverage and linters are all happy

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
