### PR TITLE
class AttenuatorMotorPositions: cleanse obsolete naming

### DIFF
--- a/src/dodal/devices/beamlines/i19/access_controlled/attenuator_motor_squad.py
+++ b/src/dodal/devices/beamlines/i19/access_controlled/attenuator_motor_squad.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Annotated, Self
 
 from ophyd_async.core import AsyncStatus
@@ -18,22 +19,44 @@ from dodal.devices.beamlines.i19.access_controlled.hutch_access import (
     ACCESS_DEVICE_NAME,
 )
 
-PermittedKeyStr = Annotated[str, StringConstraints(pattern="^[A-Za-z0-9-_]+$")]
+PermittedKeyStr = Annotated[
+    str, StringConstraints(pattern=r"^[_A-Za-z][A-Za-z0-9-_]*$")
+]
 
 
 class AttenuatorMotorPositions(BaseModel):
+    """Motor positions for attentuators in the attenuation system, be they indices on a discrete steps motor or continuous positions on an axis, or axes.
+
+    This is a validated dict which pairs off naming "tags" for each motor (e.g. "x" for a lateral x-axis motor or "w" for a filter wheel),
+    with the corresponding int or float motor position ( or position demand / request ) as appropriate.
+
+    Attributes:
+        continuous_positions: dict contributions pairing names of motors against the discrete motor position (likely to be in mm)/
+        discrete_indices: dict contributions pairing names of index stepping positioners against the discrete position index (e.g. for a filter wheel).
+
+    Examples:
+        ( Given that i19 mounted a resin wedge on their x-axis motor,
+            an aluminium wedge on their y-axis motor and their first filter wheel we will name "w" ... )
+
+        Request for motor changes:
+            {"x": 20.4} and {"w":3} might indicate a request to move x-axis to 20.4 mm and the wheel round to slot 3.
+
+        Reporting of system motor positions (on say i19, where wheel index 1 is reserved for an EMPTY slot):
+        {"x": 28.62, "y": 5.0} and {"w": 1} might indicate the resin wedge is at 28.62 mm, aluminium wedge is OUT, filter wheel at EMPTY (OUT)."
+    """
+
     model_config = ConfigDict(frozen=True)
 
-    continuous_demands: dict[PermittedKeyStr, StrictFloat | StrictInt] = Field(
+    continuous_positions: dict[PermittedKeyStr, StrictFloat | StrictInt] = Field(
         default_factory=dict, kw_only=True
     )
-    indexed_demands: dict[PermittedKeyStr, Annotated[StrictInt, Field(gt=0)]] = Field(
+    discrete_indices: dict[PermittedKeyStr, Annotated[StrictInt, Field(gt=0)]] = Field(
         default_factory=dict, kw_only=True
     )
 
     @model_validator(mode="after")
     def no_keys_clash(self) -> Self:
-        common_keys = set(self.continuous_demands).intersection(self.indexed_demands)
+        common_keys = set(self.continuous_positions).intersection(self.discrete_indices)
         common_key_count = sum(1 for _ in common_keys)
         if common_key_count < 1:
             return self
@@ -42,10 +65,26 @@ class AttenuatorMotorPositions(BaseModel):
             error_msg = f"Common {ks} found in distinct motor demands: {common_keys}"
             raise ValueError(error_msg)
 
-    def validated_complete_demand(
+    @cached_property
+    def _cached_merged_validated_dict(
         self,
     ) -> dict[PermittedKeyStr, StrictInt | StrictFloat]:
-        return self.continuous_demands | self.indexed_demands
+        """Lazily evaluate the merged dict, post validation and cache for future use.
+
+        Returns:
+            The validated union of both discrete motor index and continuous motor position contributions.
+        """
+        return self.continuous_positions | self.discrete_indices
+
+    def validated_and_complete(
+        self,
+    ) -> dict[PermittedKeyStr, StrictInt | StrictFloat]:
+        """Reports back the validated combined position information.
+
+        Returns:
+            The validated union of both discrete motor index and continuous motor position contributions.
+        """
+        return self._cached_merged_validated_dict
 
 
 class AttenuatorMotorSquad(OpticsBlueAPIDevice):
@@ -73,7 +112,7 @@ class AttenuatorMotorSquad(OpticsBlueAPIDevice):
             "params": {
                 "experiment_hutch": self._invoking_hutch,
                 "access_device": ACCESS_DEVICE_NAME,
-                "attenuator_demands": value.validated_complete_demand(),
+                "attenuator_demands": value.validated_and_complete(),
             },
             "instrument_session": self.instrument_session,
         }

--- a/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_positions.py
+++ b/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_positions.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any, Final
 
 import pytest
 from pydantic import ValidationError
@@ -7,89 +8,204 @@ from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import
     AttenuatorMotorPositions,
 )
 
+TRIAL_AXIAL_MOTOR_POSITIONS: Final[list[float]] = [
+    -4.3,
+    -2,
+    0.01,
+    0.0,
+    12.6,
+    38,
+    90.104,
+]
 
-def test_that_attenuator_position_demand_can_be_created_with_only_one_wedge():
-    wedge_position_demands = {"x": 0.5}
+
+@pytest.mark.parametrize(
+    "motor_name",
+    [
+        "_x",
+        "Y",
+        "_h",
+        "_Vert",
+        "V4",
+        "x",
+        "y",
+    ],
+)
+@pytest.mark.parametrize(
+    "trial_motor_position_mm",
+    TRIAL_AXIAL_MOTOR_POSITIONS,
+)
+def test_that_attenuator_motor_positions_can_be_created_for_just_the_one_wedge(
+    motor_name: str, trial_motor_position_mm: float
+) -> None:
+    wedge_position_demands = {motor_name: trial_motor_position_mm}
     wheel_position_demands = {}
     position_demand = AttenuatorMotorPositions(
-        continuous_demands=wedge_position_demands,
-        indexed_demands=wheel_position_demands,
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
     )
     assert position_demand is not None
 
 
-def test_that_attenuator_position_demand_with_only_one_wedge_provides_expected_rest_format():
-    wedge_position_demands = {"y": 14.9}
+@pytest.mark.parametrize(
+    "trial_motor_position_mm",
+    TRIAL_AXIAL_MOTOR_POSITIONS,
+)
+def test_that_attenuator_motor_positions_with_for_one_wedge_provides_expected_rest_format(
+    trial_motor_position_mm: float,
+) -> None:
+    wedge_position_demands = {"y": trial_motor_position_mm}
     wheel_position_demands = {}
     position_demand = AttenuatorMotorPositions(
-        continuous_demands=wedge_position_demands,
-        indexed_demands=wheel_position_demands,
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
     )
-    restful_payload = position_demand.validated_complete_demand()
-    assert restful_payload["y"] == 14.9
+    restful_payload = position_demand.validated_and_complete()
+    assert restful_payload["y"] == trial_motor_position_mm
 
 
-def test_that_attenuator_position_demand_can_be_created_with_only_one_wheel():
+TRIAL_WHEEL_INDICES = [
+    1,
+    2,
+    4,
+    5,
+    3,
+    6,
+    8,
+]
+
+WHEEL_NAMES = ["w", "V", "_w1", "_W_one", "w4", "spare_wheel"]
+
+# split testing matrix across two tests to reduce the number of cases without losing
+# variety / stress testing
+
+
+@pytest.mark.parametrize("wheel_name", ["u", "t"])
+@pytest.mark.parametrize(
+    "trial_index",
+    TRIAL_WHEEL_INDICES,
+)
+def test_that_attenuator_motor_positions_can_be_created_for_only_one_wheel_at_any_index(
+    wheel_name: str, trial_index: int
+) -> None:
     wedge_position_demands = {}
-    wheel_position_demands = {"w": 2}
+    wheel_position_demands = {wheel_name: trial_index}
     position_demand = AttenuatorMotorPositions(
-        continuous_demands=wedge_position_demands,
-        indexed_demands=wheel_position_demands,
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
     )
     assert position_demand is not None
 
 
-def test_that_attenuator_position_demand_with_only_one_wheel_provides_expected_rest_format():
+@pytest.mark.parametrize(
+    "wheel_name",
+    WHEEL_NAMES,
+)
+@pytest.mark.parametrize(
+    "trial_index",
+    [3, 4],
+)
+def test_that_attenuator_motor_positions_for_only_one_wheel_can_be_created_with_any_wheel_name(
+    wheel_name: str, trial_index: int
+) -> None:
     wedge_position_demands = {}
-    wheel_position_demands = {"w": 6}
+    wheel_position_demands = {wheel_name: trial_index}
     position_demand = AttenuatorMotorPositions(
-        continuous_demands=wedge_position_demands,
-        indexed_demands=wheel_position_demands,
-    )
-    restful_payload = position_demand.validated_complete_demand()
-    assert restful_payload["w"] == 6
-
-
-def test_that_empty_attenuator_position_demand_can_be_created():
-    wedge_position_demands = {}
-    wheel_position_demands = {}
-    position_demand = AttenuatorMotorPositions(
-        continuous_demands=wedge_position_demands,
-        indexed_demands=wheel_position_demands,
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
     )
     assert position_demand is not None
 
 
-def test_that_empty_attenuator_position_demand_provides_empty_rest_format():
+@pytest.mark.parametrize(
+    "trial_index",
+    TRIAL_WHEEL_INDICES,
+)
+def test_that_attenuator_motor_positions_for_only_one_wheel_provides_expected_rest_format(
+    trial_index: int,
+) -> None:
+    wedge_position_demands = {}
+    wheel_position_demands = {"w": trial_index}
+    position_demand = AttenuatorMotorPositions(
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
+    )
+    restful_payload = position_demand.validated_and_complete()
+    assert restful_payload["w"] == trial_index
+
+
+def test_that_empty_attenuator_motor_positions_can_be_created() -> None:
     wedge_position_demands = {}
     wheel_position_demands = {}
     position_demand = AttenuatorMotorPositions(
-        continuous_demands=wedge_position_demands,
-        indexed_demands=wheel_position_demands,
-    )
-    restful_payload = position_demand.validated_complete_demand()
-    assert restful_payload == {}
-
-
-def test_that_attenuator_position_demand_triplet_can_be_created():
-    standard_wedge_position_demand = {"x": 25.9, "y": 5.0}
-    standard_wheel_position_demand = {"w": 4}
-    position_demand = AttenuatorMotorPositions(
-        continuous_demands=standard_wedge_position_demand,
-        indexed_demands=standard_wheel_position_demand,
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
     )
     assert position_demand is not None
 
 
-def test_that_attenuator_position_demand_triplet_provides_expected_rest_format():
+def test_that_empty_attenuator_motor_positions_provides_empty_rest_format() -> None:
+    wedge_position_demands = {}
+    wheel_position_demands = {}
+    position_demand = AttenuatorMotorPositions(
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
+    )
+    restful_payload = position_demand.validated_and_complete()
+    expected_rest_dict = {}
+    assert restful_payload == expected_rest_dict
+
+
+@pytest.mark.parametrize(
+    "trial_motor_position_mm",
+    TRIAL_AXIAL_MOTOR_POSITIONS,
+)
+@pytest.mark.parametrize(
+    "trial_index",
+    TRIAL_WHEEL_INDICES,
+)
+def test_that_attenuator_motor_positions_triplet_can_be_created(
+    trial_motor_position_mm: float, trial_index: int
+) -> None:
+    standard_wedge_position_demand = {"x": trial_motor_position_mm, "y": 5.0}
+    standard_wheel_position_demand = {"w": trial_index}
+    position_demand = AttenuatorMotorPositions(
+        continuous_positions=standard_wedge_position_demand,
+        discrete_indices=standard_wheel_position_demand,
+    )
+    assert position_demand is not None
+
+
+def test_that_attenuator_motor_positions_triplet_provides_expected_rest_format() -> (
+    None
+):
     wedge_position_demands = {"x": 0.1, "y": 90.1}
     wheel_position_demands = {"w": 6}
     position_demand = AttenuatorMotorPositions(
-        continuous_demands=wedge_position_demands,
-        indexed_demands=wheel_position_demands,
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
     )
-    restful_payload = position_demand.validated_complete_demand()
-    assert restful_payload == {"x": 0.1, "y": 90.1, "w": 6}
+    restful_payload = position_demand.validated_and_complete()
+    expected_rest_dict = {"x": 0.1, "y": 90.1, "w": 6}
+    assert restful_payload == expected_rest_dict
+
+
+@pytest.mark.parametrize(
+    "trial_index",
+    TRIAL_WHEEL_INDICES,
+)
+def test_that_attenuator_motor_keys_accepts_leading_underscores_or_upper_case_letters(
+    trial_index: int,
+) -> None:
+    wedge_position_demands = {"_x": 0.1, "Y": 90.1}
+    wheel_position_demands = {"_W": trial_index}
+    position_demand = AttenuatorMotorPositions(
+        continuous_positions=wedge_position_demands,
+        discrete_indices=wheel_position_demands,
+    )
+    restful_payload = position_demand.validated_and_complete()
+    expected_rest_dict = {"_x": 0.1, "Y": 90.1, "_W": trial_index}
+    assert restful_payload == expected_rest_dict
 
 
 # Happy path tests above
@@ -97,7 +213,9 @@ def test_that_attenuator_position_demand_triplet_provides_expected_rest_format()
 # Unhappy path tests below
 
 
-def test_that_attenuator_position_raises_error_when_discrete_and_continuous_demands_overload_axis_label():
+def test_that_attenuator_motor_positions_raises_error_when_discrete_and_continuous_demands_overload_axis_label() -> (
+    None
+):
     wedge_position_demands = {"x": 0.1, "v": 90.1}
     wheel_position_demands = {"w": 6, "v": 7}
     anticipated_preamble: str = (
@@ -105,116 +223,125 @@ def test_that_attenuator_position_raises_error_when_discrete_and_continuous_dema
     )
     with pytest.raises(expected_exception=ValueError, match=anticipated_preamble):
         AttenuatorMotorPositions(
-            continuous_demands=wedge_position_demands,
-            indexed_demands=wheel_position_demands,
+            continuous_positions=wedge_position_demands,
+            discrete_indices=wheel_position_demands,
         )
+
+
+INVALID_FLOATS: Final = [
+    None,
+    ValueError(),
+    "8.0",  # ie String rather than numerical float is invalid
+    "14",
+    "k",
+    "",
+    "game_over",
+    math.cos,
+    object(),
+    False,
+    True,
+]
 
 
 @pytest.mark.parametrize(
     "invalid_x",
-    [
-        None,
-        ValueError(),
-        "8.0",
-        "14",
-        "k",
-        "",
-        "game_over",
-        math.cos,
-        object(),
-        False,
-        True,
-    ],
+    INVALID_FLOATS,
 )
-def test_that_attenuator_position_creation_raises_error_when_continuous_position_demand_is_invalid(
+def test_that_attenuator_motor_positions_creation_raises_error_when_continuous_position_is_invalid(
     invalid_x,
-):
+) -> None:
     wedge_position_demands = {"x": invalid_x, "y": 90.1}
     wheel_position_demands = {}
     with pytest.raises(expected_exception=ValidationError):
         AttenuatorMotorPositions(
-            continuous_demands=wedge_position_demands,
-            indexed_demands=wheel_position_demands,
+            continuous_positions=wedge_position_demands,
+            discrete_indices=wheel_position_demands,
         )
+
+
+# indices need to be positive non-zero naturals
+INVALID_NATURALS: Final[list[Any]] = [
+    None,
+    -3,
+    0,
+    "2.0",
+    "-12",
+    "5",
+    "q",
+    "",
+    "longer_string",
+    math.exp,
+    AttributeError(),
+    object(),
+    False,
+    True,
+]
 
 
 @pytest.mark.parametrize(
     "invalid_w",
-    [
-        None,
-        -3,
-        0,
-        "2.0",
-        "-12",
-        "q",
-        "",
-        "longer_string",
-        math.exp,
-        AttributeError(),
-        object(),
-        False,
-        True,
-    ],
+    INVALID_NATURALS,
 )
-def test_that_attenuator_position_creation_raises_error_when_indexed_position_demand_is_invalid(
+def test_that_attenuator_motor_positions_creation_raises_error_when_indexed_position_is_invalid(
     invalid_w,
-):
+) -> None:
     wedge_position_demands = {"x": 14.88, "y": 90.1}
     wheel_position_demands = {"w": invalid_w, "v": 3}
     with pytest.raises(expected_exception=ValidationError):
         AttenuatorMotorPositions(
-            continuous_demands=wedge_position_demands,
-            indexed_demands=wheel_position_demands,
+            continuous_positions=wedge_position_demands,
+            discrete_indices=wheel_position_demands,
         )
+
+
+INVALID_MOTOR_IDENTIFIERS: Final[list[Any]] = [
+    None,
+    6,
+    -98.7,
+    "-9.87",
+    "",
+    " ",
+    ".a1",
+    "$7",
+    "2B",
+    "-U",
+    "x6^",
+    0,
+    math.cos,
+    AttributeError(),
+    object(),
+    False,
+    True,
+]
 
 
 @pytest.mark.parametrize(
     "invalid_key",
-    [
-        None,
-        6,
-        -98.7,
-        "",
-        math.cos,
-        AttributeError(),
-        object(),
-        False,
-        True,
-    ],
+    INVALID_MOTOR_IDENTIFIERS,
 )
-def test_that_attenuator_position_creation_raises_error_when_continuous_position_key_is_invalid(
+def test_that_attenuator_motor_positions_creation_raises_error_when_continuous_position_key_is_invalid(
     invalid_key,
-):
+) -> None:
     wedge_position_demands = {"x": 32.65, invalid_key: 80.1}
     wheel_position_demands = {"w": 8}
     with pytest.raises(expected_exception=ValidationError):
         AttenuatorMotorPositions(
-            continuous_demands=wedge_position_demands,
-            indexed_demands=wheel_position_demands,
+            continuous_positions=wedge_position_demands,
+            discrete_indices=wheel_position_demands,
         )
 
 
 @pytest.mark.parametrize(
     "invalid_key",
-    [
-        None,
-        44,
-        ValueError(),
-        -1.234,
-        "",
-        math.cos,
-        object(),
-        False,
-        True,
-    ],
+    INVALID_MOTOR_IDENTIFIERS,
 )
-def test_that_attenuator_position_creation_raises_error_when_indexed_position_key_is_invalid(
+def test_that_attenuator_motor_positions_creation_raises_error_when_indexed_position_key_is_invalid(
     invalid_key,
-):
+) -> None:
     wedge_position_demands = {"x": 24.08, "y": 71.4}
     wheel_position_demands = {"w": 1, invalid_key: 2}
     with pytest.raises(expected_exception=ValidationError):
         AttenuatorMotorPositions(
-            continuous_demands=wedge_position_demands,
-            indexed_demands=wheel_position_demands,
+            continuous_positions=wedge_position_demands,
+            discrete_indices=wheel_position_demands,
         )

--- a/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_squad.py
+++ b/tests/devices/beamlines/i19/access_controlled/test_attenuator_motor_squad.py
@@ -13,9 +13,9 @@ from dodal.devices.beamlines.i19.access_controlled.blueapi_device import HutchSt
 
 
 def given_position_demands() -> AttenuatorMotorPositions:
-    position_demand = MagicMock()
+    position_demand = MagicMock(spec=AttenuatorMotorPositions)
     restful_payload = {"x": 54.3, "y": 72.1, "w": 4}
-    position_demand.validated_complete_demand = MagicMock(return_value=restful_payload)
+    position_demand.validated_and_complete = MagicMock(return_value=restful_payload)
     return position_demand
 
 


### PR DESCRIPTION
* Internal naming conventions within the Attenuator motor positions class had been left in prior state before recent rename ( where the rename relfected a widened scope from purely demanding motor moves to also capture live positions of motors )

   The resulting obsolescene meant names of methods and internal variables
   did not reflect the wider usage scope - that is hereby fixed

* Also make internal merge of discrete indexed positions and continuous motor axis positions into a cached property saves the merge being recalculated - and makes its evaluation lazy

* Update tests to reflect renaming

* Improve tests with parametrized test cases

* Fix quirk in axis naming convention which used to (inadvertently) permit leading integer in name/tag of wheel or axial motor

* Tighten test cases to capture this and other oversights in original test suite

Fixes #2163

### Instructions to reviewer on how to test:
1. Confirm name updates make logical sense to any reader unfamiliar with what the code does
2. Confirm You don't need to read the code in detail to understand the names - if that proves to be necessary, fail the CR
3. Confirm linters etc are happy

### Checks for reviewer
- [ ] Would the PR title make sense to a scientist on a set of release notes
- [ ] If a new device has been added does it follow the [standards](https://diamondlightsource.github.io/dodal/main/reference/device-standards.html)
- [ ] If changing the API for a pre-existing device, ensure that any beamlines using this device have updated their Bluesky plans accordingly
- [ ] Have the connection tests for the relevant beamline(s) been run via `dodal connect ${BEAMLINE}`
